### PR TITLE
Fixes #27945 - modify description of --tags option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Subcommands:
       list                          List the checks based on criteria
       list-tags                     List the tags to use for filtering checks
       check                         Run the health checks against the system
-        --label label               Run only a specific check
-        --tags tags                 Limit only for specific set of tags
+        --label label               Run only a specific check with a label
+        --tags tags                 Run only those with all specific set of tags
 
     upgrade                       Upgrade related commands
       list-versions                 List versions this system is upgradable to

--- a/lib/foreman_maintain/cli/base.rb
+++ b/lib/foreman_maintain/cli/base.rb
@@ -135,7 +135,7 @@ module ForemanMaintain
 
       def self.label_option
         option '--label', 'label',
-               'Limit only for a specific label. ' \
+               'Run only a specific check with a label. ' \
                  '(Use "list" command to see available labels)' do |label|
           raise ArgumentError, 'value not specified' if label.nil? || label.empty?
           underscorize(label).to_sym
@@ -144,7 +144,7 @@ module ForemanMaintain
 
       def self.tags_option
         option('--tags', 'tags',
-               'Limit only for specific set of labels. ' \
+               'Run only those with all specific set of tags. ' \
                  '(Use list-tags command to see available tags)',
                :multivalued => true) do |tags|
           raise ArgumentError, 'value not specified' if tags.nil? || tags.empty?


### PR DESCRIPTION
With this commit, it will allow user to enter multiple values separated with commas for tags filter.