### PR TITLE
CLI for procedure invocation

### DIFF
--- a/definitions/procedures/foreman_tasks/delete.rb
+++ b/definitions/procedures/foreman_tasks/delete.rb
@@ -2,6 +2,7 @@ module Procedures::ForemanTasks
   class Delete < ForemanMaintain::Procedure
     metadata do
       param :state, 'In what state should the task be deleted'
+      description 'delete tasks'
     end
 
     def run
@@ -26,7 +27,7 @@ module Procedures::ForemanTasks
       end
     end
 
-    def description
+    def runtime_message
       "Delete #{@state} tasks"
     end
   end

--- a/definitions/procedures/hammer_setup.rb
+++ b/definitions/procedures/hammer_setup.rb
@@ -1,4 +1,8 @@
 class Procedures::HammerSetup < ForemanMaintain::Procedure
+  metadata do
+    description 'setup hammer'
+  end
+
   def run
     setup_from_default || setup_from_answers
     puts "New settings saved into #{hammer.config_file}"
@@ -7,10 +11,6 @@ class Procedures::HammerSetup < ForemanMaintain::Procedure
 
   def necessary?
     !hammer.ready?
-  end
-
-  def description
-    'Setup hammer'
   end
 
   private

--- a/definitions/procedures/install_package.rb
+++ b/definitions/procedures/install_package.rb
@@ -1,6 +1,7 @@
 class Procedures::InstallPackage < ForemanMaintain::Procedure
   metadata do
     param :packages, 'List of packages to install', :array => true
+    description 'install packages(s)'
   end
 
   def run
@@ -11,7 +12,7 @@ class Procedures::InstallPackage < ForemanMaintain::Procedure
     @packages.any? { |package| package_version(package).nil? }
   end
 
-  def description
+  def runtime_message
     "Install package(s) #{@packages.join(', ')}"
   end
 end

--- a/lib/foreman_maintain/cli.rb
+++ b/lib/foreman_maintain/cli.rb
@@ -1,6 +1,7 @@
 require 'clamp'
 require 'highline'
 require 'foreman_maintain/cli/base'
+require 'foreman_maintain/cli/transform_clamp_options'
 require 'foreman_maintain/cli/health_command'
 require 'foreman_maintain/cli/upgrade_command'
 require 'foreman_maintain/cli/advanced_command'

--- a/lib/foreman_maintain/cli.rb
+++ b/lib/foreman_maintain/cli.rb
@@ -3,12 +3,14 @@ require 'highline'
 require 'foreman_maintain/cli/base'
 require 'foreman_maintain/cli/health_command'
 require 'foreman_maintain/cli/upgrade_command'
+require 'foreman_maintain/cli/advanced_command'
 
 module ForemanMaintain
   module Cli
     class MainCommand < Base
       subcommand 'health', 'Health related commands', HealthCommand
       subcommand 'upgrade', 'Upgrade related commands', UpgradeCommand
+      subcommand 'advanced', 'Advanced tools for server maintenance', AdvancedCommand
     end
   end
 end

--- a/lib/foreman_maintain/cli/advanced/procedure/abstract_by_tag_command.rb
+++ b/lib/foreman_maintain/cli/advanced/procedure/abstract_by_tag_command.rb
@@ -1,0 +1,38 @@
+module ForemanMaintain
+  module Cli
+    module Procedure
+      class AbstractByTagCommand < AbstractProcedureCommand
+        def self.tag_params_to_options(tag)
+          params = params_for_tag(tag)
+          params.values.each do |param|
+            mapping = param[:procedures]
+            instance = param[:instance]
+            param_to_option(instance, :description => instance.description + " #{mapping}")
+          end
+        end
+
+        def self.params_for_tag(tag)
+          params = {}
+          ForemanMaintain.available_procedures(:tags => tag).each do |procedure|
+            procedure.params.values.each do |param|
+              unless params.key?(param.name)
+                params[param.name] = { :instance => param, :procedures => [] }
+              end
+              params[param.name][:procedures] += [procedure.label.to_s]
+            end
+          end
+          params
+        end
+
+        def execute
+          tag = underscorize(invocation_path.split.last).to_sym
+          scenario = ForemanMaintain::Scenario.new
+          ForemanMaintain.available_procedures(:tags => tag).sort_by(&:label).each do |procedure|
+            scenario.add_step(procedure.new(params_for_procedure(procedure)))
+          end
+          run_scenario(scenario)
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/cli/advanced/procedure/abstract_procedure_command.rb
+++ b/lib/foreman_maintain/cli/advanced/procedure/abstract_procedure_command.rb
@@ -1,0 +1,67 @@
+module ForemanMaintain
+  module Cli
+    module Procedure
+      class AbstractProcedureCommand < Base
+        def execute
+          label = underscorize(invocation_path.split.last)
+          procedure = procedure(label.to_sym)
+          scenario = ForemanMaintain::Scenario.new
+          scenario.add_step(procedure.new(params_for_procedure(procedure)))
+          run_scenario(scenario)
+        end
+
+        # transform clamp options into procedure params
+        def options_to_params
+          @params ||= self.class.recognised_options.inject({}) do |par, option|
+            par[option_sym(option)] = send(option.read_method) if metadata_option?(option)
+            par
+          end
+        end
+
+        def self.params_to_options(params)
+          params.values.each do |param|
+            param_to_option(param)
+          end
+        end
+
+        def self.param_to_option(param, custom = {})
+          switches = custom.fetch(:switches, option_switches(param))
+          opt_type = custom.fetch(:type, option_type(param))
+          description = custom.fetch(:description, param.description)
+          options = custom.fetch(:options, {})
+          # clamp doesnt allow required flags
+          options[:required] ||= param.required? unless param.flag?
+          options[:multivalued] ||= param.array?
+          option(switches, opt_type, description, options)
+        end
+
+        def self.option_switches(param)
+          ['--' + dashize(param.name.to_s)]
+        end
+
+        def self.option_type(param)
+          param.flag? ? :flag : param.name.to_s.upcase
+        end
+
+        private
+
+        def option_sym(option)
+          option.switches.first[2..-1].to_sym
+        end
+
+        def metadata_option?(option)
+          !option.switches.include?('--help') && !option.switches.include?('--assumeyes')
+        end
+
+        def params_for_procedure(procedure)
+          all_params = options_to_params
+          params = {}
+          procedure.params.values.each do |param|
+            params[param.name] = all_params[param.name]
+          end
+          params
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/cli/advanced/procedure/abstract_procedure_command.rb
+++ b/lib/foreman_maintain/cli/advanced/procedure/abstract_procedure_command.rb
@@ -2,64 +2,14 @@ module ForemanMaintain
   module Cli
     module Procedure
       class AbstractProcedureCommand < Base
+        include ForemanMaintain::Cli::TransformClampOptions
+
         def execute
           label = underscorize(invocation_path.split.last)
           procedure = procedure(label.to_sym)
           scenario = ForemanMaintain::Scenario.new
-          scenario.add_step(procedure.new(params_for_procedure(procedure)))
+          scenario.add_step(procedure.new(get_params_for(procedure)))
           run_scenario(scenario)
-        end
-
-        # transform clamp options into procedure params
-        def options_to_params
-          @params ||= self.class.recognised_options.inject({}) do |par, option|
-            par[option_sym(option)] = send(option.read_method) if metadata_option?(option)
-            par
-          end
-        end
-
-        def self.params_to_options(params)
-          params.values.each do |param|
-            param_to_option(param)
-          end
-        end
-
-        def self.param_to_option(param, custom = {})
-          switches = custom.fetch(:switches, option_switches(param))
-          opt_type = custom.fetch(:type, option_type(param))
-          description = custom.fetch(:description, param.description)
-          options = custom.fetch(:options, {})
-          # clamp doesnt allow required flags
-          options[:required] ||= param.required? unless param.flag?
-          options[:multivalued] ||= param.array?
-          option(switches, opt_type, description, options)
-        end
-
-        def self.option_switches(param)
-          ['--' + dashize(param.name.to_s)]
-        end
-
-        def self.option_type(param)
-          param.flag? ? :flag : param.name.to_s.upcase
-        end
-
-        private
-
-        def option_sym(option)
-          option.switches.first[2..-1].to_sym
-        end
-
-        def metadata_option?(option)
-          !option.switches.include?('--help') && !option.switches.include?('--assumeyes')
-        end
-
-        def params_for_procedure(procedure)
-          all_params = options_to_params
-          params = {}
-          procedure.params.values.each do |param|
-            params[param.name] = all_params[param.name]
-          end
-          params
         end
       end
     end

--- a/lib/foreman_maintain/cli/advanced/procedure/by_tag_command.rb
+++ b/lib/foreman_maintain/cli/advanced/procedure/by_tag_command.rb
@@ -1,0 +1,32 @@
+require 'foreman_maintain/cli/advanced/procedure/abstract_by_tag_command'
+
+module ForemanMaintain
+  module Cli
+    module Procedure
+      class ByTagCommand < Base
+        available_tags(ForemanMaintain.available_procedures(nil)).each do |tag|
+          klass = Class.new(AbstractByTagCommand) do
+            tag_params_to_options(tag)
+            interactive_option
+          end
+          procedures = ForemanMaintain.available_procedures(:tags => tag).map do |procedure|
+            procedure.label.to_s
+          end
+
+          subcommand(dashize(tag), "Run procedures tagged ##{tag} #{procedures}", klass)
+        end
+
+        def execute
+          puts help
+        end
+
+        def help
+          if self.class.recognised_subcommands.empty?
+            warn 'WARNING: There were no tags found in procedures'
+          end
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/cli/advanced/procedure/run_command.rb
+++ b/lib/foreman_maintain/cli/advanced/procedure/run_command.rb
@@ -1,0 +1,17 @@
+require 'foreman_maintain/cli/advanced/procedure/abstract_procedure_command'
+
+module ForemanMaintain
+  module Cli
+    module Procedure
+      class RunCommand < Base
+        ForemanMaintain.available_procedures(nil).each do |procedure|
+          klass = Class.new(AbstractProcedureCommand) do
+            params_to_options(procedure.params)
+            interactive_option
+          end
+          subcommand(dashize(procedure.label), procedure.description, klass)
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/cli/advanced/procedure_command.rb
+++ b/lib/foreman_maintain/cli/advanced/procedure_command.rb
@@ -1,0 +1,11 @@
+require 'foreman_maintain/cli/advanced/procedure/run_command'
+require 'foreman_maintain/cli/advanced/procedure/by_tag_command'
+
+module ForemanMaintain
+  module Cli
+    class ProcedureCommand < Base
+      subcommand 'run', 'Run maintain procedures manually', Procedure::RunCommand
+      subcommand 'by-tag', 'Run maintain procedures in bulks', Procedure::ByTagCommand
+    end
+  end
+end

--- a/lib/foreman_maintain/cli/advanced_command.rb
+++ b/lib/foreman_maintain/cli/advanced_command.rb
@@ -1,0 +1,9 @@
+require 'foreman_maintain/cli/advanced/procedure_command'
+
+module ForemanMaintain
+  module Cli
+    class AdvancedCommand < Base
+      subcommand 'procedure', 'Run maintain procedures manually', ProcedureCommand
+    end
+  end
+end

--- a/lib/foreman_maintain/cli/base.rb
+++ b/lib/foreman_maintain/cli/base.rb
@@ -1,10 +1,16 @@
+require 'foreman_maintain/csv_parser'
+
 module ForemanMaintain
   module Cli
     class Base < Clamp::Command
       include Concerns::Finders
 
-      def dashize(string)
+      def self.dashize(string)
         string.to_s.tr('_', '-')
+      end
+
+      def dashize(string)
+        self.class.dashize(string)
       end
 
       def underscorize(string)
@@ -35,8 +41,28 @@ module ForemanMaintain
         ForemanMaintain.available_checks(filter)
       end
 
+      def available_procedures
+        filter = {}
+        filter[:tags] = tags if respond_to?(:tags)
+        ForemanMaintain.available_procedures(filter)
+      end
+
       def available_tags(collection)
-        collection.inject([]) { |array, check| array.concat(check.tags).uniq }.sort_by(&:to_s)
+        self.class.available_tags(collection)
+      end
+
+      def self.available_tags(collection)
+        collection.inject([]) { |array, item| array.concat(item.tags).uniq }.sort_by(&:to_s)
+      end
+
+      def self.option(switches, type, description, opts = {}, &block)
+        multivalued = opts.delete(:multivalued)
+        description += ' (comma-separated list)' if multivalued
+        super(switches, type, description, opts) do |value|
+          value = CSVParser.new.parse(value) if multivalued
+          value = instance_exec(value, &block) if block
+          value
+        end
       end
 
       def self.label_option
@@ -49,11 +75,12 @@ module ForemanMaintain
       end
 
       def self.tags_option
-        option '--tags', 'tags',
+        option('--tags', 'tags',
                'Limit only for specific set of labels. ' \
-                 '(Use list-tags command to see available tags)' do |tags|
+                 '(Use list-tags command to see available tags)',
+               :multivalued => true) do |tags|
           raise ArgumentError, 'value not specified' if tags.nil? || tags.empty?
-          tags.split(',').map(&:strip).map { |tag| underscorize(tag).to_sym }
+          tags.map { |tag| underscorize(tag).to_sym }
         end
       end
 

--- a/lib/foreman_maintain/cli/transform_clamp_options.rb
+++ b/lib/foreman_maintain/cli/transform_clamp_options.rb
@@ -1,0 +1,66 @@
+module ForemanMaintain
+  module Cli
+    module TransformClampOptions
+      def self.included(base)
+        base.send(:include, OptionsToParams)
+        base.extend(ParamsToOptions)
+      end
+
+      module OptionsToParams
+        def options_to_params
+          @params ||= self.class.recognised_options.inject({}) do |par, option|
+            par[option_sym(option)] = send(option.read_method) if metadata_option?(option)
+            par
+          end
+        end
+
+        def get_params_for(definition)
+          all_params = options_to_params
+          params = {}
+          definition.params.values.each do |param|
+            params[param.name] = all_params[param.name]
+          end
+          params
+        end
+
+        private
+
+        def option_sym(option)
+          option.switches.first[2..-1].to_sym
+        end
+
+        def metadata_option?(option)
+          !option.switches.include?('--help') && !option.switches.include?('--assumeyes')
+        end
+      end
+
+      module ParamsToOptions
+        def params_to_options(params)
+          params.values.each do |param|
+            param_to_option(param)
+          end
+        end
+
+        def param_to_option(param, custom = {})
+          switches = custom.fetch(:switches, option_switches(param))
+          opt_type = custom.fetch(:type, option_type(param))
+          description = custom.fetch(:description, param.description)
+          options = custom.fetch(:options, {})
+
+          # clamp doesnt allow required flags
+          options[:required] ||= param.required? unless param.flag?
+          options[:multivalued] ||= param.array?
+          option(switches, opt_type, description, options)
+        end
+
+        def option_switches(param)
+          ['--' + dashize(param.name.to_s)]
+        end
+
+        def option_type(param)
+          param.flag? ? :flag : param.name.to_s.upcase
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/concerns/metadata.rb
+++ b/lib/foreman_maintain/concerns/metadata.rb
@@ -149,7 +149,7 @@ module ForemanMaintain
         end
 
         def params
-          metadata[:params] || []
+          metadata[:params] || {}
         end
 
         def before
@@ -232,6 +232,10 @@ module ForemanMaintain
 
       def description
         self.class.description
+      end
+
+      def runtime_message
+        description + (params.empty? ? '' : " (#{params})")
       end
 
       def tags

--- a/lib/foreman_maintain/csv_parser.rb
+++ b/lib/foreman_maintain/csv_parser.rb
@@ -1,0 +1,81 @@
+module ForemanMaintain
+  class CSVParser
+    def initialize
+      reset_parser
+    end
+
+    def parse(data)
+      return [] if data.nil?
+      reset_parser
+      data.each_char do |char|
+        handle_escape(char) || handle_quoting(char) || handle_comma(char) || add_to_buffer(char)
+      end
+      unless @last_quote.nil?
+        raise(ArgumentError, format('Illegal quoting in %s', @raw_buffer))
+      end
+      clean_buffer
+      @value
+    end
+
+    private
+
+    def handle_comma(char)
+      if char == ','
+        clean_buffer
+        true
+      else
+        false
+      end
+    end
+
+    def handle_quoting(char)
+      if @last_quote.nil? && ["'", '"'].include?(char)
+        @last_quote = char
+        @raw_buffer += char
+        true
+      elsif @last_quote == char
+        @last_quote = nil
+        @raw_buffer += char
+        true
+      elsif @last_quote
+        add_to_buffer(char)
+        true
+      else
+        false
+      end
+    end
+
+    def handle_escape(char)
+      if @escape
+        add_to_buffer(char)
+        @escape = false
+        true
+      elsif char == '\\'
+        @escape = true
+        @raw_buffer += char
+        true
+      else
+        false
+      end
+    end
+
+    def add_to_buffer(char)
+      @buffer += char
+      @raw_buffer += char
+    end
+
+    def reset_parser
+      @value = []
+      @buffer = ''
+      @raw_buffer = ''
+      @escape = false
+      @last_quote = nil
+    end
+
+    def clean_buffer
+      @value << @buffer
+      @raw_buffer = ''
+      @buffer = ''
+    end
+  end
+end

--- a/lib/foreman_maintain/param.rb
+++ b/lib/foreman_maintain/param.rb
@@ -1,6 +1,7 @@
 module ForemanMaintain
   class Param
     attr_reader :name, :description, :options
+
     def initialize(name, description, options, &block)
       options.validate_options!(:description, :required, :flag, :array)
       @name = name

--- a/lib/foreman_maintain/reporter/cli_reporter.rb
+++ b/lib/foreman_maintain/reporter/cli_reporter.rb
@@ -173,7 +173,7 @@ module ForemanMaintain
       end
 
       def single_step_decision(step)
-        answer = ask_decision("Continue with step [#{step.description}]?")
+        answer = ask_decision("Continue with step [#{step.runtime_message}]?")
         if answer == :yes
           step
         else
@@ -184,9 +184,9 @@ module ForemanMaintain
       def multiple_steps_decision(steps)
         puts 'There are multiple steps to proceed:'
         steps.each_with_index do |step, index|
-          puts "#{index + 1}) #{step.description}"
+          puts "#{index + 1}) #{step.runtime_message}"
         end
-        ask_to_select('Select step to continue', steps, &:description)
+        ask_to_select('Select step to continue', steps, &:runtime_message)
       end
 
       def ask_decision(message)

--- a/lib/foreman_maintain/scenario.rb
+++ b/lib/foreman_maintain/scenario.rb
@@ -12,22 +12,33 @@ module ForemanMaintain
 
       attr_reader :filter_label, :filter_tags
 
-      def initialize(filter)
+      def initialize(filter, definition_kinds = [:check])
         @filter_tags = filter[:tags]
         @filter_label = filter[:label]
-        @steps = ForemanMaintain.available_checks(filter).map(&:ensure_instance)
+        @definition_kinds = definition_kinds
+        @steps = []
+        @steps += checks(filter) if definition_kinds.include?(:check)
+        @steps += procedures(filter) if definition_kinds.include?(:procedure)
         @steps = DependencyGraph.sort(@steps)
       end
 
-      def description
+      def runtime_message
         if @filter_label
-          "check with label [#{dashize(@filter_label)}]"
+          "#{kind_list} with label [#{dashize(@filter_label)}]"
         else
-          "checks with tags #{tag_string(@filter_tags)}"
+          "#{kinds_list} with tags #{tag_string(@filter_tags)}"
         end
       end
 
       private
+
+      def kinds_list
+        @definition_kinds.map { |kind| kind.to_s + 's' }.join(' and ')
+      end
+
+      def kind_list
+        @definition_kinds.map(&:to_s).join(' or ')
+      end
 
       def tag_string(tags)
         tags.map { |tag| dashize("[#{tag}]") }.join(' ')
@@ -35,6 +46,14 @@ module ForemanMaintain
 
       def dashize(string)
         string.to_s.tr('_', '-')
+      end
+
+      def checks(filter)
+        ForemanMaintain.available_checks(filter).map(&:ensure_instance)
+      end
+
+      def procedures(filter)
+        ForemanMaintain.available_procedures(filter).map(&:ensure_instance)
       end
     end
 

--- a/test/lib/cli/transform_clamp_options_test.rb
+++ b/test/lib/cli/transform_clamp_options_test.rb
@@ -1,0 +1,97 @@
+class Definition
+  def description
+    ''
+  end
+
+  def label
+    :mock
+  end
+
+  def params
+    {
+      :name     => param_name,
+      :state    => param_state,
+      :packages => param_packages
+    }
+  end
+
+  def param_name
+    ForemanMaintain::Param.new(:name, 'Definitaion name', {})
+  end
+
+  def param_state
+    ForemanMaintain::Param.new(:state, 'Definitaion state', :required => true)
+  end
+
+  def param_packages
+    ForemanMaintain::Param.new(:packages, 'Packages to Install', :array => true)
+  end
+end
+
+Option = Struct.new(:read_method, :switches)
+
+module ForemanMaintain
+  module Cli
+    class MockCommand < Base
+      include ForemanMaintain::Cli::TransformClampOptions
+
+      class << self
+        def definition
+          Definition.new
+        end
+
+        def recognised_options
+          [
+            { :read_method => :state, :switches => ['--state'] },
+            { :read_method => :assumeyes, :switches => ['--assumeyes'] }
+          ].map { |options| Option.new(options[:read_method], options[:switches]) }
+        end
+      end
+
+      def state
+        nil
+      end
+
+      def execute
+        get_params_for(Definition.new)
+      end
+    end
+  end
+end
+
+describe ForemanMaintain::Cli::TransformClampOptions do
+  subject { ForemanMaintain::Cli::MockCommand.new('', {}) }
+
+  describe 'OptionsToParams' do
+    it 'get_params_for(definition)' do
+      assert_kind_of Hash, subject.execute
+    end
+
+    it 'options_to_params' do
+      assert_nil subject.options_to_params.fetch(:state)
+    end
+  end
+
+  describe 'ParamsToOptions' do
+    subject { ForemanMaintain::Cli::MockCommand }
+
+    let(:definition) { Definition.new }
+
+    it 'params_to_options(params)' do
+      options = subject.params_to_options(definition.params)
+      refute_empty options, 'ParamsToOptions#params_to_options returned empty!'
+    end
+
+    describe 'param_to_option(param)' do
+      it 'should return clamp object' do
+        option = subject.param_to_option(definition.param_name)
+        assert_kind_of Clamp::Option::Definition, option
+      end
+
+      it 'set require flag' do
+        option = subject.param_to_option(definition.param_state)
+        assert option.required?, '--state is expected to be required'
+      end
+    end
+  end
+end

--- a/test/lib/cli_test.rb
+++ b/test/lib/cli_test.rb
@@ -22,6 +22,7 @@ module ForemanMaintain
         Subcommands:
             health                        Health related commands
             upgrade                       Upgrade related commands
+            advanced                      Advanced tools for server maintenance
 
         Options:
             -h, --help                    print help

--- a/test/lib/csv_parser_test.rb
+++ b/test/lib/csv_parser_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+require 'foreman_maintain/csv_parser'
+
+describe ForemanMaintain::CSVParser do
+  describe 'parse' do
+    let(:parser) { ForemanMaintain::CSVParser.new }
+
+    it 'parses nil' do
+      parser.parse(nil).must_equal []
+    end
+
+    it 'parses empty string' do
+      parser.parse('').must_equal ['']
+    end
+
+    it 'parses single value' do
+      parser.parse('a').must_equal ['a']
+    end
+
+    it 'parses a dquoted string' do
+      parser.parse('\"a').must_equal ['"a']
+    end
+
+    it 'parses a quoted string' do
+      parser.parse("Mary\\'s").must_equal ["Mary's"]
+    end
+
+    it 'should parse a comma separated string' do
+      parser.parse('a,b,c').must_equal %w[a b c]
+    end
+
+    it 'parses a string with escaped comma' do
+      parser.parse('a\,b,c').must_equal %w[a,b c]
+    end
+
+    it 'should parse a comma separated string with quotes' do
+      parser.parse('a,b,\\"c\\"').must_equal ['a', 'b', '"c"']
+    end
+
+    it 'parses a comma separated string with values including comma' do
+      parser.parse('a,b,"c,d"').must_equal %w[a b c,d]
+    end
+
+    it 'parses a comma separated string with values including comma (dquotes)' do
+      parser.parse("a,b,'c,d'").must_equal %w[a b c,d]
+    end
+
+    it 'raises quoting error' do
+      err = proc { parser.parse('1,"3,4""s') }.must_raise ArgumentError
+      err.message.must_equal 'Illegal quoting in "3,4""s'
+    end
+  end
+end


### PR DESCRIPTION
This is draft of CLI for running Procedures. I tried to design it so it is usable for other resources (Checks, Scenarios?).  

Note: I found confusing that `description` as a class method describe the executable and as a instance variable is being used for logging of current action. I split that into `description` - static description of the check/procedure and `runtime_message` able to print instance data (defaulting to `description`). This change needs review.

Current state looks as follows:
```
[root@sat-test-rhel7 foreman_maintain]# ./bin/foreman-maintain -h
Usage:
    foreman-maintain [OPTIONS] SUBCOMMAND [ARG] ...

Parameters:
    SUBCOMMAND                    subcommand
    [ARG] ...                     subcommand arguments

Subcommands:
    health                        Health related commands
    upgrade                       Upgrade related commands
    procedure                     Run maintain procedures manually

Options:
    -h, --help                    print help
```
```
[root@sat-test-rhel7 foreman_maintain]# ./bin/foreman-maintain procedure -h
Usage:
    foreman-maintain procedure [OPTIONS] SUBCOMMAND [ARG] ...

Parameters:
    SUBCOMMAND                    subcommand
    [ARG] ...                     subcommand arguments

Subcommands:
    run                           Run maintain procedures manually
    run-by                        Run maintain procedures manually
    list-tags                     List tags used in procedures

Options:
    -h, --help                    print help
```
All the subcommands for run are dynamicaly generated from available procedures.
```
[root@sat-test-rhel7 foreman_maintain]# ./bin/foreman-maintain procedure run -h
Usage:
    foreman-maintain procedure run [OPTIONS] SUBCOMMAND [ARG] ...

Parameters:
    SUBCOMMAND                    subcommand
    [ARG] ...                     subcommand arguments

Subcommands:
    foreman-tasks-delete          delete tasks
    foreman-tasks-resume          resume paused tasks
    foreman-tasks-ui-investigate  investigate the tasks via UI
    hammer-setup                  setup hammer
    install-package               install packages(s)
    sync-plans-disable            disable active sync plans
    sync-plans-enable             re-enable sync plans

Options:
    -h, --help                    print help
```
Parameters are generated from procedure metadata
```
[root@sat-test-rhel7 foreman_maintain]# ./bin/foreman-maintain procedure run install-package -h
Usage:
    foreman-maintain procedure run install-package [OPTIONS]

Options:
    --packages PACKAGES           List of packages to install
    -y, --assumeyes               Automatically answer yes for all questions
    -h, --help                    print help
```
`run-by` supports filtering based on tags only as filtering with labels is replaced with `run <procedure-name>`. Passing params is not supported now and needs some decision to be made 
```
[root@sat-test-rhel7 foreman_maintain]# ./bin/foreman-maintain procedure run-by -h
Usage:
    foreman-maintain procedure run-by [OPTIONS]

Options:
    --tags tags                   Limit only for specific set of labels. (Use list-tags command to see available tags)
    -y, --assumeyes               Automatically answer yes for all questions
    -h, --help                    print help
```