### PR TITLE
Newly added config constants for packaging.

### DIFF
--- a/bin/foreman-maintain
+++ b/bin/foreman-maintain
@@ -4,6 +4,8 @@ $LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
 
 require 'foreman_maintain'
 
+CONFIG_FILE = '/etc/foreman-maintain/config/foreman_maintain.yml'.freeze
+
 ForemanMaintain.setup
 
 require 'foreman_maintain/cli'

--- a/config/foreman_maintain.yml.packaging
+++ b/config/foreman_maintain.yml.packaging
@@ -1,15 +1,16 @@
 # Directory where the logs are stored.
 # The default file is named as /log/foreman_maintain.log
-:log_dir: 'log'
+:log_dir: '/var/log/foreman-maintain/'
 
 # Logger levels: mention one of debug, info, warning, error, fatal
-:log_level: 'error'
+# :log_level: 'error'
 
 # Mention definitions directories. Default
 # :definitions_dirs:
 
 # Mention file path to store data
-# :storage_file: 'data.yml'
+:storage_file: '/lib/foreman-maintain/data.yml'
 
 # Mention directory to store whole backup data
-# :backup_dir: '/lib/foreman-maintain'
+:backup_dir: '/lib/foreman-maintain'
+

--- a/definitions/features/foreman_tasks.rb
+++ b/definitions/features/foreman_tasks.rb
@@ -88,9 +88,13 @@ class Features::ForemanTasks < ForemanMaintain::Feature
 
   private
 
+  def parent_backup_dir
+    File.expand_path(ForemanMaintain.config.backup_dir)
+  end
+
   def backup_dir(state)
     @backup_dir ||=
-      "/var/lib/foreman/backup-tasks/#{state}/#{Time.now.strftime('%Y-%m-%d_%H-%M-%S')}"
+      "#{parent_backup_dir}/backup-tasks/#{state}/#{Time.now.strftime('%Y-%m-%d_%H-%M-%S')}"
   end
 
   def backup_table(table, state, fkey = 'execution_plan_uuid')

--- a/lib/foreman_maintain/config.rb
+++ b/lib/foreman_maintain/config.rb
@@ -2,18 +2,22 @@ require 'fileutils'
 module ForemanMaintain
   class Config
     attr_accessor :pre_setup_log_messages,
-                  :config_file, :definitions_dirs, :log_level, :log_dir, :storage_file
+                  :config_file, :definitions_dirs, :log_level, :log_dir, :storage_file,
+                  :backup_dir
 
     def initialize(options)
       @pre_setup_log_messages = []
-      @config_file = options.fetch(:config_file, default_config_file)
+      @config_file = options.fetch(:config_file, config_file_path)
       @options = load_config
       @definitions_dirs = @options.fetch(:definitions_dirs,
                                          [File.join(source_path, 'definitions')])
 
       @log_level = @options.fetch(:log_level, ::Logger::DEBUG)
-      @log_dir = find_log_dir_path(@options.fetch(:log_dir, 'log'))
+      @log_dir = find_dir_path(@options.fetch(:log_dir, 'log'))
       @storage_file = @options.fetch(:storage_file, 'data.yml')
+      @backup_dir = find_dir_path(
+        @options.fetch(:backup_dir, '/lib/foreman-maintain')
+      )
     end
 
     private
@@ -30,23 +34,23 @@ module ForemanMaintain
       raise "Couldn't load configuration file. Error: #{e.message}"
     end
 
-    def default_config_file
-      File.join(source_path, 'config/foreman_maintain.yml')
+    def config_file_path
+      File.exist?(CONFIG_FILE) ? CONFIG_FILE : 'config/foreman_maintain.yml'
     end
 
     def source_path
       File.expand_path('../../..', __FILE__)
     end
 
-    def find_log_dir_path(log_dir)
-      log_dir_path = File.expand_path(log_dir)
+    def find_dir_path(dir_path_str)
+      dir_path = File.expand_path(dir_path_str)
       begin
-        FileUtils.mkdir_p(log_dir_path, :mode => 0o750) unless File.exist?(log_dir_path)
+        FileUtils.mkdir_p(dir_path, :mode => 0o750) unless File.exist?(dir_path)
       rescue => e
-        $stderr.puts "No permissions to create log dir #{log_dir}"
+        $stderr.puts "No permissions to create dir #{dir_path_str}"
         $stderr.puts e.message.inspect
       end
-      log_dir_path
+      dir_path
     end
   end
 end

--- a/test/definitions/config/foreman_maintain.yml.test
+++ b/test/definitions/config/foreman_maintain.yml.test
@@ -11,3 +11,6 @@
 
 # Mention file path to store data
 :storage_file: 'test/lib/config/data_test.yml'
+
+# Mention directory to store foreman-tasks backup data
+:backup_dir: '/lib/foreman-maintain/test'

--- a/test/definitions/test_helper.rb
+++ b/test/definitions/test_helper.rb
@@ -84,6 +84,6 @@ module DefinitionsTestHelper
 end
 
 TEST_DIR = File.dirname(__FILE__)
-ForemanMaintain.setup(
-  :config_file => File.join(TEST_DIR, 'config/foreman_maintain.yml.test')
-)
+CONFIG_FILE = File.join(TEST_DIR, 'config/foreman_maintain.yml.test').freeze
+
+ForemanMaintain.setup

--- a/test/lib/test_helper.rb
+++ b/test/lib/test_helper.rb
@@ -20,7 +20,6 @@ module ResetTestState
 end
 
 TEST_DIR = File.dirname(__FILE__)
+CONFIG_FILE = File.join(TEST_DIR, 'config/foreman_maintain.yml.test').freeze
 
-ForemanMaintain.setup(
-  :config_file => File.join(TEST_DIR, 'config/foreman_maintain.yml.test')
-)
+ForemanMaintain.setup


### PR DESCRIPTION
Sorry for confusion as [log file size](https://github.com/theforeman/foreman_maintain/blob/master/lib/foreman_maintain.rb) is already set to `10mb`. 
So I didn't make any changes to it.

I forgot that 3rd argument of logger.new is in bytes not in KB. 
` Logger.new('foo.log', 10, 1024000)` -> 3rd argument is in bytes.
