### PR TITLE
Fixes #20267 - Report Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ Subcommands:
       check                         Run the health checks against the system
         --label label               Run only a specific check
         --tags tags                 Limit only for specific set of tags
-
+    report                        Generate reports
+      disk-usage                    Report disk consumption and availability of directories
+      table-counts                  Get table counts
+      table-sizes                   Get table sizes
+      all                           Generate all reports
     upgrade                       Upgrade related commands
       list-versions                 List versions this system is upgradable to
       check --target-version TARGET_VERSION   Run pre-upgrade checks for upgrading to specified version

--- a/definitions/checks/foreman_proxy/verify_dhcp_config_syntax.rb
+++ b/definitions/checks/foreman_proxy/verify_dhcp_config_syntax.rb
@@ -5,7 +5,7 @@ module Checks::ForemanProxy
       description 'Check for verifying syntax for ISP DHCP configurations'
       tags :default
       confine do
-        file_exists?('/etc/dhcp/dhcpd.conf')
+        file_exist?('/etc/dhcp/dhcpd.conf')
       end
     end
 

--- a/definitions/checks/system_registration.rb
+++ b/definitions/checks/system_registration.rb
@@ -5,7 +5,7 @@ class Checks::SystemRegistration < ForemanMaintain::Check
     tags :default
 
     confine do
-      file_exists?('/etc/rhsm/rhsm.conf') &&
+      file_exist?('/etc/rhsm/rhsm.conf') &&
         !feature(:foreman_server) &&
         feature(:foreman_proxy)
     end

--- a/definitions/features/candlepin_database.rb
+++ b/definitions/features/candlepin_database.rb
@@ -7,7 +7,7 @@ class Features::CandlepinDatabase < ForemanMaintain::Feature
     label :candlepin_database
 
     confine do
-      file_exists?(CANDLEPIN_DB_CONFIG)
+      file_exist?(CANDLEPIN_DB_CONFIG)
     end
   end
 

--- a/definitions/features/disk.rb
+++ b/definitions/features/disk.rb
@@ -1,0 +1,11 @@
+module Features
+  class Disk < ForemanMaintain::Feature
+    metadata do
+      label :disk
+    end
+
+    def usage(dir)
+      execute("du -sh #{dir} | cut -f1")
+    end
+  end
+end

--- a/definitions/features/foreman_database.rb
+++ b/definitions/features/foreman_database.rb
@@ -7,7 +7,7 @@ class Features::ForemanDatabase < ForemanMaintain::Feature
     label :foreman_database
 
     confine do
-      file_exists?(FOREMAN_DB_CONFIG)
+      file_exist?(FOREMAN_DB_CONFIG)
     end
   end
 
@@ -15,10 +15,47 @@ class Features::ForemanDatabase < ForemanMaintain::Feature
     @configuration || load_configuration
   end
 
-  private
+  def count(table, condition = '1=1')
+    query("SELECT count(*) AS count FROM #{table} WHERE #{condition}").first['count'].to_i
+  rescue CSV::MalformedCSVError
+    error_msg = "table '#{table}' does not exist"
+    logger.error(error_msg)
+    error_msg
+  end
+
+  def query(sql)
+    parse_csv(query_csv(sql))
+  end
 
   def load_configuration
     config = YAML.load(File.read(FOREMAN_DB_CONFIG))
     @configuration = config['production']
+  end
+
+  def size(op, size)
+    psql(query_size(op, size))
+  end
+
+  private
+
+  def query_size(op, size)
+    <<-SQL
+      SELECT table_name, pg_size_pretty(total_bytes) AS total
+           , pg_size_pretty(index_bytes) AS INDEX
+           , pg_size_pretty(toast_bytes) AS toast
+           , pg_size_pretty(table_bytes) AS TABLE
+         FROM (
+         SELECT *, total_bytes-index_bytes-COALESCE(toast_bytes,0) AS table_bytes FROM (
+             SELECT c.oid,nspname AS table_schema, relname AS TABLE_NAME
+                     , c.reltuples AS row_estimate
+                     , pg_total_relation_size(c.oid) AS total_bytes
+                     , pg_indexes_size(c.oid) AS index_bytes
+                     , pg_total_relation_size(reltoastrelid) AS toast_bytes
+                 FROM pg_class c
+                 LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+                 WHERE relkind = 'r'
+         ) a where a.total_bytes #{op} #{size}
+       ) a order by total_bytes DESC;
+    SQL
   end
 end

--- a/definitions/procedures/foreman_tasks/delete.rb
+++ b/definitions/procedures/foreman_tasks/delete.rb
@@ -13,7 +13,6 @@ module Procedures::ForemanTasks
     def run
       with_spinner("Deleting #{@state} task") do |spinner|
         count_tasks_before = feature(:foreman_tasks).count(@state)
-
         if count_tasks_before > 0
           spinner.update "Backup #{@state} tasks"
           feature(:foreman_tasks).backup_tasks(@state) do |backup_progress|

--- a/definitions/reports/disk_usage.rb
+++ b/definitions/reports/disk_usage.rb
@@ -1,0 +1,49 @@
+module Reports
+  class DiskUsage < ForemanMaintain::Report
+    metadata do
+      label :disk_usage
+      description 'Report disk consumption and availability of directories'
+      preparation_steps { Procedures::Packages::Install.new(:packages => %w[hdparm fio]) }
+    end
+
+    DEFAULT_DIRS = ['/var/lib/pulp', '/var/lib/mongodb', '/var/lib/pgsql'].freeze
+
+    attr_reader :stats
+
+    def run
+      @stats = {}
+      with_spinner(description) do |spinner|
+        generate_stats
+        spinner.update('Finished')
+        puts "\n"
+        puts show_stats
+      end
+    end
+
+    def to_h
+      @stats = {}
+      { label => generate_stats }
+    end
+
+    private
+
+    def generate_stats
+      DEFAULT_DIRS.each do |dir|
+        if file_exist?(dir)
+          push_stats(dir, feature(:disk).usage(dir))
+        else
+          push_stats(dir, 'does not exist')
+        end
+      end
+      stats
+    end
+
+    def push_stats(dir, usage)
+      stats[dir] = usage
+    end
+
+    def show_stats
+      stats.map { |dir, usage| "#{dir} : #{usage}" }.join("\n")
+    end
+  end
+end

--- a/definitions/reports/table/counts.rb
+++ b/definitions/reports/table/counts.rb
@@ -1,0 +1,28 @@
+module Report
+  module Table
+    class Counts < ForemanMaintain::Report
+      metadata do
+        label :table_counts
+        description 'Get table counts'
+      end
+
+      TABLES = %w[hosts dynflow_actions dynflow_steps katello_repositories].freeze
+
+      def run
+        puts "\n<table-name> : <records-found>"
+        TABLES.each do |table|
+          puts "#{table} : #{feature(:foreman_database).count(table)}"
+        end
+      end
+
+      def to_h
+        stats =
+          TABLES.inject({}) do |stat, table|
+            stat.merge(table => feature(:foreman_database).count(table))
+          end
+
+        { label => stats }
+      end
+    end
+  end
+end

--- a/definitions/reports/table/sizes.rb
+++ b/definitions/reports/table/sizes.rb
@@ -1,0 +1,42 @@
+module Reports
+  module Table
+    class Sizes < ForemanMaintain::Report
+      metadata do
+        label :table_sizes
+        description 'Get table sizes'
+        param :size, 'Show tables with size greater than equal to specified', :array => true
+      end
+
+      attr_reader :size
+
+      DEFAULT_LIMIT_IN_BYTES = Numeric::CONVERSION_NORMS[:m]
+      DEFAULT_OP = '>='.freeze
+
+      def run
+        puts feature(:foreman_database).size(*size_args)
+      end
+
+      def to_h
+        csv_data = feature(:foreman_database).size(*size_args)
+        parsed = CSV.parse(csv_data, :col_sep => '|')
+
+        stats = parsed[2, parsed.count - 3].inject({}) do |stat, row|
+          stat.merge(row.first.strip => row[1].strip)
+        end
+
+        { label => stats }
+      end
+
+      private
+
+      def size_args
+        return default_options if size.nil? || size.empty?
+        size
+      end
+
+      def default_options
+        [DEFAULT_OP, DEFAULT_LIMIT_IN_BYTES]
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -28,11 +28,13 @@ module ForemanMaintain
   require 'foreman_maintain/check'
   require 'foreman_maintain/procedure'
   require 'foreman_maintain/scenario'
+  require 'foreman_maintain/reporter'
+  require 'foreman_maintain/report_runner'
   require 'foreman_maintain/runner'
   require 'foreman_maintain/upgrade_runner'
-  require 'foreman_maintain/reporter'
   require 'foreman_maintain/utils'
   require 'foreman_maintain/error'
+  require 'foreman_maintain/report'
 
   class << self
     attr_accessor :config, :logger
@@ -89,6 +91,10 @@ module ForemanMaintain
 
     def available_procedures(*args)
       detector.available_procedures(*args)
+    end
+
+    def available_reports(*args)
+      detector.available_reports(*args)
     end
 
     def init_logger

--- a/lib/foreman_maintain/cli.rb
+++ b/lib/foreman_maintain/cli.rb
@@ -2,9 +2,11 @@ require 'clamp'
 require 'highline'
 require 'foreman_maintain/cli/base'
 require 'foreman_maintain/cli/transform_clamp_options'
+require 'foreman_maintain/cli/advanced_command'
 require 'foreman_maintain/cli/health_command'
 require 'foreman_maintain/cli/upgrade_command'
-require 'foreman_maintain/cli/advanced_command'
+require 'foreman_maintain/cli/system_report'
+require 'foreman_maintain/cli/report_command'
 
 module ForemanMaintain
   module Cli
@@ -13,6 +15,7 @@ module ForemanMaintain
 
       subcommand 'health', 'Health related commands', HealthCommand
       subcommand 'upgrade', 'Upgrade related commands', UpgradeCommand
+      subcommand 'report', 'Generate reports', ReportCommand
       subcommand 'advanced', 'Advanced tools for server maintenance', AdvancedCommand
 
       def run(*arguments)

--- a/lib/foreman_maintain/cli/advanced/procedure/abstract_by_tag_command.rb
+++ b/lib/foreman_maintain/cli/advanced/procedure/abstract_by_tag_command.rb
@@ -32,7 +32,7 @@ module ForemanMaintain
         private
 
         def scenario(invocation_path)
-          tag = underscorize(invocation_path.split.last).to_sym
+          tag = invocation_path.split.last.underscorize.to_sym
           scenario = ForemanMaintain::Scenario.new
 
           ForemanMaintain.available_procedures(:tags => tag).sort_by(&:label).each do |procedure|

--- a/lib/foreman_maintain/cli/advanced/procedure/by_tag_command.rb
+++ b/lib/foreman_maintain/cli/advanced/procedure/by_tag_command.rb
@@ -12,8 +12,7 @@ module ForemanMaintain
           procedures = ForemanMaintain.available_procedures(:tags => tag).map do |procedure|
             procedure.label.to_s
           end
-
-          subcommand(dashize(tag), "Run procedures tagged ##{tag}: #{procedures.join(', ')}", klass)
+          subcommand(tag.dashize, "Run procedures tagged ##{tag}: #{procedures.join(', ')}", klass)
         end
 
         def execute

--- a/lib/foreman_maintain/cli/advanced/procedure/run_command.rb
+++ b/lib/foreman_maintain/cli/advanced/procedure/run_command.rb
@@ -9,7 +9,7 @@ module ForemanMaintain
             params_to_options(procedure.params)
             interactive_option
           end
-          subcommand(dashize(procedure.label), procedure.description, klass)
+          subcommand(procedure.label.dashize, procedure.description, klass)
         end
       end
     end

--- a/lib/foreman_maintain/cli/base.rb
+++ b/lib/foreman_maintain/cli/base.rb
@@ -7,24 +7,12 @@ module ForemanMaintain
 
       attr_reader :runner
 
-      def self.dashize(string)
-        string.to_s.tr('_', '-')
-      end
-
-      def dashize(string)
-        self.class.dashize(string)
-      end
-
-      def underscorize(string)
-        string.to_s.tr('-', '_')
-      end
-
       def label_string(string)
-        HighLine.color("[#{dashize(string)}]", :yellow)
+        HighLine.color("[#{string.dashize}]", :yellow)
       end
 
       def tag_string(string)
-        HighLine.color("[#{dashize(string)}]", :cyan)
+        HighLine.color("[#{string.dashize}]", :cyan)
       end
 
       def print_check_info(check)
@@ -82,8 +70,8 @@ module ForemanMaintain
         option '--label', 'label',
                'Limit only for a specific label. ' \
                  '(Use "list" command to see available labels)' do |label|
-          raise ArgumentError, 'value not specified' if label.nil? || label.empty?
-          underscorize(label).to_sym
+          raise ArgumentError, 'value not specified' if label.blank?
+          label.underscorize.to_sym
         end
       end
 
@@ -92,8 +80,8 @@ module ForemanMaintain
                'Limit only for specific set of labels. ' \
                  '(Use list-tags command to see available tags)',
                :multivalued => true) do |tags|
-          raise ArgumentError, 'value not specified' if tags.nil? || tags.empty?
-          tags.map { |tag| underscorize(tag).to_sym }
+          raise ArgumentError, 'value not specified' if tags.blank?
+          tags.map(&:strip).map { |tag| tag.underscorize.to_sym }
         end
       end
 

--- a/lib/foreman_maintain/cli/report/abstract_report_command.rb
+++ b/lib/foreman_maintain/cli/report/abstract_report_command.rb
@@ -1,16 +1,13 @@
 module ForemanMaintain
   module Cli
     module Procedure
-      class AbstractProcedureCommand < Base
-        include ForemanMaintain::Cli::TransformClampOptions
-
+      class AbstractReportCommand < Base
         def execute
           label = invocation_path.split.last.underscorize
           procedure = procedure(label.to_sym)
           scenario = ForemanMaintain::Scenario.new
-          scenario.add_step(procedure.new(get_params_for(procedure)))
+          scenario.add_step(procedure.new)
           run_scenario(scenario)
-          exit runner.exit_code
         end
       end
     end

--- a/lib/foreman_maintain/cli/report/params/output.rb
+++ b/lib/foreman_maintain/cli/report/params/output.rb
@@ -1,0 +1,47 @@
+module ForemanMaintain
+  module Cli
+    module Report
+      module Params
+        class Output
+          attr_reader :output
+
+          def initialize(output = nil)
+            @output = output.to_s.downcase
+          end
+
+          def validate!
+            present!
+            validate_args!
+            validate_format!
+          end
+
+          def to_params
+            output
+          end
+
+          private
+
+          def present!
+            raise ArgumentError, 'value not specified' if output.blank?
+          end
+
+          def validate_args!
+            raise ArgumentError, 'too many arguments' if too_many_args?
+          end
+
+          def validate_format!
+            raise ArgumentError, 'invalid format' unless valid_format?
+          end
+
+          def too_many_args?
+            output.split(',').map(&:strip).length > 1
+          end
+
+          def valid_format?
+            %w[json plain-text yaml].include?(output)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/cli/report/params/size.rb
+++ b/lib/foreman_maintain/cli/report/params/size.rb
@@ -1,0 +1,63 @@
+module ForemanMaintain
+  module Cli
+    module Report
+      module Params
+        class Size
+          attr_reader :size
+
+          def initialize(size)
+            @size = disintegrate_size(size)
+          end
+
+          def operator
+            size[0]
+          end
+
+          def number
+            size[1]
+          end
+
+          def metric
+            size[2]
+          end
+
+          def validate!
+            validate_attr!(:operator)
+            validate_attr!(:number)
+            validate_attr!(:metric)
+          end
+
+          def to_params
+            [operator, number_in_bytes]
+          end
+
+          def number_in_bytes
+            number.to_bytes(metric.chars.first)
+          end
+
+          private
+
+          def validate_attr!(name)
+            raise ArgumentError, "Invalid #{name}: #{send(name)}" unless send("valid_#{name}?")
+          end
+
+          def disintegrate_size(size)
+            size.gsub(/[[:space:]]/, '').downcase.scan(/\d+|\D+/)
+          end
+
+          def valid_metric?
+            %w[b k kb m mb g gb].include?(metric)
+          end
+
+          def valid_operator?
+            %w[<= >= > < =].include?(operator)
+          end
+
+          def valid_number?
+            number.match(/\d+|\D+/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/cli/report_command.rb
+++ b/lib/foreman_maintain/cli/report_command.rb
@@ -1,0 +1,37 @@
+require 'foreman_maintain/cli/report/params/size'
+require 'foreman_maintain/cli/report/params/output'
+
+module ForemanMaintain
+  module Cli
+    class ReportCommand < SystemReport
+      ForemanMaintain.available_reports(nil).each do |report|
+        subcommand(report.label.dashize, report.description) do
+          output_format_option
+          limit_table_size_option if report.label == :table_sizes
+
+          def execute
+            label = invocation_path.split.last.underscorize
+            report = report(label.to_sym)
+            scenario = ForemanMaintain::Scenario.new
+            scenario.add_step(report.new(build_params_hash(report)))
+            run_scenario(scenario)
+          end
+
+          def build_params_hash(report)
+            Hash[report.params.map { |param, _obj| [param, send(param)] }]
+          end
+        end
+      end
+
+      subcommand('all', 'Generate all reports') do
+        output_format_option
+
+        def execute
+          scenario = ForemanMaintain::Scenario.new
+          scenario.add_steps(find_reports)
+          run_scenario(scenario)
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/cli/system_report.rb
+++ b/lib/foreman_maintain/cli/system_report.rb
@@ -1,0 +1,62 @@
+module ForemanMaintain
+  module Cli
+    class SystemReport < Base
+      class << self
+        def limit_table_size_option
+          option(['-s', '--size'], "['>=1mb'|'<=1MB']",
+                 'Show tables with size specified operator(>= or <= or > or <). '\
+                 "Defaults to '>=1MB'") do |size|
+            size = Report::Params::Size.new(size)
+            size.validate!
+            size.to_params
+          end
+        end
+
+        def output_format_option
+          option(['-o', '--output'], '[json|plain-text|yaml]',
+                 'Specify output format.',
+                 :default => 'plain-text') do |output|
+            output = Report::Params::Output.new(output)
+            output.validate!
+            output.to_params
+          end
+        end
+      end
+
+      def run_scenario(scenario)
+        if plain_text?
+          super(scenario)
+        else
+          runner_class.new(reporter, scenario).run
+        end
+      end
+
+      def plain_text?
+        output.to_s == 'plain-text'
+      end
+
+      def assumeyes?
+        false
+      end
+
+      def whitelist
+        []
+      end
+
+      def force?
+        false
+      end
+
+      def reporter
+        @reporter ||= ForemanMaintain::Reporter::PlainTextReporter.new(STDOUT, STDIN)
+      end
+
+      def runner_class
+        case output
+        when 'json' then ForemanMaintain::ReportRunner::Json
+        when 'yaml' then ForemanMaintain::ReportRunner::Yaml
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/cli/transform_clamp_options.rb
+++ b/lib/foreman_maintain/cli/transform_clamp_options.rb
@@ -55,7 +55,7 @@ module ForemanMaintain
         end
 
         def option_switches(param)
-          ['--' + dashize(param.name.to_s)]
+          ['--' + param.name.to_s.dashize]
         end
 
         def option_type(param)

--- a/lib/foreman_maintain/concerns/finders.rb
+++ b/lib/foreman_maintain/concerns/finders.rb
@@ -13,12 +13,16 @@ module ForemanMaintain
         ensure_one_object(:check, label)
       end
 
-      def find_checks(conditions)
-        detector.available_checks(conditions)
-      end
-
       def procedure(label)
         ensure_one_object(:procedure, label)
+      end
+
+      def report(label)
+        ensure_one_object(:report, label)
+      end
+
+      def find_checks(conditions)
+        detector.available_checks(conditions)
       end
 
       def find_procedures(conditions)
@@ -31,6 +35,10 @@ module ForemanMaintain
 
       def find_all_scenarios(conditions)
         detector.all_scenarios(conditions)
+      end
+
+      def find_reports
+        detector.available_reports
       end
 
       private
@@ -64,6 +72,8 @@ module ForemanMaintain
           detector.available_procedures(conditions)
         when :check
           detector.available_checks(conditions)
+        when :report
+          detector.available_reports(conditions)
         else
           raise "Unexpected object type #{object_type}"
         end

--- a/lib/foreman_maintain/concerns/system_helpers.rb
+++ b/lib/foreman_maintain/concerns/system_helpers.rb
@@ -61,7 +61,7 @@ module ForemanMaintain
         command_runner.output
       end
 
-      def file_exists?(filename)
+      def file_exist?(filename)
         File.exist?(filename)
       end
 

--- a/lib/foreman_maintain/core_ext.rb
+++ b/lib/foreman_maintain/core_ext.rb
@@ -12,6 +12,23 @@ module ForemanMaintain
     end
     String.send(:include, StripHeredoc)
 
+    module StringSymbolUtils
+      def camel_case
+        return self if self !~ /_/ && self =~ /[A-Z]+.*/
+        split('_').map(&:capitalize).join
+      end
+
+      def dashize
+        to_s.tr('_', '-')
+      end
+
+      def underscorize
+        to_s.tr('-', '_')
+      end
+    end
+    String.send(:include, StringSymbolUtils)
+    Symbol.send(:include, StringSymbolUtils)
+
     module ValidateOptions
       def validate_options!(*valid_keys)
         valid_keys.flatten!
@@ -24,5 +41,27 @@ module ForemanMaintain
       end
     end
     Hash.send(:include, ValidateOptions)
+
+    module FriendlyByte
+      CONVERSION_NORMS = {
+        :k => 1024,
+        :m => 1024**2,
+        :g => 1024**3,
+        :t => 1024**4
+      }.freeze
+
+      def to_bytes(metric)
+        to_i * CONVERSION_NORMS[metric.to_sym]
+      end
+    end
+    Numeric.send(:include, FriendlyByte)
+    String.send(:include, FriendlyByte)
+
+    module ObjectFunctions
+      def blank?
+        respond_to?(:empty?) ? empty? : !self
+      end
+    end
+    Object.send(:include, ObjectFunctions)
   end
 end

--- a/lib/foreman_maintain/detector.rb
+++ b/lib/foreman_maintain/detector.rb
@@ -48,6 +48,14 @@ module ForemanMaintain
       filter(@available_procedures, filter_conditions)
     end
 
+    def available_reports(filter_conditions = nil)
+      unless @available_reports
+        ensure_features_detected
+        @available_reports = find_present_classes(Report)
+      end
+      filter(@available_reports, filter_conditions)
+    end
+
     def find_present_classes(object_base_class)
       object_base_class.all_sub_classes.reduce([]) do |array, object_class|
         array << object_class if object_class.present?

--- a/lib/foreman_maintain/report.rb
+++ b/lib/foreman_maintain/report.rb
@@ -1,0 +1,17 @@
+module ForemanMaintain
+  class Report < Executable
+    include Concerns::Logger
+    include Concerns::SystemHelpers
+    include Concerns::Metadata
+    include Concerns::Finders
+
+    # public method to be overriden
+    def run
+      raise NotImplementedError
+    end
+
+    def to_h
+      raise NotImplementedError
+    end
+  end
+end

--- a/lib/foreman_maintain/report_runner.rb
+++ b/lib/foreman_maintain/report_runner.rb
@@ -1,0 +1,23 @@
+require 'foreman_maintain/report_runner/json'
+require 'foreman_maintain/report_runner/yaml'
+
+module ForemanMaintain
+  class ReportRunner
+    def initialize(reporter, scenario)
+      @scenario = scenario
+      @reporter = reporter
+      @result = []
+    end
+
+    def run
+      @steps_to_run = @scenario.steps.dup
+
+      until @steps_to_run.empty?
+        step = @steps_to_run.shift
+        @result << step.to_h
+      end
+
+      print_result
+    end
+  end
+end

--- a/lib/foreman_maintain/report_runner/json.rb
+++ b/lib/foreman_maintain/report_runner/json.rb
@@ -1,0 +1,9 @@
+module ForemanMaintain
+  class ReportRunner
+    class Json < ReportRunner
+      def print_result
+        puts JSON.pretty_generate(@result)
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/report_runner/yaml.rb
+++ b/lib/foreman_maintain/report_runner/yaml.rb
@@ -1,0 +1,9 @@
+module ForemanMaintain
+  class ReportRunner
+    class Yaml < ReportRunner
+      def print_result
+        puts @result.to_yaml
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/reporter.rb
+++ b/lib/foreman_maintain/reporter.rb
@@ -6,6 +6,7 @@ module ForemanMaintain
       end
     end
     require 'foreman_maintain/reporter/cli_reporter'
+    require 'foreman_maintain/reporter/plain_text_reporter'
 
     DECISION_MAPPER = {
       %w[y yes] => :yes,

--- a/lib/foreman_maintain/reporter/plain_text_reporter.rb
+++ b/lib/foreman_maintain/reporter/plain_text_reporter.rb
@@ -1,0 +1,20 @@
+module ForemanMaintain
+  class Reporter
+    class PlainTextReporter < CLIReporter
+      def before_scenario_starts(_scenario)
+        puts "\nGenerating report"
+        hline('=')
+      end
+
+      def before_execution_starts(execution)
+        puts @hl.color(execution.name, :bold)
+      end
+
+      def after_execution_finishes(execution)
+        puts(execution.output) unless execution.output.empty?
+        hline
+        new_line_if_needed
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/scenario.rb
+++ b/lib/foreman_maintain/scenario.rb
@@ -28,7 +28,7 @@ module ForemanMaintain
 
       def runtime_message
         if @filter_label
-          "#{kind_list} with label [#{dashize(@filter_label)}]"
+          "#{kind_list} with label [#{@filter_label.dashize}]"
         else
           "#{kinds_list} with tags #{tag_string(@filter_tags)}"
         end
@@ -45,11 +45,7 @@ module ForemanMaintain
       end
 
       def tag_string(tags)
-        tags.map { |tag| dashize("[#{tag}]") }.join(' ')
-      end
-
-      def dashize(string)
-        string.to_s.tr('_', '-')
+        tags.map { |tag| "[#{tag}]".dashize }.join(' ')
       end
 
       def checks(filter)

--- a/test/definitions/checks/system_registration_test.rb
+++ b/test/definitions/checks/system_registration_test.rb
@@ -13,7 +13,7 @@ describe Checks::SystemRegistration do
     let(:rhsm_hostname_cmd) { "grep '\\bhostname\\b' < /etc/rhsm/rhsm.conf" }
 
     before do
-      subject.stubs(:file_exists?).returns(true)
+      subject.stubs(:file_exist?).returns(true)
     end
 
     context 'smart-proxy' do
@@ -73,7 +73,7 @@ describe Checks::SystemRegistration do
 
   context 'when RH subscription manager conf does not exists' do
     before do
-      subject.stubs(:file_exists?).returns(false)
+      subject.stubs(:file_exist?).returns(false)
     end
 
     it "runs does not executes when rpm 'katello-ca-consumer' is absent" do

--- a/test/lib/cli/report/params/output_test.rb
+++ b/test/lib/cli/report/params/output_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+module ForemanMaintain
+  describe Cli::Report::Params::Output do
+    subject do
+      Cli::Report::Params::Output
+    end
+
+    describe '.validate!' do
+      it 'json is a valid format' do
+        assert_nil subject.new('Json').validate!
+      end
+
+      it 'yaml is a valid format' do
+        assert_nil subject.new('YAML').validate!
+      end
+
+      it 'xml is not a valid format' do
+        assert_raises ArgumentError do
+          subject.new('XML').validate!
+        end
+      end
+
+      it 'nil is not a valid format' do
+        assert_raises ArgumentError do
+          subject.new(nil).validate!
+        end
+      end
+    end
+
+    it 'to_params returns output string value' do
+      output = subject.new('JSON')
+      assert_equal 'json', output.to_params
+    end
+  end
+end

--- a/test/lib/cli/report/params/size_test.rb
+++ b/test/lib/cli/report/params/size_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+module ForemanMaintain
+  describe Cli::Report::Params::Size do
+    subject do
+      Cli::Report::Params::Size
+    end
+
+    describe 'is valid' do
+      it "if size is greater than equal '>=1m'" do
+        size = subject.new('>=1m')
+        assert_nil size.validate!
+      end
+
+      it "if size is less than equal '<=500kb'" do
+        size = subject.new('<=500kb')
+        assert_nil size.validate!
+      end
+
+      it "if size is less than equal space in-between '<= 9b'" do
+        size = subject.new('<= 9b')
+        assert_nil size.validate!
+      end
+
+      it "if size is '<1g'" do
+        size = subject.new('<1g')
+        assert_nil size.validate!
+      end
+
+      it "if size is '=1m'" do
+        size = subject.new('=1m')
+        assert_nil size.validate!
+      end
+    end
+
+    describe 'is invalid' do
+      it "if size is without any operator '1kb'" do
+        size = subject.new('1kb')
+        error = assert_raises ArgumentError do
+          size.validate!
+        end
+        assert_equal 'Invalid operator: 1', error.message
+      end
+
+      it "if size has incorrect metric '>=1gig'" do
+        size = subject.new('>=1gig')
+        error = assert_raises ArgumentError do
+          size.validate!
+        end
+
+        assert_equal 'Invalid metric: gig', error.message
+      end
+
+      it "if size has invalid number '>=kb'" do
+        size = subject.new('>=kb')
+        error = assert_raises ArgumentError do
+          size.validate!
+        end
+
+        assert_equal 'Invalid operator: >=kb', error.message
+      end
+    end
+
+    it 'to_params returns operator and number in bytes' do
+      size = subject.new('>= 1kb')
+      assert_equal ['>=', 1024], size.to_params
+    end
+  end
+end

--- a/test/lib/cli/report_command_test.rb
+++ b/test/lib/cli/report_command_test.rb
@@ -1,0 +1,90 @@
+require 'test_helper'
+
+require 'foreman_maintain/cli'
+
+module ForemanMaintain
+  describe Cli::ReportCommand do
+    include CliAssertions
+
+    let :command do
+      %w[report]
+    end
+
+    it 'prints help - lists all available commands for report' do
+      assert_cmd <<-OUTPUT.strip_heredoc
+        Usage:
+            foreman-maintain report [OPTIONS] SUBCOMMAND [ARG] ...
+
+        Parameters:
+            SUBCOMMAND                    subcommand
+            [ARG] ...                     subcommand arguments
+
+        Subcommands:
+            disk-usage                    Report disk consumption and availability of directories
+            table-counts                  Get table counts
+            table-sizes                   Get table sizes
+            all                           Generate all reports
+
+        Options:
+            -h, --help                    print help
+      OUTPUT
+    end
+
+    describe 'report all help' do
+      let :command do
+        %w[report all --help]
+      end
+
+      it 'prints help options for all reports' do
+        assert_cmd <<-OUTPUT.strip_heredoc
+          Usage:
+              foreman-maintain report all [OPTIONS]
+
+          Options:
+              -o, --output [json|plain-text|yaml] Specify output format. (default: "plain-text")
+              -h, --help                    print help
+        OUTPUT
+      end
+    end
+
+    describe 'report table-sizes help' do
+      let :command do
+        %w[report table-sizes --help]
+      end
+
+      it 'prints help options for table-sizes' do
+        assert_cmd <<-OUTPUT.strip_heredoc
+          Usage:
+              foreman-maintain report table-sizes [OPTIONS]
+
+          Options:
+              -o, --output [json|plain-text|yaml] Specify output format. (default: "plain-text")
+              -s, --size ['>=1mb'|'<=1MB']  Show tables with size specified operator(>= or <= or > or <). Defaults to '>=1MB'
+              -h, --help                    print help
+        OUTPUT
+      end
+    end
+
+    describe 'report table-sizes with size option' do
+      let :command do
+        %w[report table-sizes --size=<1m]
+      end
+
+      it 'should execute successfully' do
+        Cli::ReportCommand.any_instance.expects(:run_scenario)
+        assert_equal '', run_cmd
+      end
+    end
+
+    describe 'report table-counts with output option' do
+      let :command do
+        %w[report table-counts --output=json]
+      end
+
+      it 'should execute successfully' do
+        Cli::ReportCommand.any_instance.expects(:run_scenario)
+        assert_equal '', run_cmd
+      end
+    end
+  end
+end

--- a/test/lib/cli/system_report_test.rb
+++ b/test/lib/cli/system_report_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+module ForemanMaintain
+  describe Cli::SystemReport do
+    let(:system_report_class) { Cli::SystemReport }
+
+    def stub_output(output)
+      system_report_class.any_instance.stubs(:output => output)
+    end
+
+    describe '.runner_class' do
+      it 'returns Json report runner' do
+        stub_output('json')
+
+        assert_equal ForemanMaintain::ReportRunner::Json,
+                     system_report_class.new(nil).runner_class
+      end
+
+      it 'returns Yaml report runner' do
+        stub_output('yaml')
+
+        assert_equal ForemanMaintain::ReportRunner::Yaml,
+                     system_report_class.new(nil).runner_class
+      end
+    end
+
+    describe '.reporter' do
+      it 'is kind of PlainTextReporter' do
+        assert_kind_of ForemanMaintain::Reporter::PlainTextReporter,
+                       system_report_class.new(nil).reporter
+      end
+    end
+  end
+end

--- a/test/lib/cli_test.rb
+++ b/test/lib/cli_test.rb
@@ -22,6 +22,7 @@ module ForemanMaintain
         Subcommands:
             health                        Health related commands
             upgrade                       Upgrade related commands
+            report                        Generate reports
             advanced                      Advanced tools for server maintenance
 
         Options:

--- a/test/lib/report_runner_test.rb
+++ b/test/lib/report_runner_test.rb
@@ -1,0 +1,6 @@
+require 'test_helper'
+
+module ForemanMaintain
+  describe ReportRunner do
+  end
+end

--- a/test/lib/support/definitions/reports/du.rb
+++ b/test/lib/support/definitions/reports/du.rb
@@ -1,0 +1,8 @@
+module Reports
+  class DiskUsage < ForemanMaintain::Report
+    metadata do
+      label :disk_usage
+      description 'Report disk consumption and availability of directories'
+    end
+  end
+end

--- a/test/lib/support/definitions/reports/tc.rb
+++ b/test/lib/support/definitions/reports/tc.rb
@@ -1,0 +1,10 @@
+module Report
+  module Table
+    class Counts < ForemanMaintain::Report
+      metadata do
+        label :table_counts
+        description 'Get table counts'
+      end
+    end
+  end
+end

--- a/test/lib/support/definitions/reports/ts.rb
+++ b/test/lib/support/definitions/reports/ts.rb
@@ -1,0 +1,11 @@
+module Reports
+  module Table
+    class Sizes < ForemanMaintain::Report
+      metadata do
+        label :table_sizes
+        description 'Get table sizes'
+        param :size, 'Show tables with size greater than equal to specified', :array => true
+      end
+    end
+  end
+end


### PR DESCRIPTION
```
Subcommands:
    disk-usage                    Report disk consumption and availability of directories
    table-counts                  Get table counts
    table-sizes                   Get table sizes
    all                           Generate all reports
```

- [x] All commands working
- [x] Namespace `DiskSpeedMininal` check as `Disk::Performance`
- [x] Functional `json` and yaml output.
       `-o, --output [json|plain-text|yaml] Specify output format. (default: "plain-text")`
- [x] Test cases
- [x] Params validations (http://projects.theforeman.org/issues/20729)
- [x] Merge Procedure-CLI