### PR TITLE
Updated default location for foreman_maintain.yml config file

### DIFF
--- a/bin/foreman-maintain
+++ b/bin/foreman-maintain
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
 
 require 'foreman_maintain'
 
-CONFIG_FILE = '/etc/foreman-maintain/config/foreman_maintain.yml'.freeze
+CONFIG_FILE = '/etc/foreman-maintain/foreman_maintain.yml'.freeze
 
 ForemanMaintain.setup
 


### PR DESCRIPTION
Updated default location for looking up foreman_maintain config file. New location (/etc/foreman-maintain/foreman_maintain.yml) is less deep than earlier location.