### PR TITLE
Fixes #19496 - passenger recycler

### DIFF
--- a/bin/passenger-recycler
+++ b/bin/passenger-recycler
@@ -3,12 +3,12 @@
 # Trivial Passenger memory monitor and recycler. See the configuration file
 # /etc/passenger-recycler.yaml for options. Execute via SCL.
 #
-require "yaml"
+require 'yaml'
 
-$conf = {}
-CONFIG = '/etc/passenger-recycler.yaml'
-$conf = YAML.load_file(CONFIG) if File.readable?(CONFIG)
-exit 0 unless $conf[:ENABLED]
+CONFIG = {}.freeze
+CONFIG_FILE = '/etc/passenger-recycler.yaml'.freeze
+CONFIG = YAML.load_file(CONFIG_FILE) if File.readable?(CONFIG_FILE)
+exit 0 unless CONFIG[:ENABLED]
 
 def running?(pid)
   return Process.getpgid(pid) != -1
@@ -16,12 +16,28 @@ rescue Errno::ESRCH
   return false
 end
 
-def debug msg
-  puts(msg) if $conf[:DEBUG]
+def debug(msg)
+  puts(msg) if CONFIG[:DEBUG]
 end
 
-def verbose msg
-  puts(msg) if $conf[:VERBOSE]
+def verbose(msg)
+  puts(msg) if CONFIG[:VERBOSE]
+end
+
+def kill(pid)
+  if running?(pid) && CONFIG[:KILL_BUSY]
+    verbose "Process #{pid} is still running, sending SIGKILL"
+    Process.kill 'KILL', pid
+    sleep 5
+  end
+end
+
+def process_status?(pid)
+  if running?(pid)
+    verbose "Process #{pid} still terminating, moving on..."
+  else
+    verbose "Process successfully #{pid} terminated"
+  end
 end
 
 require 'phusion_passenger'
@@ -31,38 +47,35 @@ require 'phusion_passenger/admin_tools/memory_stats'
 PhusionPassenger.locate_directories
 stats = PhusionPassenger::AdminTools::MemoryStats.new
 unless stats.platform_provides_private_dirty_rss_information?
-  puts "Please run as root or platform unsupported"
+  puts 'Please run as root or platform unsupported'
   exit 1
 end
 killed = 0
 stats.passenger_processes.each do |p|
   pid = p.pid.to_i
   debug "Checking #{pid} with RSS of #{p.private_dirty_rss}"
-  if p.private_dirty_rss > $conf[:MAX_PRIV_RSS_MEMORY]
-    started = `ps -p#{pid} -o start=`.strip rescue '?'
-    status_ps = `ps -p#{pid} -u`
-    status_all = `passenger-status 2>/dev/null`
-    status_backtraces = `passenger-status --show=backtraces 2>/dev/null`
-    verbose "Terminating #{pid} (started #{started}) with private dirty RSS size of #{p.private_dirty_rss} MB"
-    Process.kill "SIGUSR1", pid
-    sleep $conf[:GRACEFUL_SHUTDOWN_SLEEP]
-    if running?(pid) && $conf[:KILL_BUSY]
-      verbose "Process #{pid} is still running, sending SIGKILL"
-      Process.kill "KILL", pid
-      sleep 5
-    end
-    if running?(pid)
-      verbose "Process #{pid} still terminating, moving on..."
-    else
-      verbose "Process successfully #{pid} terminated"
-    end
-    if $conf[:SEND_STATUS]
-      verbose status_ps
-      verbose status_all
-      verbose status_backtraces
-    end
-    killed += 1
-    exit(1) if killed >= $conf[:MAX_TERMINATION]
+  next unless p.private_dirty_rss > CONFIG[:MAX_PRIV_RSS_MEMORY]
+  started = begin
+              `ps -p#{pid} -o start=`.strip
+            rescue StandardError => e
+              verbose "Error: #{e.message} \nReturning '?'"
+              '?'
+            end
+  status_ps = `ps -p#{pid} -u`
+  status_all = `passenger-status 2> /dev/null`
+  status_backtraces = `passenger-status --show=backtraces 2>/dev/null`
+  verbose "Terminating #{pid} (started #{started}) with private dirty RSS" \
+          " size of #{p.private_dirty_rss} MB"
+  Process.kill 'SIGUSR1', pid
+  sleep CONFIG[:GRACEFUL_SHUTDOWN_SLEEP]
+  kill(pid)
+  process_status?(pid)
+  if CONFIG[:SEND_STATUS]
+    verbose status_ps
+    verbose status_all
+    verbose status_backtraces
   end
+  killed += 1
+  exit(1) if killed >= CONFIG[:MAX_TERMINATION]
 end
 exit 0

--- a/bin/passenger-recycler
+++ b/bin/passenger-recycler
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+#
+# Trivial Passenger memory monitor and recycler. See the configuration file
+# /etc/passenger-recycler.yaml for options. Execute via SCL.
+#
+require "yaml"
+
+$conf = {}
+CONFIG = '/etc/passenger-recycler.yaml'
+$conf = YAML.load_file(CONFIG) if File.readable?(CONFIG)
+exit 0 unless $conf[:ENABLED]
+
+def running?(pid)
+  return Process.getpgid(pid) != -1
+rescue Errno::ESRCH
+  return false
+end
+
+def debug msg
+  puts(msg) if $conf[:DEBUG]
+end
+
+def verbose msg
+  puts(msg) if $conf[:VERBOSE]
+end
+
+require 'phusion_passenger'
+require 'phusion_passenger/platform_info'
+require 'phusion_passenger/platform_info/ruby'
+require 'phusion_passenger/admin_tools/memory_stats'
+PhusionPassenger.locate_directories
+stats = PhusionPassenger::AdminTools::MemoryStats.new
+unless stats.platform_provides_private_dirty_rss_information?
+  puts "Please run as root or platform unsupported"
+  exit 1
+end
+killed = 0
+stats.passenger_processes.each do |p|
+  pid = p.pid.to_i
+  debug "Checking #{pid} with RSS of #{p.private_dirty_rss}"
+  if p.private_dirty_rss > $conf[:MAX_PRIV_RSS_MEMORY]
+    started = `ps -p#{pid} -o start=`.strip rescue '?'
+    status_ps = `ps -p#{pid} -u`
+    status_all = `passenger-status 2>/dev/null`
+    status_backtraces = `passenger-status --show=backtraces 2>/dev/null`
+    verbose "Terminating #{pid} (started #{started}) with private dirty RSS size of #{p.private_dirty_rss} MB"
+    Process.kill "SIGUSR1", pid
+    sleep $conf[:GRACEFUL_SHUTDOWN_SLEEP]
+    if running?(pid) && $conf[:KILL_BUSY]
+      verbose "Process #{pid} is still running, sending SIGKILL"
+      Process.kill "KILL", pid
+      sleep 5
+    end
+    if running?(pid)
+      verbose "Process #{pid} still terminating, moving on..."
+    else
+      verbose "Process successfully #{pid} terminated"
+    end
+    if $conf[:SEND_STATUS]
+      verbose status_ps
+      verbose status_all
+      verbose status_backtraces
+    end
+    killed += 1
+    exit(1) if killed >= $conf[:MAX_TERMINATION]
+  end
+end
+exit 0

--- a/config/passenger-recycler.cron
+++ b/config/passenger-recycler.cron
@@ -1,0 +1,3 @@
+# Configuration file /etc/cron.d/passenger-recycler to run passenger-recycler
+# every 5 minutes.
+*/5 * * * * root /usr/bin/scl enable tfm -- ruby /usr/bin/passenger-recycler

--- a/config/passenger-recycler.cron
+++ b/config/passenger-recycler.cron
@@ -1,3 +1,0 @@
-# Configuration file /etc/cron.d/passenger-recycler to run passenger-recycler
-# every 5 minutes.
-*/5 * * * * root /usr/bin/scl enable tfm -- ruby /usr/bin/passenger-recycler

--- a/config/passenger-recycler.yaml
+++ b/config/passenger-recycler.yaml
@@ -1,0 +1,37 @@
+---
+#
+# Trivial Passenger memory monitor. By default it is executed from cron every
+# five minutes and it kills one process that exceeds the RSS memory threashold
+# configured.
+#
+
+# Set to 'false' to completely disable this script.
+:ENABLED: true
+
+# RSS memory threashold to recycle processes (in kB).
+:MAX_PRIV_RSS_MEMORY: 2_000_000
+
+# Controls amount of processes killed during one run. This number should be
+# smaller by one or two than maximum allowed amount of processes by passenger
+# (defaults to 6) so there is at least one process left.
+:MAX_TERMINATION: 4
+
+# Kill processes which do not terminate gracefully using SIGKILL after
+# GRACEFUL_SHUTDOWN_SLEEP period.
+:KILL_BUSY: true
+
+# Amount of seconds to wait for graceful shutdown (SIGTERM) until a process
+# kill (SIGKILL) is sent. Must be lower than 5 minutes (300 seconds). This
+# gives Passenger some extra time for respawning application before another
+# process is terminated.
+:GRACEFUL_SHUTDOWN_SLEEP: 90
+
+# Print 'passenger-status' and 'ps' output before termination to get some extra
+# information via email from cron. Only printed when a kill is performed.
+:SEND_STATUS: true
+
+# Print verbose information "Process terminating" or "Process killed".
+:VERBOSE: true
+
+# Print extra debugging information.
+:DEBUG: false

--- a/config/passenger-recycler.yaml
+++ b/config/passenger-recycler.yaml
@@ -21,7 +21,7 @@
 :KILL_BUSY: true
 
 # Amount of seconds to wait for graceful shutdown (SIGTERM) until a process
-# kill (SIGKILL) is sent. Must be lower than 5 minutes (300 seconds). This
+# kill (SIGKILL) is sent. Must be lower than 15 minutes (900 seconds). This
 # gives Passenger some extra time for respawning application before another
 # process is terminated.
 :GRACEFUL_SHUTDOWN_SLEEP: 90

--- a/definitions/procedures/passenger_recycler.rb
+++ b/definitions/procedures/passenger_recycler.rb
@@ -3,11 +3,11 @@ class Procedures::PassengerRecycler < ForemanMaintain::Procedure
     description 'Perform Passenger memory recycling'
 
     confine do
-      execute?('which scl') && execute?('which foreman-maintain-passenger-recycler')
+      execute?('which scl') && execute?('which passenger-recycler')
     end
   end
 
   def run
-    execute!('scl enable tfm -- ruby foreman-maintain-passenger-recycler')
+    execute!('scl enable tfm -- ruby passenger-recycler')
   end
 end

--- a/definitions/procedures/passenger_recycler.rb
+++ b/definitions/procedures/passenger_recycler.rb
@@ -1,0 +1,13 @@
+class Procedures::PassengerRecycler < ForemanMaintain::Procedure
+  metadata do
+    description 'Perform Passenger memory recycling'
+
+    confine do
+      execute?('which scl') && execute?('which foreman-maintain-passenger-recycler')
+    end
+  end
+
+  def run
+    execute!('scl enable tfm -- ruby foreman-maintain-passenger-recycler')
+  end
+end

--- a/extras/passenger-recycler.cron
+++ b/extras/passenger-recycler.cron
@@ -1,0 +1,3 @@
+# Configuration file /etc/cron.d/passenger-recycler to run passenger-recycler
+# every 15 minutes.
+*/15 * * * * root /usr/bin/scl enable tfm -- ruby /usr/bin/passenger-recycler


### PR DESCRIPTION
@lzap, I am carrying over https://github.com/theforeman/foreman_maintain/pull/78 here

Following things covered in this PR:
1. Updated `bin/passenger-recycler` to comply with Rubocop standards.
2. Introduced `extras` directory. Which can be used to reside files such as `.cron, .conf` etc.
3. New procedure to execute `passenger-recycler`
   `./bin/foreman-maintain advanced procedure run passenger-recycler`

Next steps:
1. Update [foreman-packaging](https://github.com/theforeman/foreman-packaging/tree/rpm/develop) to install `bin/passenger-recycler` to `/usr/bin/`
2. Setup ` extras/passenger-recycler` to ` /etc/cron.d/passenger-recycler`.

PS: I have not renamed the `passenger-recycler` script and thinking to keep it that way.