### PR TITLE
Fixes #20597 - store the current target version of upgrade

### DIFF
--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -108,7 +108,7 @@ module ForemanMaintain
       config.pre_setup_log_messages.clear
     end
 
-    def storage(label)
+    def storage(label = :default)
       ForemanMaintain::YamlStorage.load(label)
     rescue => e
       logger.error "Invalid Storage label i.e #{label}. Error - #{e.message}"

--- a/lib/foreman_maintain/cli/upgrade_command.rb
+++ b/lib/foreman_maintain/cli/upgrade_command.rb
@@ -6,7 +6,19 @@ module ForemanMaintain
                :required => false
       end
 
+      def current_target_version
+        current_target_version = ForemanMaintain::UpgradeRunner.current_target_version
+        if current_target_version && target_version && target_version != current_target_version
+          raise Error::UsageError,
+                "Can't set target version #{target_version}, "\
+                "#{current_target_version} already in progress"
+        end
+        @target_version = current_target_version if current_target_version
+        return true if current_target_version
+      end
+
       def validate_target_version!
+        return if current_target_version
         unless UpgradeRunner.available_targets.include?(target_version)
           message_start = if target_version
                             "Can't upgrade to #{target_version}"

--- a/lib/foreman_maintain/yaml_storage.rb
+++ b/lib/foreman_maintain/yaml_storage.rb
@@ -13,6 +13,11 @@ module ForemanMaintain
       self.class.save_sub_key(sub_key, data)
     end
 
+    def update_and_save(attributes)
+      @data.merge!(attributes)
+      save
+    end
+
     class << self
       def load_file
         if File.exist?(storage_file_path)


### PR DESCRIPTION
This allows to prevent running one upgrade before finishing another one.
It also fixes an issue, where after updating the packages, one would not
be able to continue with the current upgrade when something goes wrong.