### PR TITLE
Fixes #21208 - upgrade runner should comply with -y option

### DIFF
--- a/definitions/scenarios/upgrade_to_satellite_6_2.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_2.rb
@@ -43,7 +43,7 @@ module Scenarios::Satellite_6_2
 
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.2'))
-      add_step(Procedures::Packages::Update.new(:assumeyes => false))
+      add_step(Procedures::Packages::Update.new(:assumeyes => assumeyes?))
       add_step(Procedures::Installer::Upgrade.new)
     end
   end

--- a/definitions/scenarios/upgrade_to_satellite_6_2_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_2_z.rb
@@ -42,7 +42,7 @@ module Scenarios::Satellite_6_2_z
     end
 
     def compose
-      add_step(Procedures::Packages::Update.new(:assumeyes => false))
+      add_step(Procedures::Packages::Update.new(:assumeyes => assumeyes?))
       add_step(Procedures::Installer::Upgrade.new)
     end
   end

--- a/definitions/scenarios/upgrade_to_satellite_6_3.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_3.rb
@@ -43,7 +43,7 @@ module Scenarios::Satellite_6_3
 
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.3'))
-      add_step(Procedures::Packages::Update.new(:assumeyes => false))
+      add_step(Procedures::Packages::Update.new(:assumeyes => assumeyes?))
       add_step(Procedures::Installer::Upgrade.new)
     end
   end

--- a/definitions/scenarios/upgrade_to_satellite_6_3_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_3_z.rb
@@ -42,7 +42,7 @@ module Scenarios::Satellite_6_3_z
     end
 
     def compose
-      add_step(Procedures::Packages::Update.new(:assumeyes => false))
+      add_step(Procedures::Packages::Update.new(:assumeyes => assumeyes?))
       add_step(Procedures::Installer::Upgrade.new)
     end
   end

--- a/lib/foreman_maintain/scenario.rb
+++ b/lib/foreman_maintain/scenario.rb
@@ -7,6 +7,7 @@ module ForemanMaintain
     extend Concerns::Finders
 
     attr_reader :steps
+    attr_accessor :assumeyes
 
     class FilteredScenario < Scenario
       metadata do
@@ -116,6 +117,10 @@ module ForemanMaintain
       else
         steps
       end
+    end
+
+    def assumeyes?
+      @assumeyes
     end
 
     def passed?

--- a/lib/foreman_maintain/upgrade_runner.rb
+++ b/lib/foreman_maintain/upgrade_runner.rb
@@ -58,6 +58,7 @@ module ForemanMaintain
     def initialize(version, reporter, options = {})
       super(reporter, [], options)
       @tag = self.class.versions_to_tags[version]
+      @assumeyes = options.fetch(:assumeyes, false)
       raise "Unknown version #{version}" unless tag
       @version = version
       @scenario_cache = {}
@@ -132,6 +133,7 @@ module ForemanMaintain
 
     def run_phase(phase)
       with_non_empty_scenario(phase) do |scenario|
+        scenario.assumeyes = assumeyes?
         confirm_scenario(scenario)
         return if quit?
         self.phase = phase

--- a/test/lib/runner_test.rb
+++ b/test/lib/runner_test.rb
@@ -30,6 +30,11 @@ module ForemanMaintain
       Scenarios::Dummy::WarnAndFail.new
     end
 
+    it 'scenario should have access to attribute assumeyes' do
+      success_scenario.assumeyes = true
+      assert success_scenario.assumeyes?
+    end
+
     it 'performs all steps in the scenario' do
       reporter.planned_next_steps_answers = %w[y n]
       runner.run

--- a/test/lib/upgrade_runner_test.rb
+++ b/test/lib/upgrade_runner_test.rb
@@ -20,6 +20,11 @@ module ForemanMaintain
                         :whitelist => %w[present-service-is-running service-is-stopped])
     end
 
+    it 'sets assumeyes from options' do
+      upgrade_runner = UpgradeRunner.new('1.15', reporter, :assumeyes => true)
+      assert(upgrade_runner.assumeyes?)
+    end
+
     it 'lists versions available for upgrading, based on available scenarios' do
       UpgradeRunner.available_targets.must_equal ['1.15']
     end


### PR DESCRIPTION
Pass on the `assumeyes` flag value from `UpgradeRunner` to `upgrade-scenario` which then invokes procedures with `assumeyes` option passed as args.