### PR TITLE
Fixes #21320 - repeated --assumeyes option in packages

### DIFF
--- a/lib/foreman_maintain/cli/base.rb
+++ b/lib/foreman_maintain/cli/base.rb
@@ -98,6 +98,8 @@ module ForemanMaintain
       end
 
       def self.interactive_option
+        delete_duplicate_assumeyes_if_any
+
         option ['-y', '--assumeyes'], :flag,
                'Automatically answer yes for all questions'
 
@@ -109,6 +111,10 @@ module ForemanMaintain
 
         option ['-f', '--force'], :flag,
                'Force steps that would be skipped as they were already run'
+      end
+
+      def self.delete_duplicate_assumeyes_if_any
+        declared_options.delete_if { |opt| opt.handles?('--assumeyes') }
       end
     end
   end


### PR DESCRIPTION
![screenshot-before-after-change](https://user-images.githubusercontent.com/6470528/31597147-7741c504-b264-11e7-8b13-31c7825c28d4.png)

We are already have an interactive option `-y, --assumeyes`.
To maintain consistency between `foreman-maintain advanced procedure run {procedure-name} -h` command, with this commit suppressed an option ` --assumeyes` added from procedure.
So that it won't display repetitive ` --assumeyes` option.

