### PR TITLE
Fixes #21351 - foreman-rake katello:upgrade_check in pre_upgrade

### DIFF
--- a/definitions/checks/foreman_rake/katello_upgrade_check.rb
+++ b/definitions/checks/foreman_rake/katello_upgrade_check.rb
@@ -1,0 +1,27 @@
+module Checks::ForemanRake
+  class KatelloUpgradeCheck < ForemanMaintain::Check
+    metadata do
+      label :katello_upgrade_check
+      tags :pre_upgrade
+      description 'Check for active tasks using katello:upgrade_check'
+      confine do
+        feature(:katello) && command_exists?('foreman-rake')
+      end
+    end
+
+    def run
+      output = execute('foreman-rake katello:upgrade_check')
+      assert(ready_to_upgrade?(output),
+             output,
+             :next_steps =>
+                [Procedures::ForemanTasks::Resume.new,
+                 Procedures::ForemanTasks::UiInvestigate.new('search_query' => 'state = paused')])
+    end
+
+    private
+
+    def ready_to_upgrade?(output)
+      /PASS/ =~ output
+    end
+  end
+end

--- a/lib/foreman_maintain/concerns/system_helpers.rb
+++ b/lib/foreman_maintain/concerns/system_helpers.rb
@@ -136,6 +136,11 @@ module ForemanMaintain
       def version(value)
         Version.new(value)
       end
+
+      def command_exists?(cmd_name)
+        dir_path = execute("command -v #{cmd_name}")
+        !dir_path.strip.empty?
+      end
     end
   end
 end

--- a/test/definitions/checks/foreman_rake/katello_upgrade_check_test.rb
+++ b/test/definitions/checks/foreman_rake/katello_upgrade_check_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+describe Checks::ForemanRake::KatelloUpgradeCheck do
+  include DefinitionsTestHelper
+
+  subject do
+    Checks::ForemanRake::KatelloUpgradeCheck.new
+  end
+
+  it 'passes when no active tasks are present' do
+    subject.stubs(:ready_to_upgrade?).returns(true)
+    result = run_check(subject)
+    assert result.success?, 'Check expected to succeed'
+  end
+
+  it 'fails when any active tasks are present' do
+    subject.stubs(:ready_to_upgrade?).returns(false)
+    result = run_check(subject)
+    assert result.fail?, 'Check expected to fail'
+    assert_equal [Procedures::ForemanTasks::Resume, Procedures::ForemanTasks::UiInvestigate],
+                 subject.next_steps.map(&:class)
+  end
+end


### PR DESCRIPTION
With this commit, `foreman-rake katello:upgrade_check` will get run in pre_upgrade checks.

If there is no active task present then it will show `ok` result and in case of failure whole output of rake task will get shown. 
As this check is again related to tasks, provided two steps for user:
- Resume tasks 
- Investigate URL with search query `state = paused`

As mentioned in [document](https://access.redhat.com/solutions/2089951), currently tasks cleanup script is present but specific to sat 6.2 so I have not included it in steps.
