### PR TITLE
Fixes #21208 - set value of assumeyes to true for package update

### DIFF
--- a/definitions/scenarios/upgrade_to_satellite_6_2.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_2.rb
@@ -43,7 +43,7 @@ module Scenarios::Satellite_6_2
 
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.2'))
-      add_step(Procedures::Packages::Update.new(:assumeyes => false))
+      add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step(Procedures::Installer::Upgrade.new)
     end
   end

--- a/definitions/scenarios/upgrade_to_satellite_6_2_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_2_z.rb
@@ -42,7 +42,7 @@ module Scenarios::Satellite_6_2_z
     end
 
     def compose
-      add_step(Procedures::Packages::Update.new(:assumeyes => false))
+      add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step(Procedures::Installer::Upgrade.new)
     end
   end

--- a/definitions/scenarios/upgrade_to_satellite_6_3.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_3.rb
@@ -43,7 +43,7 @@ module Scenarios::Satellite_6_3
 
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.3'))
-      add_step(Procedures::Packages::Update.new(:assumeyes => false))
+      add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step(Procedures::Installer::Upgrade.new)
     end
   end

--- a/definitions/scenarios/upgrade_to_satellite_6_3_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_3_z.rb
@@ -42,7 +42,7 @@ module Scenarios::Satellite_6_3_z
     end
 
     def compose
-      add_step(Procedures::Packages::Update.new(:assumeyes => false))
+      add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step(Procedures::Installer::Upgrade.new)
     end
   end


### PR DESCRIPTION
@iNecas & @swapab ,
With reference to our discussion on other [PR-107](https://github.com/theforeman/foreman_maintain/pull/107#discussion_r144760494) for same issue, I have made changes in this separate PR i.e pass `true` value to assumeyes arg for Procedures::Packages::Update procedure.

Ready for review.

