### PR TITLE
Fixes #21452 - Add yum clean all before packages update

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ class Procedures::InstallPackage < ForemanMaintain::Procedure
   end
 
   def run
-    install_packages(@packages)
+    packages_action(:install, @packages)
   end
 
   # if false, the step will be considered as done: it will not be executed

--- a/definitions/procedures/packages/update.rb
+++ b/definitions/procedures/packages/update.rb
@@ -6,7 +6,9 @@ module Procedures::Packages
     end
 
     def run
-      packages_action(:update, @packages, :assumeyes => @assumeyes.nil? ? assumeyes? : @assumeyes)
+      assumeyes_val = @assumeyes.nil? ? assumeyes? : @assumeyes
+      clean_all_packages(:assumeyes => assumeyes_val)
+      packages_action(:update, @packages, :assumeyes => assumeyes_val)
     end
 
     def necessary?

--- a/lib/foreman_maintain/concerns/system_helpers.rb
+++ b/lib/foreman_maintain/concerns/system_helpers.rb
@@ -76,13 +76,6 @@ module ForemanMaintain
         execute('hostname -f')
       end
 
-      def install_packages(packages, options = {})
-        options.validate_options!(:assumeyes)
-        yum_options = []
-        yum_options << '-y' if options[:assumeyes]
-        execute!("yum #{yum_options.join(' ')} install #{packages.join(' ')}", :interactive => true)
-      end
-
       def server?
         find_package('foreman')
       end
@@ -101,6 +94,15 @@ module ForemanMaintain
         yum_options << '-y' if options[:assumeyes]
         execute!("yum #{yum_options.join(' ')} #{action} #{packages.join(' ')}",
                  :interactive => true)
+      end
+
+      def clean_all_packages(options = {})
+        options.validate_options!(:assumeyes)
+        yum_options = []
+        yum_options << '-y' if options[:assumeyes]
+        execute!("yum #{yum_options.join(' ')} clean all", :interactive => true)
+        execute!('rm -rf /var/cache/yum')
+        execute!('rm -rf /var/cache/dnf')
       end
 
       def package_version(name)


### PR DESCRIPTION
`yum clean all` doesn't delete `/var/cache/yum`.
According to below BZ issue and one knowledge based article: 
- https://bugzilla.redhat.com/show_bug.cgi?id=1214203
- https://access.redhat.com/solutions/1989973 

Added `rm -rf /var/cache/yum` and `rm -rf /var/cache/dnf` after `yum clean all` command for safer side. Due to removal of cache folder for `dnf`, it will take some time at next run.
