### PR TITLE
Fixes #21507 - Added check for curl status code 000

### DIFF
--- a/definitions/features/foreman_proxy.rb
+++ b/definitions/features/foreman_proxy.rb
@@ -26,12 +26,16 @@ class Features::ForemanProxy < ForemanMaintain::Feature
   end
 
   def find_http_error_msg(array_output, curl_http_status)
-    http_line = ''
-    array_output.each do |str|
-      next unless str.include?('HTTP')
-      http_line = str
+    if curl_http_status == 0
+      'No valid HTTP response (Connection failed)'
+    else
+      http_line = ''
+      array_output.each do |str|
+        next unless str.include?('HTTP')
+        http_line = str
+      end
+      http_line.split(curl_http_status.to_s).last.strip
     end
-    http_line.split(curl_http_status.to_s).last.strip
   end
 
   def run_dhcp_curl


### PR DESCRIPTION
In certain scenarios, curl seems to be exiting with $http_code of 000. When this happens, find_http_error_msg function does not handle the status code and encounters a nil exception.

The [issue](http://projects.theforeman.org/issues/21507) was originally reported by manually stopping foreman-proxy service which closes the port curl queries, but the same behavior is shown when the hostname is (temporarily) unresolvable too.

example:
```
$ curl -w '%{http_code}' https://nonexistant.example.com/
curl: (6) Could not resolve host: nonexistant.example.com
000$
```