### PR TITLE
Fixes #21588 - cofine hammer ping check to katello feature

### DIFF
--- a/definitions/checks/hammer_ping.rb
+++ b/definitions/checks/hammer_ping.rb
@@ -5,6 +5,10 @@ class Checks::HammerPing < ForemanMaintain::Check
     for_feature :hammer
     description 'Check whether all services are running using hammer ping'
     tags :default
+
+    confine do
+      feature(:katello)
+    end
   end
 
   def run


### PR DESCRIPTION
hammer ping command is not available for standalone foreman instance