### PR TITLE
Fixes #21596 - warnings related to profile files on bash load

### DIFF
--- a/definitions/features/foreman_database.rb
+++ b/definitions/features/foreman_database.rb
@@ -16,6 +16,6 @@ class Features::ForemanDatabase < ForemanMaintain::Feature
   end
 
   def psql(query)
-    execute("su - postgres -c 'psql -d foreman'", :stdin => query)
+    execute("su postgres -c 'cd ~; psql -d foreman'", :stdin => query)
   end
 end


### PR DESCRIPTION
I have tested this for sync-plans it works fine.
On reproducer server, tried command - `su - -s /bin/sh postgres` and it is not loading `readonly` variables warning messages.

