### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/lib/foreman_maintain/version.rb
+++ b/lib/foreman_maintain/version.rb
@@ -1,3 +1,3 @@
 module ForemanMaintain
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.1.1'.freeze
 end


### PR DESCRIPTION
Bumping foreman-maintain to 0.1.1. This version includes fixes to hammer credential downcasing and --version description.