### PR TITLE
fixes #22636 - recycler should initialize passenger first

### DIFF
--- a/bin/passenger-recycler
+++ b/bin/passenger-recycler
@@ -41,10 +41,10 @@ def process_status?(pid)
 end
 
 require 'phusion_passenger'
+PhusionPassenger.locate_directories
 require 'phusion_passenger/platform_info'
 require 'phusion_passenger/platform_info/ruby'
 require 'phusion_passenger/admin_tools/memory_stats'
-PhusionPassenger.locate_directories
 stats = PhusionPassenger::AdminTools::MemoryStats.new
 unless stats.platform_provides_private_dirty_rss_information?
   puts 'Please run as root or platform unsupported'


### PR DESCRIPTION
If Ruby is installed in a non-standard location, the following exception
is being thrown when starting passenger-recycler:

````
/usr/local/lib/ruby/site_ruby/2.4/rubygems/core_ext/kernel_require.rb:135:in `require': cannot load such file -- /phusion_passenger/utils/tmpio (LoadError)
from /usr/local/lib/ruby/site_ruby/2.4/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
from /usr/local/lib/ruby/site_ruby/2.4/rubygems/core_ext/kernel_require.rb:39:in `require'
from /usr/local/lib/ruby/gems/2.4/gems/passenger-5.1.12/src/ruby_supportlib/phusion_passenger.rb:240:in `require_passenger_lib'
from /usr/local/lib/ruby/gems/2.4/gems/passenger-5.1.12/src/ruby_supportlib/phusion_passenger/platform_info.rb:26:in `<top (required)>'
from /usr/local/lib/ruby/site_ruby/2.4/rubygems/core_ext/kernel_require.rb:59:in `require'
from /usr/local/lib/ruby/site_ruby/2.4/rubygems/core_ext/kernel_require.rb:59:in `require'
from /usr/local/lib/ruby/gems/2.4/gems/foreman_maintain-0.1.3/bin/passenger-recycler:44:in `<top (required)>'
from /usr/local/bin/passenger-recycler:23:in `load'
from /usr/local/bin/passenger-recycler:23:in `<main>'
````