### PR TITLE
Add context into scenario

### DIFF
--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -20,6 +20,7 @@ module ForemanMaintain
   require 'foreman_maintain/top_level_modules'
   require 'foreman_maintain/yaml_storage'
   require 'foreman_maintain/config'
+  require 'foreman_maintain/context'
   require 'foreman_maintain/detector'
   require 'foreman_maintain/dependency_graph'
   require 'foreman_maintain/param'

--- a/lib/foreman_maintain/context.rb
+++ b/lib/foreman_maintain/context.rb
@@ -1,0 +1,34 @@
+module ForemanMaintain
+  class Context
+    def initialize(data = {})
+      @data = data
+      @mapping = {}
+    end
+
+    def set(key, value, mapping = {})
+      @data[key] = value
+      map(key, mapping)
+    end
+
+    def get(key, default = nil)
+      @data.fetch(key, default)
+    end
+
+    def to_hash
+      @data
+    end
+
+    def map(key, mapping = {})
+      @mapping[key] ||= {}
+      @mapping[key].merge!(mapping)
+    end
+
+    def params_for(definition)
+      @mapping.inject({}) do |params, (key, mapping)|
+        target = mapping[definition]
+        params[target] = @data[key] unless target.nil?
+        params
+      end
+    end
+  end
+end

--- a/test/lib/cli/advanced_procedure_command_test.rb
+++ b/test/lib/cli/advanced_procedure_command_test.rb
@@ -111,6 +111,7 @@ module ForemanMaintain
               upgrade-migration             Procedures::Upgrade::Migration
               upgrade-post-migration        Procedures::Upgrade::PostMigration
               upgrade-pre-migration         Procedures::Upgrade::PreMigration
+              with-param                    Procedures::WithParam
 
           Options:
               -h, --help                    print help

--- a/test/lib/context_test.rb
+++ b/test/lib/context_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+module ForemanMaintain
+  describe Context do
+    let(:context) { ForemanMaintain::Context.new }
+
+    it 'stores key-value' do
+      context.set(:backup_dir, '/tmp')
+      assert_equal '/tmp', context.get(:backup_dir)
+    end
+
+    it 'allows to fetch value with preset default' do
+      assert_equal '/tmp/default', context.get(:backup_dir, '/tmp/default')
+    end
+
+    it 'returns the key-values as an hash' do
+      context.set(:backup_dir, '/tmp')
+      expected = { :backup_dir => '/tmp' }
+      assert_equal expected, context.to_hash
+    end
+
+    describe 'mapping' do
+      let(:context) { ForemanMaintain::Context.new(:backup_dir => '/tmp') }
+
+      class FakeProcedure; end
+      class FakeCheck; end
+
+      it 'allows to set mapping for a key' do
+        context.map(:backup_dir, ForemanMaintain::FakeProcedure => :backup_directory)
+        expected_params = { :backup_directory => '/tmp' }
+        assert_equal expected_params, context.params_for(ForemanMaintain::FakeProcedure)
+      end
+
+      it 'allows set key with mapping in one set' do
+        context.set(:debug, true, ForemanMaintain::FakeProcedure => :debugger)
+        expected_params = { :debugger => true }
+        assert_equal expected_params, context.params_for(ForemanMaintain::FakeProcedure)
+      end
+
+      it 'allows to extend mapping' do
+        context.map(:backup_dir, ForemanMaintain::FakeProcedure => :backup_directory)
+        context.map(:backup_dir, ForemanMaintain::FakeCheck => :backup_directory)
+        expected_params = { :backup_directory => '/tmp' }
+        assert_equal expected_params, context.params_for(ForemanMaintain::FakeProcedure)
+        assert_equal expected_params, context.params_for(ForemanMaintain::FakeCheck)
+      end
+    end
+  end
+end

--- a/test/lib/scenario_test.rb
+++ b/test/lib/scenario_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+module ForemanMaintain
+  describe Scenario do
+    let(:scenario) { Scenarios::WithContext.new(:param => 'value') }
+    let(:reporter) { Support::LogReporter.new }
+    let(:runner) { Runner.new(reporter, scenario) }
+
+    it 'pass context params to the procedure' do
+      runner.run
+      reporter.output.must_equal("value\n")
+    end
+  end
+end

--- a/test/lib/support/definitions/procedures/with_param.rb
+++ b/test/lib/support/definitions/procedures/with_param.rb
@@ -1,0 +1,9 @@
+class Procedures::WithParam < ForemanMaintain::Procedure
+  metadata do
+    param :parameter, 'Parameter'
+  end
+
+  def run
+    puts @parameter
+  end
+end

--- a/test/lib/support/definitions/scenarios/with_context.rb
+++ b/test/lib/support/definitions/scenarios/with_context.rb
@@ -1,0 +1,9 @@
+class Scenarios::WithContext < ForemanMaintain::Scenario
+  def compose
+    add_steps_with_context(Procedures::WithParam)
+  end
+
+  def set_context_mapping
+    context.map(:param, Procedures::WithParam => :parameter)
+  end
+end


### PR DESCRIPTION
Context adds to scenario an ability to distribute own parameters
to included executables. Scenario accepts parameters and keeps mapping
of the params to params of the executables. The mapping is opt-in
so each executable gets just the correct params.

For the usage see the scenario_test