### PR TITLE
Fixes #22759 - enhance cpdb validate check

### DIFF
--- a/config/foreman_maintain.yml.example
+++ b/config/foreman_maintain.yml.example
@@ -19,3 +19,7 @@
 
 # Mention path where foreman-proxy certificates stored on filesystem
 # :foreman_proxy_cert_path: '/etc/foreman'
+
+# Mention directory path to store candlepin db backups
+# :db_backup_dir: '/var/lib/foreman-maintain/db-backups'
+

--- a/config/foreman_maintain.yml.packaging
+++ b/config/foreman_maintain.yml.packaging
@@ -20,3 +20,5 @@
 # Mention path where foreman-proxy certificates stored on filesystem
 # :foreman_proxy_cert_path: '/etc/foreman'
 
+# Mention directory path to store candlepin db backups
+# :db_backup_dir: '/var/lib/foreman-maintain/db-backups'

--- a/definitions/checks/candlepin/validate_db.rb
+++ b/definitions/checks/candlepin/validate_db.rb
@@ -10,7 +10,15 @@ module Checks::Candlepin
     end
 
     def run
-      feature(:candlepin_database).execute_cpdb_validate_cmd
+      result, result_msg = feature(:candlepin_database).execute_cpdb_validate_cmd
+      next_steps = []
+      if feature(:downstream) && feature(:downstream).current_minor_version == '6.2'
+        next_steps.concat(
+          [Procedures::Candlepin::DeleteOrphanedRecordsFromEnvContent.new,
+           Procedures::KnowledgeBaseArticle.new(:doc => 'fix_cpdb_validate_failure')]
+        )
+      end
+      assert(result == 0, result_msg, :next_steps => next_steps)
     end
   end
 end

--- a/definitions/procedures/candlepin/delete_orphaned_records_from_env_content.rb
+++ b/definitions/procedures/candlepin/delete_orphaned_records_from_env_content.rb
@@ -1,0 +1,34 @@
+module Procedures::Candlepin
+  class DeleteOrphanedRecordsFromEnvContent < ForemanMaintain::Procedure
+    metadata do
+      description 'Delete orphaned record(s) from cp_env_content with unresolvable content'
+      label :candlepin_delete_orphaned_records_from_env_content
+
+      confine do
+        feature(:candlepin_database) &&
+          feature(:downstream) &&
+          feature(:downstream).current_minor_version == '6.2' &&
+          feature(:candlepin_database).table_exist?('cp_env_content')
+      end
+    end
+
+    def run
+      with_spinner('Deleting cp_env_content record(s) with unresolvable content') do |spinner|
+        spinner.update 'Finding cp_env_content records with unresolvable content'
+        env_content_ids = feature(:candlepin_database).env_content_ids_with_null_content
+        if env_content_ids.empty?
+          spinner.update 'No orphaned records found'
+        else
+          spinner.update 'Taking a backup of the candlepin database'
+          feature(:candlepin_database).perform_backup
+
+          puts "Total #{env_content_ids.length} records with unresolvable content"
+          spinner.update 'Deleting record(s) from cp_env_content table'
+          feature(:candlepin_database).delete_records_by_ids(
+            'cp_env_content', env_content_ids
+          )
+        end
+      end
+    end
+  end
+end

--- a/definitions/procedures/knowledge_base_article.rb
+++ b/definitions/procedures/knowledge_base_article.rb
@@ -1,0 +1,29 @@
+class Procedures::KnowledgeBaseArticle < ForemanMaintain::Procedure
+  metadata do
+    description 'Show knowledge base article for troubleshooting'
+
+    confine do
+      feature(:downstream)
+    end
+    param :doc,
+          'Document name required to select a correct article',
+          :required => true
+    advanced_run false
+  end
+
+  def run
+    ask(<<-MESSAGE.strip_heredoc)
+      Go to #{kcs_documents[@doc]}
+      please follow steps from above article to resolve this issue
+      press ENTER once done.
+    MESSAGE
+  end
+
+  private
+
+  def kcs_documents
+    {
+      'fix_cpdb_validate_failure' => 'https://access.redhat.com/solutions/3362821'
+    }
+  end
+end

--- a/lib/foreman_maintain/concerns/base_database.rb
+++ b/lib/foreman_maintain/concerns/base_database.rb
@@ -22,6 +22,49 @@ module ForemanMaintain
         psql('SELECT 1 as ping', config)
       end
 
+      def backup_file_path(config = configuration)
+        dump_file_name = "#{config['database']}_#{Time.now.strftime('%Y-%m-%d_%H-%M-%S')}.dump"
+        "#{backup_dir}/#{dump_file_name}.bz2"
+      end
+
+      def backup_db_command(file_path, config = configuration)
+        pg_dump_cmd = "pg_dump -Fc #{config['database']}"
+        "runuser - postgres -c '#{pg_dump_cmd}' | bzip2 -9 > #{file_path}"
+      end
+
+      def backup_dir
+        @backup_dir ||= File.expand_path(ForemanMaintain.config.db_backup_dir)
+      end
+
+      def perform_backup(config = configuration)
+        file_path = backup_file_path(config)
+        backup_cmd = backup_db_command(file_path, config)
+        execute!(backup_cmd)
+        puts "\n Note: Database backup file path - #{file_path}"
+        puts "\n In case of any exception, use above dump file to restore DB."
+      end
+
+      def table_exist?(table_name)
+        sql = <<-SQL
+          SELECT EXISTS ( SELECT *
+          FROM information_schema.tables WHERE table_name =  '#{table_name}' )
+        SQL
+        result = query(sql)
+        return false if result.nil? || (result && result.empty?)
+        result.first['exists'].eql?('t')
+      end
+
+      def delete_records_by_ids(tbl_name, rec_ids)
+        quotize_rec_ids = rec_ids.map { |el| "'#{el}'" }.join(',')
+        unless quotize_rec_ids.empty?
+          psql(<<-SQL)
+            BEGIN;
+             DELETE FROM #{tbl_name} WHERE id IN (#{quotize_rec_ids});
+            COMMIT;
+          SQL
+        end
+      end
+
       private
 
       def psql_db_connection_str(config)

--- a/lib/foreman_maintain/concerns/system_helpers.rb
+++ b/lib/foreman_maintain/concerns/system_helpers.rb
@@ -61,6 +61,11 @@ module ForemanMaintain
         command_runner.output
       end
 
+      def execute_with_status(command, options = {})
+        result_msg = execute(command, options)
+        [$CHILD_STATUS.to_i, result_msg]
+      end
+
       def file_exists?(filename)
         File.exist?(filename)
       end

--- a/lib/foreman_maintain/config.rb
+++ b/lib/foreman_maintain/config.rb
@@ -3,7 +3,8 @@ module ForemanMaintain
   class Config
     attr_accessor :pre_setup_log_messages,
                   :config_file, :definitions_dirs, :log_level, :log_dir, :log_file_size,
-                  :storage_file, :backup_dir, :foreman_proxy_cert_path
+                  :storage_file, :backup_dir, :foreman_proxy_cert_path,
+                  :db_backup_dir
 
     def initialize(options)
       @pre_setup_log_messages = []
@@ -12,10 +13,7 @@ module ForemanMaintain
       @definitions_dirs = @options.fetch(:definitions_dirs,
                                          [File.join(source_path, 'definitions')])
       load_log_configs
-      @storage_file = @options.fetch(:storage_file, 'data.yml')
-      @backup_dir = find_dir_path(
-        @options.fetch(:backup_dir, '/var/lib/foreman-maintain')
-      )
+      load_backup_dir_paths
       @foreman_proxy_cert_path = @options.fetch(:foreman_proxy_cert_path, '/etc/foreman')
     end
 
@@ -25,6 +23,16 @@ module ForemanMaintain
       @log_level = @options.fetch(:log_level, ::Logger::DEBUG)
       @log_dir = find_dir_path(@options.fetch(:log_dir, 'log'))
       @log_file_size = @options.fetch(:log_file_size, 10_000)
+    end
+
+    def load_backup_dir_paths
+      @storage_file = @options.fetch(:storage_file, 'data.yml')
+      @backup_dir = find_dir_path(
+        @options.fetch(:backup_dir, '/var/lib/foreman-maintain')
+      )
+      @db_backup_dir = find_dir_path(
+        @options.fetch(:db_backup_dir, '/var/lib/foreman-maintain/db-backups')
+      )
     end
 
     def load_config


### PR DESCRIPTION

@iNecas, 
could you please suggest me which is the ideal location to store candlepin dump files?
so that I will modify `value for candlepin_db_backup_dir` in config files.

Currently, I have set default value to `/tmp` which needs to be change.
For value `'/var/lib/foreman-maintain/db-backups'` to `candlepin_db_backup_dir`, it is giving me permission error while creating dump. I have tried by giving different `chmod` but still failing. 
Do I need to modify `chown` for this directory?