### PR TITLE
Fixes #22851 - added new metadata 'advanced_run'

### DIFF
--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -92,6 +92,11 @@ module ForemanMaintain
       detector.available_procedures(*args)
     end
 
+    def allowed_available_procedures(*args)
+      procedures = detector.available_procedures(*args)
+      procedures.select(&:advanced_run?)
+    end
+
     def init_logger
       # Note - If timestamp added to filename then number of log files i.e second
       # argument to Logger.new will not work as expected

--- a/lib/foreman_maintain/cli/advanced/procedure/abstract_by_tag_command.rb
+++ b/lib/foreman_maintain/cli/advanced/procedure/abstract_by_tag_command.rb
@@ -13,7 +13,7 @@ module ForemanMaintain
 
         def self.params_for_tag(tag)
           params = {}
-          ForemanMaintain.available_procedures(:tags => tag).each do |procedure|
+          ForemanMaintain.allowed_available_procedures(:tags => tag).each do |procedure|
             procedure.params.each_value do |param|
               unless params.key?(param.name)
                 params[param.name] = { :instance => param, :procedures => [] }
@@ -35,7 +35,9 @@ module ForemanMaintain
           tag = underscorize(invocation_path.split.last).to_sym
           scenario = ForemanMaintain::Scenario.new
 
-          ForemanMaintain.available_procedures(:tags => tag).sort_by(&:label).each do |procedure|
+          ForemanMaintain.allowed_available_procedures(
+            :tags => tag
+          ).sort_by(&:label).each do |procedure|
             scenario.add_step(procedure.new(get_params_for(procedure)))
           end
 

--- a/lib/foreman_maintain/cli/advanced/procedure/by_tag_command.rb
+++ b/lib/foreman_maintain/cli/advanced/procedure/by_tag_command.rb
@@ -4,12 +4,14 @@ module ForemanMaintain
   module Cli
     module Procedure
       class ByTagCommand < Base
-        available_tags(ForemanMaintain.available_procedures(nil)).each do |tag|
+        available_tags(ForemanMaintain.allowed_available_procedures(nil)).each do |tag|
           klass = Class.new(AbstractByTagCommand) do
             tag_params_to_options(tag)
             interactive_option
           end
-          procedures = ForemanMaintain.available_procedures(:tags => tag).map do |procedure|
+          procedures = ForemanMaintain.allowed_available_procedures(
+            :tags => tag
+          ).map do |procedure|
             procedure.label.to_s
           end
 

--- a/lib/foreman_maintain/cli/advanced/procedure/run_command.rb
+++ b/lib/foreman_maintain/cli/advanced/procedure/run_command.rb
@@ -4,7 +4,7 @@ module ForemanMaintain
   module Cli
     module Procedure
       class RunCommand < Base
-        ForemanMaintain.available_procedures(nil).each do |procedure|
+        ForemanMaintain.allowed_available_procedures(nil).each do |procedure|
           klass = Class.new(AbstractProcedureCommand) do
             params_to_options(procedure.params)
             interactive_option

--- a/lib/foreman_maintain/concerns/metadata.rb
+++ b/lib/foreman_maintain/concerns/metadata.rb
@@ -96,6 +96,10 @@ module ForemanMaintain
           @data[:run_once] = true
         end
 
+        def advanced_run(advanced_run)
+          @data[:advanced_run] = advanced_run
+        end
+
         def self.eval_dsl(metadata, &block)
           new(metadata).tap do |dsl|
             dsl.instance_eval(&block)
@@ -174,13 +178,18 @@ module ForemanMaintain
           metadata[:run_once]
         end
 
+        def advanced_run?
+          metadata[:advanced_run]
+        end
+
         def initialize_metadata
           { :tags => [],
             :confine_blocks => [],
             :params => {},
             :preparation_steps_blocks => [],
             :before => [],
-            :after => [] }.tap do |metadata|
+            :after => [],
+            :advanced_run => true }.tap do |metadata|
             if superclass.respond_to?(:metadata)
               metadata[:label] = superclass.metadata[:label]
             end
@@ -270,6 +279,10 @@ module ForemanMaintain
 
       def preparation_steps(*args)
         self.class.preparation_steps(*args)
+      end
+
+      def advanced_run?
+        self.class.advanced_run?
       end
     end
   end

--- a/test/lib/metadata_test.rb
+++ b/test/lib/metadata_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+module ForemanMaintain
+  module Concerns
+    describe Metadata do
+      it 'depending upon direct_invocation, it allows procedure to run using advanced command' do
+        procedures = ForemanMaintain.allowed_available_procedures(nil)
+        assert_includes(procedures, Procedures::Setup,
+                        'procedure is missing')
+        refute_includes(procedures, Procedures::AdvancedRunNotAllowed,
+                        'procedures that should not be found are present')
+      end
+    end
+  end
+end

--- a/test/lib/support/definitions/procedures/advanced_run_not_allowed.rb
+++ b/test/lib/support/definitions/procedures/advanced_run_not_allowed.rb
@@ -1,0 +1,7 @@
+class Procedures::AdvancedRunNotAllowed < ForemanMaintain::Procedure
+  metadata do
+    advanced_run false
+  end
+
+  def run; end
+end


### PR DESCRIPTION
Boolean value for metadata 'advanced_run' of any procedure
will decide whether that procedure can be executed from
'advanced procedure' command or not.