### PR TITLE
Fixes #22738 - check for verifying symlink under setting.d dir

### DIFF
--- a/definitions/checks/remote_execution/verify_settings_file_already_exists.rb
+++ b/definitions/checks/remote_execution/verify_settings_file_already_exists.rb
@@ -1,0 +1,42 @@
+module Checks::RemoteExecution
+  class VerifySettingsFileAlreadyExists < ForemanMaintain::Check
+    metadata do
+      description 'Check to verify remote_execution_ssh settings already exist'
+
+      confine do
+        feature(:downstream) &&
+          feature(:downstream).current_minor_version == '6.2' &&
+          find_package('tfm-rubygem-smart_proxy_dynflow_core') &&
+          file_exists?('/etc/smart_proxy_dynflow_core')
+      end
+    end
+
+    def run
+      if file_exists?('/etc/smart_proxy_dynflow_core/settings.d')
+        symlinks = find_symlinks(settingd_dir_path)
+        assert(
+          symlinks.empty?,
+          failure_msg(settingd_dir_path, symlinks),
+          :next_steps => [
+            Procedures::RemoteExecution::RemoveExistingSettingsd.new(
+              :dirpath => settingd_dir_path
+            )
+          ]
+        )
+      end
+    end
+
+    private
+
+    def failure_msg(dir_path, symlinks)
+      'Settings related to remote_execution_ssh are already present'\
+      " under #{dir_path} and " \
+      "\nit would conflict with the installer from the next version." \
+      "\nsymlinks available - #{symlinks.join(', ')}"
+    end
+
+    def settingd_dir_path
+      '/etc/smart_proxy_dynflow_core/settings.d'
+    end
+  end
+end

--- a/definitions/procedures/remote_execution/remove_existing_settingsd.rb
+++ b/definitions/procedures/remote_execution/remove_existing_settingsd.rb
@@ -1,0 +1,18 @@
+module Procedures::RemoteExecution
+  class RemoveExistingSettingsd < ForemanMaintain::Procedure
+    metadata do
+      param :dirpath,
+            'Directory path for settings.d folder',
+            :required => true
+      description 'Remove existing settings.d directory before installer run.' \
+        "\n The next run of the installer will re-create the directory properly."
+      advanced_run false
+    end
+
+    def run
+      with_spinner("Removing existing #{@dirpath} directory") do |_spinner|
+        execute!("rm -rf #{@dirpath}")
+      end
+    end
+  end
+end

--- a/definitions/scenarios/upgrade_to_satellite_6_3.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_3.rb
@@ -21,6 +21,7 @@ module Scenarios::Satellite_6_3
     def compose
       add_steps(find_checks(:default))
       add_steps(find_checks(:pre_upgrade))
+      add_step(Checks::RemoteExecution::VerifySettingsFileAlreadyExists.new)
     end
   end
 

--- a/lib/foreman_maintain/concerns/system_helpers.rb
+++ b/lib/foreman_maintain/concerns/system_helpers.rb
@@ -142,6 +142,12 @@ module ForemanMaintain
       def format_shell_args(options = {})
         options.map { |shell_optn, val| " #{shell_optn} '#{shellescape(val)}'" }.join
       end
+
+      def find_symlinks(dir_path)
+        cmd = "find '#{dir_path}' -maxdepth 1 -type l"
+        result = execute(cmd).strip
+        result.split(/\n/)
+      end
     end
   end
 end


### PR DESCRIPTION
With this commit, it verifies symlink exist under `/etc/smart_proxy_dynflow_core/settings.d`
If yes, it gives step to remove `settings.d` directory.