### PR TITLE
Fixes #22975 - satellite-installer requires LANG=en_US.utf-8

### DIFF
--- a/definitions/procedures/installer/upgrade.rb
+++ b/definitions/procedures/installer/upgrade.rb
@@ -1,7 +1,7 @@
 module Procedures::Installer
   class Upgrade < ForemanMaintain::Procedure
     def run
-      execute!("#{installer_command} --upgrade", :interactive => true)
+      execute!("LANG=en_US.utf-8 #{installer_command} --upgrade", :interactive => true)
     end
 
     private


### PR DESCRIPTION
Upgrading a Satellite from 6.2 -> 6.3 today I got the following error that this resolves:

```
The LANG envrionment variable should not be set to C
Your system does not meet configuration criteria
```


See https://github.com/Katello/katello-installer/blob/master/checks/lang.rb