### PR TITLE
Fixes #23289 - Add note about puppetserver

### DIFF
--- a/definitions/features/puppet_server.rb
+++ b/definitions/features/puppet_server.rb
@@ -2,6 +2,9 @@ class Features::PuppetServer < ForemanMaintain::Feature
   metadata do
     label :puppet_server
 
+    # We only check puppetserver and not puppet-server, as puppet-server
+    # is a part of httpd and relies on httpd service to restart, therefore
+    # not requiring a separate service to restart
     confine do
       find_package('puppetserver')
     end


### PR DESCRIPTION
both 'puppetserver' and 'puppet-server' are puppet server
packages depending on puppet 3/4