### PR TITLE
Fixes #23271 - use service-wait for service command

### DIFF
--- a/definitions/features/service.rb
+++ b/definitions/features/service.rb
@@ -66,12 +66,21 @@ class Features::Service < ForemanMaintain::Feature
   end
 
   def perform_action_on_service(action, service)
-    command = "systemctl #{action} #{service}"
+    command = service_command(action, service)
     if action == 'status'
       status = execute(command)
       puts "\n\n#{status}\n\n"
     else
       execute!(command)
+    end
+  end
+
+  def service_command(action, service)
+    if File.exist?('/usr/sbin/service-wait') &&
+       !%w[enable disable].include?(action)
+      "service-wait #{service} #{action}"
+    else
+      "systemctl #{action} #{service}"
     end
   end
 


### PR DESCRIPTION
when the service-wait command is present on the system,
we should use this in favor of systemctl. This is how
the katello-service script functioned.