### PR TITLE
Fixes #23411 - use dynflowd in services for foreman-tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ test/definitions/config/foreman-maintain-hammer-default.yml
 data.yml
 .ruby-version
 .ruby-gemset
+*~
+*.swp
+*.swo

--- a/definitions/features/foreman_tasks.rb
+++ b/definitions/features/foreman_tasks.rb
@@ -108,7 +108,11 @@ class Features::ForemanTasks < ForemanMaintain::Feature
   end
 
   def services
-    { 'foreman-tasks' => 30 }
+    if check_min_version('foreman', '1.17')
+      { 'dynflowd' => 30 }
+    else
+      { 'foreman-tasks' => 30 }
+    end
   end
 
   private


### PR DESCRIPTION
In foreman 1.17+, foreman-tasks was renamed to dynflowd