### PR TITLE
Fixes #23498 - run with mongo 3.4 from scl

### DIFF
--- a/lib/foreman_maintain/reporter/cli_reporter.rb
+++ b/lib/foreman_maintain/reporter/cli_reporter.rb
@@ -88,7 +88,8 @@ module ForemanMaintain
       end
 
       def before_execution_starts(execution)
-        logger.info("--- Execution step '#{execution.name}' started ---")
+        label = execution.step.label.to_s.tr('_', '-')
+        logger.info("--- Execution step '#{execution.name}' [#{label}] started ---")
         puts(execution_info(execution, ''))
       end
 

--- a/lib/foreman_maintain/utils/mongo_core.rb
+++ b/lib/foreman_maintain/utils/mongo_core.rb
@@ -34,4 +34,45 @@ module ForemanMaintain::Utils
       'scl enable rh-mongodb34 -- mongodump'
     end
   end
+
+  class MongoCoreInstalled < MongoCore
+    include ForemanMaintain::Concerns::SystemHelpers
+
+    attr_reader :services, :server_config_files, :client_command, :dump_command
+
+    def initialize
+      @services = {}
+      @server_config_files = []
+
+      detect_mongo_default
+      detect_mongo_34
+      raise ForemanMaintain::Error::Fail, 'Mongo client was not found' unless @client_command
+    end
+
+    private
+
+    def detect_mongo_34
+      if find_package('rh-mongodb34-mongodb-server')
+        @services['rh-mongodb34-mongod'] = 5
+        @server_config_files << '/etc/opt/rh/rh-mongodb34/mongod.conf'
+      end
+
+      if find_package('rh-mongodb34-mongodb')
+        @client_command = 'scl enable rh-mongodb34 -- mongo'
+        @dump_command = 'scl enable rh-mongodb34 -- mongodump'
+      end
+    end
+
+    def detect_mongo_default
+      if find_package('mongodb-server')
+        @services['mongod'] = 5
+        @server_config_files << '/etc/mongod.conf'
+      end
+
+      if find_package('mongodb')
+        @client_command = 'mongo'
+        @dump_command = 'mongodump'
+      end
+    end
+  end
 end


### PR DESCRIPTION
To get version of the db server (may be remote) we assume the
'mongo' command is always available. If there is only mongo from SCL
present the mongo client has to be called from  within a scl.

With current state of things it is safe to assume there is at least
some mongo client installed. For the future We will need to figure out
how to install a correct version of the client.