### PR TITLE
Fixes #23637 - backup and restore ssh keys for proxy

### DIFF
--- a/definitions/features/foreman_proxy.rb
+++ b/definitions/features/foreman_proxy.rb
@@ -40,7 +40,8 @@ class Features::ForemanProxy < ForemanMaintain::Feature
   def config_files(for_features = ['all'])
     configs = [
       '/etc/foreman-proxy',
-      '/usr/share/foreman-proxy/.ssh/',
+      '/usr/share/foreman-proxy/.ssh',
+      '/var/lib/foreman-proxy/ssh',
       '/etc/smart_proxy_dynflow_core/settings.yml',
       '/etc/sudoers.d/foreman-proxy'
     ]

--- a/definitions/procedures/restore/configs.rb
+++ b/definitions/procedures/restore/configs.rb
@@ -12,6 +12,7 @@ module Procedures::Restore
       backup = ForemanMaintain::Utils::Backup.new(@backup_dir)
       with_spinner('Resetting') do |spinner|
         spinner.update('Restoring configs')
+        clean_conflicting_data
         restore_configs(backup)
       end
     end
@@ -27,6 +28,13 @@ module Procedures::Restore
       }
 
       feature(:tar).run(tar_options)
+    end
+
+    private
+
+    def clean_conflicting_data
+      # tar is unable to --overwrite dir with symlink
+      execute('rm -rf /usr/share/foreman-proxy/.ssh')
     end
   end
 end


### PR DESCRIPTION
Added missing directory with ssh keys for proxy and fixing
restore failure during file extractions. On some instances
the symlink can be replaced with the actual content which prevents
tar to extract.