### PR TITLE
Fixes #22221 - RAM check before upgrade

### DIFF
--- a/definitions/checks/check_available_memory.rb
+++ b/definitions/checks/check_available_memory.rb
@@ -1,0 +1,24 @@
+class Checks::CheckAvailableMemory < ForemanMaintain::Check
+  metadata do
+    label :check_available_memory
+    description 'Check if system has sufficient RAM available'
+    tags :pre_upgrade
+  end
+
+  def run
+    with_spinner('Checking if system has sufficient RAM') do
+      total_ram = execute("grep MemTotal /proc/meminfo | awk '{print $2}'").to_i
+      curr_feature = available_feature
+      disp_mem = curr_feature.display_mem
+      mem_in_gb = (curr_feature.min_mem / 1024) / 1024
+      msg = "System has total #{mem_in_gb} GB RAM, at least #{disp_mem} GB RAM required."
+      assert(curr_feature.min_mem < total_ram, msg)
+    end
+  end
+
+  private
+
+  def available_feature
+    feature(:downstream) || feature(:katello) || feature(:upstream)
+  end
+end

--- a/definitions/features/downstream.rb
+++ b/definitions/features/downstream.rb
@@ -1,10 +1,21 @@
 class Features::Downstream < ForemanMaintain::Feature
+  MIN_MEM = 7_900_000
+  DISPLAY_MEM = 8
+
   metadata do
     label :downstream
 
     confine do
       downstream_installation?
     end
+  end
+
+  def min_mem
+    MIN_MEM
+  end
+
+  def display_mem
+    DISPLAY_MEM
   end
 
   def less_than_version?(version)

--- a/definitions/features/katello.rb
+++ b/definitions/features/katello.rb
@@ -1,10 +1,21 @@
 class Features::Katello < ForemanMaintain::Feature
+  MIN_MEM = 7_900_000
+  DISPLAY_MEM = 8
+
   metadata do
     label :katello
 
     confine do
       find_package('katello')
     end
+  end
+
+  def min_mem
+    MIN_MEM
+  end
+
+  def display_mem
+    DISPLAY_MEM
   end
 
   def data_dirs

--- a/definitions/features/upstream.rb
+++ b/definitions/features/upstream.rb
@@ -1,10 +1,21 @@
 class Features::Upstream < ForemanMaintain::Feature
+  MIN_MEM = 4_100_000
+  DISPLAY_MEM = 4
+
   metadata do
     label :upstream
 
     confine do
       !downstream_installation?
     end
+  end
+
+  def min_mem
+    MIN_MEM
+  end
+
+  def display_mem
+    DISPLAY_MEM
   end
 
   def setup_repositories(_version)


### PR DESCRIPTION
This adds feature to check RAM for system, it checks,
1. If its upstream and if katello is enabled then 8 GB of RAM required.
2. If its upstream and if katello not enabled then 4GB ram.
3. For downstream its always 8 gb.