### PR TITLE
Fixes #23940 - Change backup metadata keys to have colon

### DIFF
--- a/definitions/procedures/backup/metadata.rb
+++ b/definitions/procedures/backup/metadata.rb
@@ -11,11 +11,11 @@ module Procedures::Backup
     def run
       with_spinner('Collecting metadata') do |spinner|
         metadata = {}
-        metadata['os_version'] = release_info(spinner)
-        metadata['plugin_list'] = plugin_list(spinner) || []
-        metadata['proxy_features'] = proxy_feature_list(spinner) || []
-        metadata['rpms'] = rpms(spinner)
-        metadata['incremental'] = @incremental_dir || false
+        metadata[':os_version'] = release_info(spinner)
+        metadata[':plugin_list'] = plugin_list(spinner) || []
+        metadata[':proxy_features'] = proxy_feature_list(spinner) || []
+        metadata[':rpms'] = rpms(spinner)
+        metadata[':incremental'] = @incremental_dir || false
         save_metadata(metadata, spinner)
       end
     end


### PR DESCRIPTION
Katello-backup used ':key' in the metadata.yaml file. We
should continue to use this to not break any existing functionality
around the backup metadata