### PR TITLE
Fixes #24184 - fix typo for clear_register method

### DIFF
--- a/lib/foreman_maintain/upgrade_runner.rb
+++ b/lib/foreman_maintain/upgrade_runner.rb
@@ -37,7 +37,7 @@ module ForemanMaintain
       end
 
       def clear_register
-        versions_to_tags.lear
+        versions_to_tags.clear
       end
 
       def current_target_version


### PR DESCRIPTION
@iNecas,

While going through the code found this so thought to fix it.
I didn't get any place where `clear_register` method is being called. So I am not sure whether we really need this method. If not, may I remove this method? 


