### PR TITLE
Fixes #23500 - upstream repositories check

### DIFF
--- a/definitions/checks/repositories/check_upstream_repository.rb
+++ b/definitions/checks/repositories/check_upstream_repository.rb
@@ -13,9 +13,9 @@ class Checks::CheckUpstreamRepository < ForemanMaintain::Check
 
   def run
     with_spinner('Checking for presence of upstream repositories') do
-      enabled_upstream_repos = feature(:system_repos).upstream_repos_id
+      enabled_upstream_repos = feature(:system_repos).upstream_repos_ids
       assert(enabled_upstream_repos.empty?,
-             "System has upstream #{enabled_upstream_repos} repositories enabled",
+             "System has upstream #{enabled_upstream_repos.join(',')} repositories enabled",
              :next_steps => Procedures::Repositories::Disable.new(:repos => enabled_upstream_repos))
     end
   end

--- a/definitions/checks/repositories/check_upstream_repository.rb
+++ b/definitions/checks/repositories/check_upstream_repository.rb
@@ -13,48 +13,10 @@ class Checks::CheckUpstreamRepository < ForemanMaintain::Check
 
   def run
     with_spinner('Checking for presence of upstream repositories') do
-      enabled_upstream_repos = run_compare
-      repos_to_disable = comma_separated_repositories(enabled_upstream_repos)
+      enabled_upstream_repos = feature(:system_repos).upstream_repos_id
       assert(enabled_upstream_repos.empty?,
-             "System has upstream #{repos_to_disable} repositories enabled",
-             :next_steps => Procedures::Repositories::Disable.new(:repos => repos_to_disable))
+             "System has upstream #{enabled_upstream_repos} repositories enabled",
+             :next_steps => Procedures::Repositories::Disable.new(:repos => enabled_upstream_repos))
     end
-  end
-
-  def comma_separated_repositories(repos)
-    repos.map! { |r| r.gsub(%r{Repo-id:|\/+\w*}, '') }.join(',')
-  end
-
-  def run_compare
-    enabled_upstream_repos = []
-    repo_id = ''
-    system_repos.each do |repo|
-      repo_id = repo if repo =~ /Repo-id/
-      next unless repo =~ /Repo-baseurl/
-
-      upstream_repo.each do |regex|
-        enabled_upstream_repos.push(repo_id) if repo =~ regex
-      end
-    end
-    return enabled_upstream_repos
-  end
-
-  def system_repos
-    repos = execute("yum repolist enabled -d 6 -e 0 2> /dev/null | grep -E 'Repo-id|Repo-baseurl'")
-    return [] if repos.empty?
-
-    repos.delete!(' ').split("\n")
-  end
-
-  def upstream_repo
-    repo_urls = { :Foreman => %r{yum.theforeman.org\/},
-                  :Katello => %r{fedorapeople.org\/groups\/katello\/releases\/yum\/[\/|\w|.]*} }
-    [/#{repo_urls[:Foreman]}+releases/,
-     /#{repo_urls[:Foreman]}+plugins/,
-     /#{repo_urls[:Katello]}+katello/,
-     /#{repo_urls[:Katello]}+client/,
-     /#{repo_urls[:Katello]}+candlepin/,
-     /#{repo_urls[:Katello]}+pulp/,
-     %r{yum.puppetlabs.com\/el\/[\/|\w|.]*}]
   end
 end

--- a/definitions/checks/repositories/check_upstream_repository.rb
+++ b/definitions/checks/repositories/check_upstream_repository.rb
@@ -1,0 +1,60 @@
+class Checks::CheckUpstreamRepository < ForemanMaintain::Check
+  metadata do
+    label :check_upstream_repository
+    description 'Check if any upstream repositories are enabled on system'
+    tags :pre_upgrade
+    preparation_steps do
+      Procedures::Packages::Install.new(:packages => %w[yum-utils])
+    end
+    confine do
+      feature(:downstream)
+    end
+  end
+
+  def run
+    with_spinner('Checking for presence of upstream repositories') do
+      enabled_upstream_repos = run_compare
+      repos_to_disable = comma_separated_repositories(enabled_upstream_repos)
+      assert(enabled_upstream_repos.empty?,
+             "System has upstream #{repos_to_disable} repositories enabled",
+             :next_steps => Procedures::Repositories::Disable.new(:repos => repos_to_disable))
+    end
+  end
+
+  def comma_separated_repositories(repos)
+    repos.map! { |r| r.gsub(%r{Repo-id:|\/+\w*}, '') }.join(',')
+  end
+
+  def run_compare
+    enabled_upstream_repos = []
+    repo_id = ''
+    system_repos.each do |repo|
+      repo_id = repo if repo =~ /Repo-id/
+      next unless repo =~ /Repo-baseurl/
+
+      upstream_repo.each do |regex|
+        enabled_upstream_repos.push(repo_id) if repo =~ regex
+      end
+    end
+    return enabled_upstream_repos
+  end
+
+  def system_repos
+    repos = execute("yum repolist enabled -d 6 -e 0 2> /dev/null | grep -E 'Repo-id|Repo-baseurl'")
+    return [] if repos.empty?
+
+    repos.delete!(' ').split("\n")
+  end
+
+  def upstream_repo
+    repo_urls = { :Foreman => %r{yum.theforeman.org\/},
+                  :Katello => %r{fedorapeople.org\/groups\/katello\/releases\/yum\/[\/|\w|.]*} }
+    [/#{repo_urls[:Foreman]}+releases/,
+     /#{repo_urls[:Foreman]}+plugins/,
+     /#{repo_urls[:Katello]}+katello/,
+     /#{repo_urls[:Katello]}+client/,
+     /#{repo_urls[:Katello]}+candlepin/,
+     /#{repo_urls[:Katello]}+pulp/,
+     %r{yum.puppetlabs.com\/el\/[\/|\w|.]*}]
+  end
+end

--- a/definitions/features/system_repos.rb
+++ b/definitions/features/system_repos.rb
@@ -11,7 +11,7 @@ class Features::SystemRepos < ForemanMaintain::Feature
         repositories[repo] = url if url =~ regex
       end
     end
-    return repositories
+    repositories
   end
 
   def enabled_repos_hash

--- a/definitions/features/system_repos.rb
+++ b/definitions/features/system_repos.rb
@@ -6,7 +6,7 @@ class Features::SystemRepos < ForemanMaintain::Feature
 
   def upstream_repos
     repositories = {}
-    list.each do |repo, url|
+    enabled_repos_hash.each do |repo, url|
       upstream_repo_urls.each do |regex|
         repositories[repo] = url if url =~ regex
       end
@@ -14,7 +14,7 @@ class Features::SystemRepos < ForemanMaintain::Feature
     return repositories
   end
 
-  def list
+  def enabled_repos_hash
     repos = execute("yum repolist enabled -d 6 -e 0 2> /dev/null | grep -E 'Repo-id|Repo-baseurl'")
     return {} if repos.empty?
 

--- a/definitions/features/system_repos.rb
+++ b/definitions/features/system_repos.rb
@@ -1,0 +1,47 @@
+class Features::SystemRepos < ForemanMaintain::Feature
+  metadata do
+    label :system_repos
+    description 'Feature for operations on yum repositories of system'
+  end
+
+  def upstream_repos
+    repositories = {}
+    list.each do |repo, url|
+      upstream_repo_urls.each do |regex|
+        repositories[repo] = url if url =~ regex
+      end
+    end
+    return repositories
+  end
+
+  def list
+    repos = execute("yum repolist enabled -d 6 -e 0 2> /dev/null | grep -E 'Repo-id|Repo-baseurl'")
+    return {} if repos.empty?
+
+    Hash[*repos.delete!(' ').split("\n")]
+  end
+
+  def upstream_repos_id
+    comma_separated_repoid(upstream_repos.keys)
+  end
+
+  def comma_separated_repoid(repos)
+    repos.map { |r| r.gsub(%r{Repo-id:|\/+\w*}, '') }.join(',')
+  end
+
+  def disable_repos(repo_id)
+    execute!("yum-config-manager --disable #{repo_id}")
+  end
+
+  def upstream_repo_urls
+    repo_urls = { :Foreman => %r{yum.theforeman.org\/},
+                  :Katello => %r{fedorapeople.org\/groups\/katello\/releases\/yum\/[\/|\w|.]*} }
+    [/#{repo_urls[:Foreman]}+releases/,
+     /#{repo_urls[:Foreman]}+plugins/,
+     /#{repo_urls[:Katello]}+katello/,
+     /#{repo_urls[:Katello]}+client/,
+     /#{repo_urls[:Katello]}+candlepin/,
+     /#{repo_urls[:Katello]}+pulp/,
+     %r{yum.puppetlabs.com\/el\/[\w|\/|\.]*\/x86_64}]
+  end
+end

--- a/definitions/features/system_repos.rb
+++ b/definitions/features/system_repos.rb
@@ -21,16 +21,16 @@ class Features::SystemRepos < ForemanMaintain::Feature
     Hash[*repos.delete!(' ').split("\n")]
   end
 
-  def upstream_repos_id
-    comma_separated_repoid(upstream_repos.keys)
+  def upstream_repos_ids
+    trim_repoids(upstream_repos.keys)
   end
 
-  def comma_separated_repoid(repos)
-    repos.map { |r| r.gsub(%r{Repo-id:|\/+\w*}, '') }.join(',')
+  def trim_repoids(repos)
+    repos.map { |r| r.gsub(%r{Repo-id:|\/+\w*}, '') }
   end
 
-  def disable_repos(repo_id)
-    execute!("yum-config-manager --disable #{repo_id}")
+  def disable_repos(repo_ids)
+    execute!("yum-config-manager --disable #{repo_ids.join(',')}")
   end
 
   def upstream_repo_urls

--- a/definitions/features/system_repos.rb
+++ b/definitions/features/system_repos.rb
@@ -25,12 +25,14 @@ class Features::SystemRepos < ForemanMaintain::Feature
     trim_repoids(upstream_repos.keys)
   end
 
-  def trim_repoids(repos)
-    repos.map { |r| r.gsub(%r{Repo-id:|\/+\w*}, '') }
-  end
-
   def disable_repos(repo_ids)
     execute!("yum-config-manager --disable #{repo_ids.join(',')}")
+  end
+
+  private
+
+  def trim_repoids(repos)
+    repos.map { |r| r.gsub(%r{Repo-id:|\/+\w*}, '') }
   end
 
   def upstream_repo_urls

--- a/definitions/features/system_repos.rb
+++ b/definitions/features/system_repos.rb
@@ -42,6 +42,7 @@ class Features::SystemRepos < ForemanMaintain::Feature
      /#{repo_urls[:Katello]}+client/,
      /#{repo_urls[:Katello]}+candlepin/,
      /#{repo_urls[:Katello]}+pulp/,
-     %r{yum.puppetlabs.com\/el\/[\w|\/|\.]*\/x86_64}]
+     %r{yum.puppetlabs.com\/el\/[\w|\/|\.]*\/x86_64},
+     %r{repos.fedorapeople.org\/repos\/pulp\/[\/|\w|.]*\/x86_64}]
   end
 end

--- a/definitions/procedures/repositories/disable.rb
+++ b/definitions/procedures/repositories/disable.rb
@@ -6,7 +6,7 @@ module Procedures::Repositories
     end
     def run
       with_spinner('Disabling repositories') do
-        execute!("yum-config-manager --disable #{@repos}")
+        feature(:system_repos).disable_repos(@repos)
       end
     end
   end

--- a/definitions/procedures/repositories/disable.rb
+++ b/definitions/procedures/repositories/disable.rb
@@ -1,0 +1,13 @@
+module Procedures::Repositories
+  class Disable < ForemanMaintain::Procedure
+    metadata do
+      param :repos, 'List of repositories to disable'
+      description 'Disable repositories'
+    end
+    def run
+      with_spinner('Disabling repositories') do
+        execute!("yum-config-manager --disable #{@repos}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This checks if katello, pulp, candlepin, foreman, foreman-plugin, puppet repositories enabled on system and provides a procedure to disable those.