### PR TITLE
Fixes #24789 - Recognize services on capsule

### DIFF
--- a/definitions/features/gofer.rb
+++ b/definitions/features/gofer.rb
@@ -1,0 +1,15 @@
+class Features::Gofer < ForemanMaintain::Feature
+  metadata do
+    label :gofer
+
+    confine do
+      find_package('gofer')
+    end
+  end
+
+  def services
+    {
+      'goferd' => 30
+    }
+  end
+end

--- a/definitions/features/katello.rb
+++ b/definitions/features/katello.rb
@@ -17,10 +17,7 @@ class Features::Katello < ForemanMaintain::Feature
 
   def services
     {
-      'qpidd'                    => 10,
-      'qdrouterd'                => 10,
-      'goferd'                   => 30,
-      'elasticsearch'            => 30
+      'elasticsearch' => 30
     }
   end
 

--- a/definitions/features/pulp.rb
+++ b/definitions/features/pulp.rb
@@ -10,10 +10,13 @@ class Features::Pulp < ForemanMaintain::Feature
   def services
     {
       'squid'                    => 10,
+      'qpidd'                    => 10,
+      'qdrouterd'                => 10,
       'pulp_workers'             => 20,
       'pulp_celerybeat'          => 20,
       'pulp_resource_manager'    => 20,
-      'pulp_streamer'            => 20
+      'pulp_streamer'            => 20,
+      'httpd'                    => 30
     }
   end
 


### PR DESCRIPTION
Moving services to correct features. qpidd and qdrouterd belongs to
Pulp. httpd is dependency of goth Foreman and Pulp so it was added to
both. gofer is a feature of a client registered to Katello (which is
orthogonal to server/proxy) and was moved to separate gofer feature.