### PR TITLE
Fixes #24797 - Use dynflowd on Foreman >= 1.17

### DIFF
--- a/definitions/features/foreman_tasks.rb
+++ b/definitions/features/foreman_tasks.rb
@@ -108,11 +108,11 @@ class Features::ForemanTasks < ForemanMaintain::Feature
   end
 
   def services
-    if check_min_version('foreman', '1.17')
-      { 'dynflowd' => 30 }
-    else
-      { 'foreman-tasks' => 30 }
-    end
+    { service_name => 30 }
+  end
+
+  def service_name
+    check_min_version('foreman', '1.17') ? 'dynflowd' : 'foreman-tasks'
   end
 
   private

--- a/definitions/features/hammer.rb
+++ b/definitions/features/hammer.rb
@@ -11,14 +11,6 @@ class Features::Hammer < ForemanMaintain::Feature
     end
   end
 
-  SERVICES_MAPPING = {
-    'candlepin_auth' => %w[postgresql tomcat],
-    'candlepin' => %w[postgresql tomcat],
-    'pulp_auth' => %w[pulp_resource_manager pulp_workers pulp_celerybeat],
-    'pulp' => %w[pulp_resource_manager pulp_workers pulp_celerybeat],
-    'foreman_tasks' => %w[foreman-tasks]
-  }.freeze
-
   def initialize
     @configuration = { :foreman => {} }
     @config_files = []
@@ -145,10 +137,25 @@ class Features::Hammer < ForemanMaintain::Feature
     resources_failed
   end
 
+  def related_services(resource)
+    case resource
+    when 'candlepin_auth'
+      %w[postgresql tomcat]
+    when 'candlepin'
+      %w[postgresql tomcat]
+    when 'pulp_auth'
+      %w[pulp_resource_manager pulp_workers pulp_celerybeat]
+    when 'pulp'
+      %w[pulp_resource_manager pulp_workers pulp_celerybeat]
+    when 'foreman_tasks'
+      [feature(:foreman_tasks).service_name]
+    end
+  end
+
   def map_resources_with_services(resources)
     service_names = []
     resources.each do |resource|
-      service_names.concat(SERVICES_MAPPING[resource])
+      service_names.concat(related_services(resource))
     end
     service_names
   end


### PR DESCRIPTION
In foreman 1.17 the Dynflow became part of Foreman and the dynflowd
service is used instead of foreman-tasks. We keep mapping of resources
from 'hammer ping' to related services and it was missing the change.

IMO this should be just a temporary fix and we need to change the HammerPing check to use the services directly as tracked in https://projects.theforeman.org/issues/24793