### PR TITLE
Fixes #24784 - Do not pre-setup Hammer when httpd is down

### DIFF
--- a/definitions/checks/foreman_tasks/not_paused.rb
+++ b/definitions/checks/foreman_tasks/not_paused.rb
@@ -5,6 +5,7 @@ module Checks::ForemanTasks
       for_feature :foreman_tasks
       description 'Check for paused tasks'
       tags :default
+      after :services_up, :hammer_ping
     end
 
     def run

--- a/definitions/checks/hammer_ping.rb
+++ b/definitions/checks/hammer_ping.rb
@@ -5,6 +5,7 @@ class Checks::HammerPing < ForemanMaintain::Check
     for_feature :hammer
     description 'Check whether all services are running using hammer ping'
     tags :default
+    after :services_up
 
     confine do
       feature(:katello)

--- a/definitions/procedures/hammer_setup.rb
+++ b/definitions/procedures/hammer_setup.rb
@@ -5,8 +5,13 @@ class Procedures::HammerSetup < ForemanMaintain::Procedure
   end
 
   def run
-    result = feature(:hammer).setup_admin_access
-    logger.info 'Hammer was configured successfully.' if result
+    if feature(:foreman_server) && ForemanMaintain::Utils.system_service('httpd', 30).running?
+      puts 'Configuring Hammer CLI...'
+      result = feature(:hammer).setup_admin_access
+      logger.info 'Hammer was configured successfully.' if result
+    else
+      skip("#{feature(:instance).product_name} server is not running. Hammer can't be setup now.")
+    end
   end
 
   def necessary?

--- a/test/definitions/procedures/hammer_setup_test.rb
+++ b/test/definitions/procedures/hammer_setup_test.rb
@@ -34,6 +34,8 @@ describe Procedures::HammerSetup do
 
   context 'there is a default configuration with valid credentials' do
     it 'uses the default config and sets the feature' do
+      assume_feature_present(:foreman_server)
+      assume_service_running('httpd')
       hammer_ins.stubs(:_check_connection).returns(true)
       result = run_procedure(subject)
       assert result.success?, 'the procedure was expected to succeed'
@@ -43,10 +45,22 @@ describe Procedures::HammerSetup do
 
   context 'there is a configuration with invalid credentials' do
     it 'calls setup_admin_access and sets the feature' do
+      assume_feature_present(:foreman_server)
+      assume_service_running('httpd')
       hammer_ins.stubs(:_check_connection).returns(false)
       hammer_ins.expects(:setup_admin_access).returns(true)
       result = run_procedure(subject)
       assert result.success?, 'the procedure was expected to succeed'
+    end
+
+    it 'skipps setup_admin_access if httpd is down' do
+      assume_feature_present(:foreman_server)
+      assume_service_stopped('httpd')
+      hammer_ins.stubs(:_check_connection).returns(false)
+      hammer_ins.expects(:setup_admin_access).never
+      result = run_procedure(subject)
+      assert result.success?, 'the procedure was expected to succeed'
+      assert result.status, :skipped
     end
   end
 end


### PR DESCRIPTION
Usualy when Hammer is needed we try to pre-setup it
at the beginning of the scenario so that the user is not asked for
credentials in the middle of execution. If the httpd is down the setup
fail and the whole scenario stops. This patch allow skipping of
the pre-setup and do it when Hammer is really needed.