### PR TITLE
Fixes #24858 - Fixed formatting of katello-service params

### DIFF
--- a/definitions/features/service.rb
+++ b/definitions/features/service.rb
@@ -150,8 +150,12 @@ class Features::Service < ForemanMaintain::Feature
 
   def katello_service_filters(options)
     filters = ''
-    filters += "--exclude #{options[:exclude]}" if options[:exclude] && options[:exclude].any?
-    filters += "--only #{options[:only]}" if options[:only] && options[:only].any?
+    if options[:exclude] && options[:exclude].any?
+      filters += "--exclude #{options[:exclude].join(',')}"
+    end
+    if options[:only] && options[:only].any?
+      filters += "--only #{options[:only].join(',')}"
+    end
     filters
   end
 end


### PR DESCRIPTION
This fixes the formatting of --only and --exclude parameters
when passed to katello-service.

Before: katello-service start --only ["postgresql", "squid"]
After:  katello-service start --only postgresql,squid