### PR TITLE
Fixes #25032 - Setup hammer on system with defaults set

### DIFF
--- a/definitions/features/hammer.rb
+++ b/definitions/features/hammer.rb
@@ -212,6 +212,6 @@ class Features::Hammer < ForemanMaintain::Feature
   end
 
   def _check_connection
-    `#{command_base} architecture list 2>&1` && $CHILD_STATUS.exitstatus == 0
+    `#{command_base} user list --per-page 1 2>&1` && $CHILD_STATUS.exitstatus == 0
   end
 end


### PR DESCRIPTION
When organization is set in hammer defaults foreman-maintain
is not able to setup hammer properly. The original cause is
API controller fails for architecture list with org argument set.
As a workaround in foreman-maintain we use different API endpoint
to confirm hammer auth is properly set.