### PR TITLE
Fixes #25261 - fix passenger-recycler procedure

### DIFF
--- a/bin/passenger-recycler
+++ b/bin/passenger-recycler
@@ -11,9 +11,9 @@ CONFIG = YAML.load_file(CONFIG_FILE) if File.readable?(CONFIG_FILE)
 exit 0 unless CONFIG[:ENABLED]
 
 def running?(pid)
-  return Process.getpgid(pid) != -1
+  Process.getpgid(pid) != -1
 rescue Errno::ESRCH
-  return false
+  false
 end
 
 def debug(msg)
@@ -25,11 +25,10 @@ def verbose(msg)
 end
 
 def kill(pid)
-  if running?(pid) && CONFIG[:KILL_BUSY]
-    verbose "Process #{pid} is still running, sending SIGKILL"
-    Process.kill 'KILL', pid
-    sleep 5
-  end
+  return unless running?(pid) && CONFIG[:KILL_BUSY]
+  verbose "Process #{pid} is still running, sending SIGKILL"
+  Process.kill 'KILL', pid
+  sleep 5
 end
 
 def process_status?(pid)
@@ -38,6 +37,10 @@ def process_status?(pid)
   else
     verbose "Process successfully #{pid} terminated"
   end
+end
+
+def show_passenger_status(status_messages)
+  status_messages.each { |msg| verbose msg }
 end
 
 require 'phusion_passenger'
@@ -65,25 +68,22 @@ stats.passenger_processes.each do |p|
   pid = p.pid.to_i
   started = get_process_start(pid)
   get_pid_mem_kb, get_pid_mem_mb = get_rss_info(p)
-  debug_message = "Checking #{pid} with RSS of #{get_pid_mem_kb}"
-  verbose_message = "Terminating #{pid} (started #{started}) with private" \
-                    " RSS size of #{get_pid_mem_mb} MB"
-  debug debug_message
+  debug "Checking #{pid} with RSS of #{get_pid_mem_kb}"
   next unless get_pid_mem_kb > CONFIG[:MAX_PRIV_RSS_MEMORY]
   status_ps = `ps -p#{pid} -u`
   status_all = `passenger-status 2> /dev/null`
   status_backtraces = `passenger-status --show=backtraces 2>/dev/null`
-  verbose verbose_message
-  Process.kill 'SIGUSR1', pid
-  sleep CONFIG[:GRACEFUL_SHUTDOWN_SLEEP]
-  kill(pid)
-  process_status?(pid)
-  if CONFIG[:SEND_STATUS]
-    verbose status_ps
-    verbose status_all
-    verbose status_backtraces
+  verbose("Terminating #{pid} (started #{started}) with private RSS size of #{get_pid_mem_mb} MB")
+  begin
+    Process.kill 'SIGUSR1', pid
+    sleep CONFIG[:GRACEFUL_SHUTDOWN_SLEEP]
+    kill(pid)
+    process_status?(pid)
+    show_passenger_status([status_ps, status_all, status_backtraces]) if CONFIG[:SEND_STATUS]
+    killed += 1
+    exit(1) if killed >= CONFIG[:MAX_TERMINATION]
+  rescue Errno::ESRCH
+    puts "#{Process.pid}: #{pid} is NOT running"
   end
-  killed += 1
-  exit(1) if killed >= CONFIG[:MAX_TERMINATION]
 end
 exit 0

--- a/definitions/procedures/passenger_recycler.rb
+++ b/definitions/procedures/passenger_recycler.rb
@@ -3,11 +3,12 @@ class Procedures::PassengerRecycler < ForemanMaintain::Procedure
     description 'Perform Passenger memory recycling'
 
     confine do
-      execute?('which scl') && execute?('which passenger-recycler')
+      execute?('which passenger-recycler')
     end
   end
 
   def run
-    execute!('scl enable tfm -- ruby passenger-recycler')
+    passenger_recycler_path = execute('which passenger-recycler')
+    execute!(passenger_recycler_path)
   end
 end

--- a/extras/passenger-recycler.cron
+++ b/extras/passenger-recycler.cron
@@ -1,3 +1,3 @@
 # Configuration file /etc/cron.d/passenger-recycler to run passenger-recycler
 # every 15 minutes.
-*/15 * * * * root /usr/bin/scl enable tfm -- ruby /usr/bin/passenger-recycler
+*/15 * * * * root /usr/bin/passenger-recycler


### PR DESCRIPTION

As per [discussion](https://github.com/theforeman/foreman_maintain/pull/89#issue-137172688),
now `/usr/bin` contains executable file for passenger-recycler.
Using Gem.bin_path it loads `foreman_maintain/bin/passenger-recycler` so I think we don't need to run it using `scl enable tfm -- ruby passenger-recycler`.


@lzap and @iNecas, please correct me in case I am missing something.