### PR TITLE
Fixes #23563 - check and correct hammer cli_config.yml

### DIFF
--- a/definitions/checks/check_hammer_config.rb
+++ b/definitions/checks/check_hammer_config.rb
@@ -1,0 +1,30 @@
+require 'uri'
+class Checks::CheckHammerConfig < ForemanMaintain::Check
+  metadata do
+    label :check_hammer_config
+    description 'Check if hammer configuration file is using FQDN of system'
+    tags :pre_upgrade
+    confine do
+      feature(:downstream)
+    end
+  end
+
+  def run
+    with_spinner('Checking hostname of hammer configuration') do
+      assert(compare_hostname?, 'The :host parameter configured for hammer should not be'\
+        " 'localhost'")
+    end
+  end
+
+  def hammer_host_url
+    if feature(:hammer).configuration[:foreman][:host]
+      URI.parse(feature(:hammer).configuration[:foreman][:host]).host
+    end
+  end
+
+  def compare_hostname?
+    return hammer_host_url != 'localhost' unless hammer_host_url.nil?
+
+    true
+  end
+end

--- a/definitions/checks/check_hammer_config.rb
+++ b/definitions/checks/check_hammer_config.rb
@@ -3,16 +3,19 @@ class Checks::CheckHammerConfig < ForemanMaintain::Check
   metadata do
     label :check_hammer_config
     description 'Check if hammer configuration file is using FQDN of system'
-    tags :pre_upgrade
+    tags :post_upgrade
     confine do
       feature(:downstream)
     end
   end
 
   def run
+    msg = "\nMake sure :host: <system_fqdn> is included in "\
+           'your ~/.hammer/cli.modules.d/foreman.yml or'\
+           "\nin /etc/hammer/cli.modules.d/foreman.yml file."
     with_spinner('Checking hostname of hammer configuration') do
-      assert(compare_hostname?, 'The :host parameter configured for hammer should not be'\
-        " 'localhost'")
+      assert(compare_hostname?, "\nThe :host: parameter configured for hammer should not be"\
+        " 'localhost'. #{msg}", :warn => true)
     end
   end
 


### PR DESCRIPTION
This adds the check for hammer configuration, it checks for :host parameter and if its set as localhost then check fails. I have used hammer feature itself to get :host parameter value and compared that with localhost