### PR TITLE
Fixes #19942 - upstream upgrade - 1.14 -> 1.15 -> 1.16

### DIFF
--- a/definitions/features/downstream.rb
+++ b/definitions/features/downstream.rb
@@ -16,7 +16,7 @@ class Features::Downstream < ForemanMaintain::Feature
   end
 
   def current_version
-    @current_version ||= rpm_version('satellite') || version_from_source
+    @current_version ||= package_version('satellite') || version_from_source
   end
 
   def current_minor_version

--- a/definitions/features/upstream.rb
+++ b/definitions/features/upstream.rb
@@ -7,7 +7,16 @@ class Features::Upstream < ForemanMaintain::Feature
     end
   end
 
-  def setup_repositories(_version)
-    raise NotImplementedError
+  def current_version
+    @current_version ||= package_version('foreman')
+  end
+
+  def current_minor_version
+    current_version.to_s[/^\d+\.\d+/]
+  end
+
+  def setup_repositories(version)
+    distros.upgrade_version = version
+    distros.setup_repositories
   end
 end

--- a/definitions/scenarios/upgrade_foreman_1_15.rb
+++ b/definitions/scenarios/upgrade_foreman_1_15.rb
@@ -1,0 +1,76 @@
+module Scenarios::Foreman_1_15
+  class Abstract < ForemanMaintain::Scenario
+    def self.upgrade_metadata(&block)
+      metadata do
+        tags :upgrade_to_foreman_1_15
+        confine do
+          feature(:upstream) && feature(:upstream).current_minor_version == '1.14'
+        end
+        instance_eval(&block)
+      end
+    end
+  end
+
+  class PreUpgradeCheck < Abstract
+    upgrade_metadata do
+      description 'Checks before upgrading to Foreman 1.15'
+      tags :pre_upgrade_checks
+      run_strategy :fail_slow
+    end
+
+    def compose
+      add_steps(find_checks(:default))
+      add_steps(find_checks(:pre_upgrade))
+    end
+  end
+
+  class PreMigrations < Abstract
+    upgrade_metadata do
+      description 'Procedures before migrating to Foreman 1.15'
+      tags :pre_migrations
+    end
+
+    def compose
+      add_steps(find_procedures(:pre_migrations))
+    end
+  end
+
+  class Migrations < Abstract
+    upgrade_metadata do
+      description 'Migration scripts to Foreman 1.15'
+      tags :migrations
+    end
+
+    def compose
+      add_step(Procedures::Repositories::Setup.new(:version => '1.15'))
+      add_step(Procedures::Packages::Update.new(:assumeyes => false))
+      add_step(Procedures::Installer::Upgrade.new)
+    end
+  end
+
+  class PostMigrations < Abstract
+    upgrade_metadata do
+      description 'Procedures after migrating to Foreman 1.15'
+      tags :post_migrations
+    end
+
+    def compose
+      add_steps(find_procedures(:post_migrations))
+    end
+  end
+
+  class PostUpgradeChecks < Abstract
+    upgrade_metadata do
+      description 'Checks after upgrading to Foreman 1.15'
+      tags :post_upgrade_checks
+      run_strategy :fail_slow
+    end
+
+    def compose
+      add_steps(find_checks(:default))
+      add_steps(find_checks(:post_upgrade))
+    end
+  end
+end
+
+ForemanMaintain::UpgradeRunner.register_version('1.15', :upgrade_to_foreman_1_15)

--- a/definitions/scenarios/upgrade_foreman_1_16.rb
+++ b/definitions/scenarios/upgrade_foreman_1_16.rb
@@ -1,0 +1,76 @@
+module Scenarios::Foreman_1_16
+  class Abstract < ForemanMaintain::Scenario
+    def self.upgrade_metadata(&block)
+      metadata do
+        tags :upgrade_to_foreman_1_16
+        confine do
+          feature(:upstream) && feature(:upstream).current_minor_version == '1.15'
+        end
+        instance_eval(&block)
+      end
+    end
+  end
+
+  class PreUpgradeCheck < Abstract
+    upgrade_metadata do
+      description 'Checks before upgrading to Foreman 1.16'
+      tags :pre_upgrade_checks
+      run_strategy :fail_slow
+    end
+
+    def compose
+      add_steps(find_checks(:default))
+      add_steps(find_checks(:pre_upgrade))
+    end
+  end
+
+  class PreMigrations < Abstract
+    upgrade_metadata do
+      description 'Procedures before migrating to Foreman 1.16'
+      tags :pre_migrations
+    end
+
+    def compose
+      add_steps(find_procedures(:pre_migrations))
+    end
+  end
+
+  class Migrations < Abstract
+    upgrade_metadata do
+      description 'Migration scripts to Foreman 1.16'
+      tags :migrations
+    end
+
+    def compose
+      add_step(Procedures::Repositories::Setup.new(:version => '1.16'))
+      add_step(Procedures::Packages::Update.new(:assumeyes => false))
+      add_step(Procedures::Installer::Upgrade.new)
+    end
+  end
+
+  class PostMigrations < Abstract
+    upgrade_metadata do
+      description 'Procedures after migrating to Foreman 1.16'
+      tags :post_migrations
+    end
+
+    def compose
+      add_steps(find_procedures(:post_migrations))
+    end
+  end
+
+  class PostUpgradeChecks < Abstract
+    upgrade_metadata do
+      description 'Checks after upgrading to Foreman 1.16'
+      tags :post_upgrade_checks
+      run_strategy :fail_slow
+    end
+
+    def compose
+      add_steps(find_checks(:default))
+      add_steps(find_checks(:post_upgrade))
+    end
+  end
+end
+
+ForemanMaintain::UpgradeRunner.register_version('1.16', :upgrade_to_foreman_1_16)

--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -15,6 +15,7 @@ module ForemanMaintain
   require 'foreman_maintain/concerns/finders'
   require 'foreman_maintain/concerns/metadata'
   require 'foreman_maintain/concerns/scenario_metadata'
+  require 'foreman_maintain/concerns/system_executable'
   require 'foreman_maintain/concerns/system_helpers'
   require 'foreman_maintain/concerns/system_service'
   require 'foreman_maintain/concerns/hammer'
@@ -80,10 +81,6 @@ module ForemanMaintain
         file_paths = File.expand_path(File.join(definitions_dir, '**', '*.rb'))
         Dir.glob(file_paths).each { |f| require f }
       end
-    end
-
-    def cache
-      ObjectCache.instance
     end
 
     def detector

--- a/lib/foreman_maintain/concerns/system_executable.rb
+++ b/lib/foreman_maintain/concerns/system_executable.rb
@@ -1,0 +1,39 @@
+module ForemanMaintain
+  module Concerns
+    module SystemExecutable
+      include Logger
+
+      def execute?(command, options = {})
+        execute(command, options)
+        $CHILD_STATUS.success?
+      end
+
+      def execute!(command, options = {})
+        command_runner = Utils::CommandRunner.new(logger, command, options)
+        execution.puts '' if command_runner.interactive? && respond_to?(:execution)
+        command_runner.run
+        if command_runner.success?
+          command_runner.output
+        else
+          raise command_runner.execution_error
+        end
+      end
+
+      def execute(command, options = {})
+        command_runner = Utils::CommandRunner.new(logger, command, options)
+        execution.puts '' if command_runner.interactive? && respond_to?(:execution)
+        command_runner.run
+        command_runner.output
+      end
+
+      def execute_with_status(command, options = {})
+        result_msg = execute(command, options)
+        [$CHILD_STATUS.to_i, result_msg]
+      end
+
+      def file_exists?(filename)
+        File.exist?(filename)
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/utils.rb
+++ b/lib/foreman_maintain/utils.rb
@@ -1,4 +1,5 @@
 require 'foreman_maintain/utils/command_runner'
+require 'foreman_maintain/utils/distros'
 require 'foreman_maintain/utils/disk'
 require 'foreman_maintain/utils/bash'
 require 'foreman_maintain/utils/hash_tools'

--- a/lib/foreman_maintain/utils/distros.rb
+++ b/lib/foreman_maintain/utils/distros.rb
@@ -1,0 +1,31 @@
+require 'foreman_maintain/utils/distros/redhat'
+require 'foreman_maintain/utils/distros/debian'
+require 'foreman_maintain/utils/distros/fedora'
+
+module ForemanMaintain
+  module Utils
+    class Distros
+      include ForemanMaintain::Concerns::SystemExecutable
+
+      attr_accessor :upgrade_version
+
+      def arch
+        'x86_64'
+      end
+
+      def domain
+        'yum.theforeman.org'
+      end
+
+      def setup_repositories
+        execute!(%(yum upgrade #{upstream_repo} -y))
+        execute!(%(yum clean all))
+        execute!(%(yum install foreman-release-scl -y))
+      end
+
+      def upstream_repo
+        "https://#{domain}/releases/#{upgrade_version}/#{release_name}/#{arch}/foreman-release.rpm"
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/utils/distros/debian.rb
+++ b/lib/foreman_maintain/utils/distros/debian.rb
@@ -1,0 +1,57 @@
+module ForemanMaintain
+  module Utils
+    class Distros
+      class Debian < Distros
+        def code_name
+          @code_name ||= execute!('lsb_release -sc')
+        end
+
+        def setup_repositories
+          if source_list_file
+            update_source_list_file
+            upgrade_foreman_package
+          else
+            raise Error::Fail,
+                  "Manifest file not found. Please follow upgrade instructions #{upgrade_docs}"
+          end
+        end
+
+        private
+
+        def create_update_foreman_source_list
+          execute!(
+            "printf '#{foreman_deb_mirror}\n#{foreman_deb_mirror('plugins')}\n' > "\
+            '/etc/apt/sources.list.d/foreman.list'
+          )
+        end
+
+        def foreman_deb_mirror(plugins = nil)
+          "deb http://deb.theforeman.org/ #{plugins || code_name} #{upgrade_version}"
+        end
+
+        def upgrade_foreman_package
+          execute!(%(apt-get update))
+          execute!(%(apt-get --only-upgrade install ruby\* foreman\*))
+        end
+
+        def source_list_file
+          @source_list_file ||=
+            execute(%(grep -m1 -H -R "deb.theforeman.org" /etc/apt/ | cut -d: -f1))
+        end
+
+        def update_source_list_file
+          remove_foreman_master_source_list
+          create_update_foreman_source_list
+        end
+
+        def remove_foreman_master_source_list
+          execute!("sed -i.bkp '/deb.theforeman.org/d' /etc/apt/sources.list")
+        end
+
+        def upgrade_docs
+          "https://www.theforeman.org/manuals/#{upgrade_version}/index.html#3.6Upgrade"
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/utils/distros/fedora.rb
+++ b/lib/foreman_maintain/utils/distros/fedora.rb
@@ -1,0 +1,11 @@
+module ForemanMaintain
+  module Utils
+    class Distros
+      class Fedora < Distros
+        def release_name
+          'f24'
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/utils/distros/redhat.rb
+++ b/lib/foreman_maintain/utils/distros/redhat.rb
@@ -1,0 +1,11 @@
+module ForemanMaintain
+  module Utils
+    class Distros
+      class RedHat < Distros
+        def release_name
+          'el7'
+        end
+      end
+    end
+  end
+end

--- a/test/definitions/scenarios/upstream/upgrade_foreman_1_16_test.rb
+++ b/test/definitions/scenarios/upstream/upgrade_foreman_1_16_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+module Scenarios
+  describe Foreman_1_16::PreUpgradeCheck do
+    include DefinitionsTestHelper
+
+    before do
+      assume_feature_present(:upstream) do |feature|
+        feature.any_instance.stubs(:current_version => version('1.15'))
+      end
+      assume_feature_present(:foreman_tasks)
+    end
+
+    let :scenario do
+      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_foreman_1_16])
+    end
+
+    it 'is valid for 1.15 and 1.15.z version' do
+      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_foreman_1_16])
+
+      assume_feature_present(:upstream) do |feature_class|
+        feature_class.any_instance.stubs(:current_version => version('1.15'))
+      end
+      detector.refresh
+      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_foreman_1_16])
+
+      assume_feature_present(:upstream) do |feature_class|
+        feature_class.any_instance.stubs(:current_version => version('1.15.1'))
+      end
+      detector.refresh
+      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_foreman_1_16])
+    end
+
+    it 'is valid only for 15.1.z versions' do
+      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_foreman_1_16])
+
+      assume_feature_present(:upstream) do |feature_class|
+        feature_class.any_instance.stubs(:current_version => version('1.14.1'))
+      end
+      detector.refresh
+      refute_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_foreman_1_16])
+
+      assume_feature_present(:upstream) do |feature_class|
+        feature_class.any_instance.stubs(:current_version => version('1.16.1'))
+      end
+      detector.refresh
+      refute_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_foreman_1_16])
+
+      assume_feature_absent(:upstream)
+      detector.refresh
+      refute_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_foreman_1_16])
+    end
+
+    it 'composes the pre upgrade checks for migration from foreman 1.15.z to 1.16' do
+      assert(scenario.steps.find { |step| step.is_a? Checks::ForemanTasks::NotPaused })
+      assert(scenario.steps.find { |step| step.is_a? Checks::ForemanTasks::NotRunning })
+    end
+  end
+end

--- a/test/lib/utils/distros/debian_test.rb
+++ b/test/lib/utils/distros/debian_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+module ForemanMaintain
+  describe Utils::Distros::Debian do
+    let :debian do
+      Utils::Distros::Debian.new
+    end
+
+    let :expected_error_msg do
+      'Manifest file not found. Please follow upgrade instructions ' \
+      'https://www.theforeman.org/manuals/1.15/index.html#3.6Upgrade'
+    end
+
+    describe '.setup_repositories' do
+      it 'raises error if source_list_file not found' do
+        debian.stubs(:source_list_file)
+        debian.stubs(:upgrade_version).returns('1.15')
+
+        failure = assert_raises(Error::Fail) { debian.setup_repositories }
+        assert_equal(expected_error_msg, failure.message)
+      end
+
+      it 'successfully updates source_list_file and perform_upgrade' do
+        debian.stubs(:source_list_file).returns(true)
+        debian.expects(:update_source_list_file)
+        debian.expects(:upgrade_foreman_package)
+
+        debian.setup_repositories
+      end
+    end
+  end
+end

--- a/test/lib/utils/distros/redhat_test.rb
+++ b/test/lib/utils/distros/redhat_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+module ForemanMaintain
+  describe Utils::Distros::RedHat do
+    let :redhat do
+      Utils::Distros::RedHat.new
+    end
+
+    let :expected_repo_url do
+      'https://yum.theforeman.org/releases/1.15/el7/x86_64/foreman-release.rpm'
+    end
+
+    it 'returns expected upstream_repo' do
+      redhat.stubs(:upgrade_version).returns('1.15')
+      assert_equal expected_repo_url, redhat.upstream_repo
+    end
+  end
+end


### PR DESCRIPTION
I've created this PR from @swapab's original PR #103.
Resolved the conflicts & done with the rebase.

@ntkathole, we will address your review comments and [issue-21610](https://projects.theforeman.org/issues/21610) in this PR. 

> Note:
> 1. Performing upgrade from 1.14 do not ask confirmation from user to perform migration once all check passed.
> 2. yum update does not honour -y option provided while performing upgrade run -y.