### PR TITLE
Fixes #25433 - Mark data dir for later detection

### DIFF
--- a/definitions/features/mongo.rb
+++ b/definitions/features/mongo.rb
@@ -1,4 +1,6 @@
 class Features::Mongo < ForemanMaintain::Feature
+  include ForemanMaintain::Concerns::DirectoryMarker
+
   # assume mongo is installed when there is Pulp
   PULP_DB_CONFIG = '/etc/pulp/server.conf'.freeze
 
@@ -125,10 +127,6 @@ class Features::Mongo < ForemanMaintain::Feature
       }.merge(extra_tar_options)
       feature(:tar).run(tar_options)
     end
-  end
-
-  def find_base_directory(directory)
-    find_dir_containing_file(directory, 'mongod.lock')
   end
 
   private

--- a/definitions/features/pulp.rb
+++ b/definitions/features/pulp.rb
@@ -1,4 +1,6 @@
 class Features::Pulp < ForemanMaintain::Feature
+  include ForemanMaintain::Concerns::DirectoryMarker
+
   metadata do
     label :pulp
 
@@ -35,9 +37,5 @@ class Features::Pulp < ForemanMaintain::Feature
       '/var/lib/qpidd',
       '/etc/qpid-dispatch'
     ]
-  end
-
-  def find_base_directory(directory)
-    find_dir_containing_file(directory, '0005_puppet_module_name_change.txt')
   end
 end

--- a/definitions/features/tar.rb
+++ b/definitions/features/tar.rb
@@ -56,6 +56,7 @@ class Features::Tar < ForemanMaintain::Feature
       tar_command << options.fetch(:files, '*')
     end
 
+    logger.debug("Invoking tar from #{FileUtils.pwd}")
     execute!(tar_command.join(' '))
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/definitions/procedures/backup/offline/mongo.rb
+++ b/definitions/procedures/backup/offline/mongo.rb
@@ -26,7 +26,7 @@ module Procedures::Backup
       def data_dir
         return nil if @mount_dir.nil?
         mount_point = File.join(@mount_dir, 'mongodb')
-        dir = feature(:mongo).find_base_directory(mount_point)
+        dir = feature(:mongo).find_marked_directory(mount_point)
         fail!("Snapshot of Mongo DB was not found mounted in #{mount_point}") if dir.nil?
         dir
       end

--- a/definitions/procedures/backup/pulp.rb
+++ b/definitions/procedures/backup/pulp.rb
@@ -41,7 +41,12 @@ module Procedures::Backup
     def pulp_dir
       return feature(:pulp).data_dir if @mount_dir.nil?
       mount_point = File.join(@mount_dir, 'pulp')
-      feature(:pulp).find_base_directory(mount_point)
+      dir = feature(:pulp).find_marked_directory(mount_point)
+      unless dir
+        raise ForemanMaintain::Error::Fail,
+              "Pulp base directory not found in the mount point (#{mount_point})"
+      end
+      dir
     end
 
     def ensure_dir_unchanged

--- a/definitions/procedures/backup/snapshot/mount_mongo.rb
+++ b/definitions/procedures/backup/snapshot/mount_mongo.rb
@@ -17,16 +17,24 @@ module Procedures::Backup
 
       def run
         if feature(:mongo).local?
-          with_spinner('Creating snapshot of Mongo DB') do |spinner|
-            lv_info = get_lv_info(feature(:mongo).data_dir)
-            create_lv_snapshot('mongodb-snap', @block_size, lv_info[0])
-            spinner.update("Mounting snapshot of Mongo DB on #{mount_location('mongodb')}")
-            mount_snapshot('mongodb', lv_info[1])
-          end
+          mount_local
         else
           puts 'LV snapshots are not supported for remote databases. Doing dump instead...'
           with_spinner('Getting dump of Mongo DB') do
             feature(:mongo).dump(File.join(@backup_dir, 'mongo_dump'))
+          end
+        end
+      end
+
+      private
+
+      def mount_local
+        with_spinner('Creating snapshot of Mongo DB') do |spinner|
+          feature(:mongo).with_marked_directory(feature(:mongo).data_dir) do
+            lv_info = get_lv_info(feature(:mongo).data_dir)
+            create_lv_snapshot('mongodb-snap', @block_size, lv_info[0])
+            spinner.update("Mounting snapshot of Mongo DB on #{mount_location('mongodb')}")
+            mount_snapshot('mongodb', lv_info[1])
           end
         end
       end

--- a/definitions/procedures/backup/snapshot/mount_pulp.rb
+++ b/definitions/procedures/backup/snapshot/mount_pulp.rb
@@ -13,10 +13,12 @@ module Procedures::Backup
       def run
         skip if @skip
         with_spinner('Creating snapshot of Pulp') do |spinner|
-          lv_info = get_lv_info(feature(:pulp).data_dir)
-          create_lv_snapshot('pulp-snap', @block_size, lv_info[0])
-          spinner.update("Mounting snapshot of Pulp on #{mount_location('pulp')}")
-          mount_snapshot('pulp', lv_info[1])
+          feature(:pulp).with_marked_directory(feature(:pulp).data_dir) do
+            lv_info = get_lv_info(feature(:pulp).data_dir)
+            create_lv_snapshot('pulp-snap', @block_size, lv_info[0])
+            spinner.update("Mounting snapshot of Pulp on #{mount_location('pulp')}")
+            mount_snapshot('pulp', lv_info[1])
+          end
         end
       end
     end

--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -18,6 +18,7 @@ module ForemanMaintain
   require 'foreman_maintain/concerns/system_helpers'
   require 'foreman_maintain/concerns/hammer'
   require 'foreman_maintain/concerns/base_database'
+  require 'foreman_maintain/concerns/directory_marker'
   require 'foreman_maintain/top_level_modules'
   require 'foreman_maintain/yaml_storage'
   require 'foreman_maintain/config'

--- a/lib/foreman_maintain/concerns/directory_marker.rb
+++ b/lib/foreman_maintain/concerns/directory_marker.rb
@@ -1,0 +1,35 @@
+module ForemanMaintain
+  module Concerns
+    module DirectoryMarker
+      def with_marked_directory(directory)
+        mark_directory(directory)
+        yield
+        unmark_directory(directory)
+      end
+
+      def find_marked_directory(directory)
+        find_dir_containing_file(directory, mark_name)
+      end
+
+      def mark_name
+        cls = self.class.name.split('::').last.downcase
+        ".#{cls}_directory_mark"
+      end
+
+      private
+
+      def unmark_directory(directory)
+        filename = mark_file_path(directory)
+        File.delete(filename) if File.exist?(filename)
+      end
+
+      def mark_directory(directory)
+        File.open(mark_file_path(directory), 'a') {}
+      end
+
+      def mark_file_path(directory)
+        File.join(directory, mark_name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Original detection based on existing files was error prone due to the nature of the files.
The procedure was changed to create distinct mark/file before taking the snapshot and removing it after to not pollute the fs with our helper files.