### PR TITLE
Fixes #25535 - changed the config_files definition

### DIFF
--- a/definitions/features/foreman_server.rb
+++ b/definitions/features/foreman_server.rb
@@ -26,7 +26,7 @@ module ForemanMaintain
       def config_files
         [
           '/etc/httpd',
-          '/var/www/html/pub',
+          '/var/www/html/pub/katello-*',
           '/etc/squid',
           '/etc/foreman',
           '/etc/selinux/targeted/contexts/files/file_contexts.subs',


### PR DESCRIPTION
Before this patch, the entire /var/www/html/pub directory was backed up 
In somecases leading to a config_files.tar.gz of 10's og Gigs

This change ensures that only files that begin with katello- are added during
 this phase