### PR TITLE
Fixes #25770 - Fix travis and remove old ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: ruby
 sudo: false
+before_install: >-
+  if ruby -v | grep 'ruby 2.0';then
+    gem install bundler -v '~> 1.3'
+  fi
 rvm:
-  - 1.8.7
   - 2.0.0
   - 2.3.3
 script:


### PR DESCRIPTION
Handling bundler gem version as per pr https://github.com/Apipie/apipie-rails/pull/658 and removed old ruby version  1.8.7