### PR TITLE
Fixes #25808 - Split filters for corrupted roles

### DIFF
--- a/definitions/checks/foreman/check_corrupted_roles.rb
+++ b/definitions/checks/foreman/check_corrupted_roles.rb
@@ -1,0 +1,56 @@
+module Checks
+  module Foreman
+    class CheckCorruptedRoles < ForemanMaintain::Check
+      metadata do
+        label :corrupted_roles
+        for_feature :foreman_database
+        description 'Check for roles that have filters with multiple resources attached'
+        tags :pre_upgrade
+      end
+
+      def run
+        items = find_filter_permissions
+        assert(items.empty?,
+               'There are user roles with inconsistent filters',
+               :next_steps => Procedures::Foreman::FixCorruptedRoles.new)
+      end
+
+      def find_filter_permissions
+        feature(:foreman_database).query(self.class.inconsistent_filter_perms)
+      end
+
+      def self.inconsistent_filter_perms
+        subquery = <<-SQL
+          SELECT filters.id AS filter_id,
+                 filters.role_id,
+                 filters.search,
+                 filters.taxonomy_search,
+                 filters.override,
+                 filterings.id AS filtering_id,
+                 permissions.id AS permission_id,
+                 permissions.name AS permission_name,
+                 permissions.resource_type
+          FROM filters INNER JOIN filterings ON filters.id = filterings.filter_id
+                       INNER JOIN permissions ON permissions.id = filterings.permission_id
+        SQL
+
+        <<-SQL
+          SELECT DISTINCT first.filter_id,
+                          first.role_id,
+                          first.filtering_id,
+                          first.permission_id,
+                          first.permission_name,
+                          first.resource_type,
+                          first.search,
+                          first.taxonomy_search,
+                          first.override
+          FROM (#{subquery}) first JOIN (#{subquery}) second
+            ON first.filter_id = second.filter_id AND
+              ((first.resource_type IS NOT NULL AND second.resource_type IS NULL)
+                OR (first.resource_type IS NULL AND second.resource_type IS NOT NULL)
+                OR (first.resource_type != second.resource_type))
+        SQL
+      end
+    end
+  end
+end

--- a/definitions/procedures/foreman/fix_corrupted_roles.rb
+++ b/definitions/procedures/foreman/fix_corrupted_roles.rb
@@ -1,0 +1,103 @@
+module Procedures::Foreman
+  class FixCorruptedRoles < ForemanMaintain::Procedure
+    metadata do
+      for_feature :foreman_database
+      tags :pre_migration
+      desc = 'Create additional filters so that each filter has only permissions of one resource'
+      description desc
+    end
+
+    def run
+      items = feature(:foreman_database).query(
+        Checks::Foreman::CheckCorruptedRoles.inconsistent_filter_perms
+      )
+      items.group_by { |item| item['filter_id'] }.each_value do |filter_perm_data|
+        inconsistent_sets = filter_perm_data.group_by { |perm_data| perm_data['resource_type'] }.
+                            values
+        find_records_to_update(inconsistent_sets).each do |set|
+          update_records set
+        end
+      end
+    end
+
+    private
+
+    def find_records_to_update(inconsistent_sets)
+      largest_set = inconsistent_sets.reduce([]) do |memo, set|
+        set.count > memo.count ? set : memo
+      end
+
+      inconsistent_sets.reject do |set|
+        set == largest_set
+      end
+    end
+
+    def update_records(set)
+      new_filter = create_filter set.first['role_id'],
+                                 set.first['search'],
+                                 set.first['taxonomy_search'],
+                                 set.first['override']
+      set.each do |item|
+        destroy_filtering item
+        next if !new_filter || new_filter.empty?
+        create_filtering item, new_filter
+      end
+    end
+
+    def create_filter(role_id, search, taxonomy_search, override)
+      feature(:foreman_database).query(
+        create_filter_query(search, role_id, taxonomy_search, override)
+      ).first
+    end
+
+    def escape_val(value)
+      value ? "'#{value}'" : 'NULL'
+    end
+
+    def create_filter_query(search, role_id, taxonomy_search, override)
+      <<-SQL
+        WITH rows AS (
+          INSERT INTO filters (search, role_id, taxonomy_search, override, created_at, updated_at)
+          VALUES (#{escape_val(search)}, #{role_id}, #{escape_val(taxonomy_search)}, '#{override}', '#{Time.now}', '#{Time.now}')
+          RETURNING id
+          )
+        SELECT id
+        FROM rows
+      SQL
+    end
+
+    def create_filtering(data, new_filter)
+      feature(:foreman_database).query(
+        create_filtering_query(data['permission_id'], new_filter['id'])
+      )
+    end
+
+    def destroy_filtering(data)
+      feature(:foreman_database).query(destroy_filtering_query(data['filtering_id']))
+    end
+
+    def destroy_filtering_query(filtering_id)
+      <<-SQL
+        WITH rows AS (
+          DELETE FROM filterings
+          WHERE id = #{filtering_id}
+          RETURNING id
+        )
+        SELECT id
+        FROM rows
+      SQL
+    end
+
+    def create_filtering_query(permission_id, filter_id)
+      <<-SQL
+        WITH rows AS (
+          INSERT INTO filterings (filter_id, permission_id, created_at, updated_at)
+          VALUES (#{filter_id}, #{permission_id}, '#{Time.now}', '#{Time.now}')
+          RETURNING id
+        )
+        SELECT id
+        FROM rows
+      SQL
+    end
+  end
+end

--- a/test/definitions/checks/foreman/check_corrupted_roles_test.rb
+++ b/test/definitions/checks/foreman/check_corrupted_roles_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+describe Checks::Foreman::CheckCorruptedRoles do
+  include DefinitionsTestHelper
+
+  subject do
+    Checks::Foreman::CheckCorruptedRoles.new
+  end
+
+  it 'passes when no corupted roles detected' do
+    assume_feature_present(:foreman_database, :query => [])
+    result = run_check(subject)
+    assert result.success?, 'Check expected to succeed'
+  end
+
+  it 'fails when some roles with corrupted filters detected' do
+    assume_feature_present(:foreman_database, :query => [{ 'role_id' => 5 }])
+    result = run_check(subject)
+    assert result.fail?, 'Check expected to fail'
+    assert_match 'There are user roles with inconsistent filters', result.output
+    assert_equal [Procedures::Foreman::FixCorruptedRoles],
+                 subject.next_steps.map(&:class)
+  end
+end


### PR DESCRIPTION
When we change resource type for permission which is
already assigned to role, it causes filter to have
permissions with multiple resource types associated,
which does not pass validations. It is impossible to
recover from UI, because the changed permission does
not show when editing filter even though it is still
assigned to that filter.

Added check detects such roles and related procedure
splits the filters to remove validation errors.