### PR TITLE
Refs #25186 - downcase repo_name before matching regex

### DIFF
--- a/definitions/checks/check_hotfix_installed.rb
+++ b/definitions/checks/check_hotfix_installed.rb
@@ -48,7 +48,7 @@ class Checks::CheckHotfixInstalled < ForemanMaintain::Check
     IO.popen([repoquery_cmd, '-a', '--installed', '--qf', '%{ui_from_repo} %{nvra}']) do |io|
       io.each do |line|
         repo, pkg = line.chomp.split
-        packages << pkg if /satellite|rhscl/ =~ repo[1..-1]
+        packages << pkg if /satellite|rhscl/ =~ repo[1..-1].downcase
       end
     end
     packages


### PR DESCRIPTION
@mbacovsky,
Added small change in hotfix_check.

@jameerpathan111 noticed that in latest snap sat 6.5, there are repositories contain `Satellite` word in names.  Applied `downcase` on repo_name before matching with `/satellite|rhscl/` for safer side.
