### PR TITLE
Fixes #25939 - Fix mongo engines during restore

### DIFF
--- a/definitions/features/mongo.rb
+++ b/definitions/features/mongo.rb
@@ -32,6 +32,10 @@ class Features::Mongo < ForemanMaintain::Feature
   end
 
   def initialize
+    reload_db_config
+  end
+
+  def reload_db_config
     @configuration = load_db_config(config_file)
   end
 

--- a/definitions/procedures/restore/configs.rb
+++ b/definitions/procedures/restore/configs.rb
@@ -14,6 +14,7 @@ module Procedures::Restore
         spinner.update('Restoring configs')
         clean_conflicting_data
         restore_configs(backup)
+        reload_configs
       end
     end
 
@@ -28,6 +29,10 @@ module Procedures::Restore
       }
 
       feature(:tar).run(tar_options)
+    end
+
+    def reload_configs
+      feature(:mongo).reload_db_config if feature(:mongo)
     end
 
     private

--- a/definitions/procedures/restore/ensure_mongo_engine_matches.rb
+++ b/definitions/procedures/restore/ensure_mongo_engine_matches.rb
@@ -1,0 +1,28 @@
+module Procedures::Restore
+  class EnsureMongoEngineMatches < ForemanMaintain::Procedure
+    metadata do
+      description 'Ensure restored MongoDB storage engine matches the current DB'
+      for_feature :mongo
+    end
+
+    def run
+      if feature(:mongo).local? && engine_mismatch?
+        with_spinner('') do |spinner|
+          feature(:service).handle_services(spinner, 'stop', :only => feature(:mongo).services)
+          spinner.update('Clean MongoDB data')
+          data_path = Dir[feature(:mongo).data_dir + '/*']
+          FileUtils.rm_rf(data_path)
+          feature(:service).handle_services(spinner, 'start', :only => feature(:mongo).services)
+        end
+      end
+    end
+
+    private
+
+    def engine_mismatch?
+      tiger_file = File.join(feature(:mongo).data_dir, 'WiredTiger.wt')
+      config_file = feature(:mongo).core.server_config_files.first
+      File.exist?(tiger_file) && File.open(config_file).grep(/^storage.engine:\s*mmapv1/).any?
+    end
+  end
+end

--- a/definitions/procedures/restore/ensure_mongo_engine_matches.rb
+++ b/definitions/procedures/restore/ensure_mongo_engine_matches.rb
@@ -5,6 +5,7 @@ module Procedures::Restore
       for_feature :mongo
     end
 
+    # rubocop:disable Metrics/AbcSize
     def run
       if feature(:mongo).local? && mongo_data_dir_exists? && engine_mismatch?
         with_spinner('Clean MongoDB data') do |spinner|
@@ -17,6 +18,7 @@ module Procedures::Restore
         end
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     private
 

--- a/definitions/procedures/restore/ensure_mongo_engine_matches.rb
+++ b/definitions/procedures/restore/ensure_mongo_engine_matches.rb
@@ -6,8 +6,8 @@ module Procedures::Restore
     end
 
     def run
-      if feature(:mongo).local? && engine_mismatch?
-        with_spinner('') do |spinner|
+      if feature(:mongo).local? && mongo_data_dir_exists? && engine_mismatch?
+        with_spinner('Clean MongoDB data') do |spinner|
           feature(:service).handle_services(spinner, 'stop', :only => feature(:mongo).services)
           spinner.update('Clean MongoDB data')
           data_path = Dir[feature(:mongo).data_dir + '/*']
@@ -23,6 +23,10 @@ module Procedures::Restore
       tiger_file = File.join(feature(:mongo).data_dir, 'WiredTiger.wt')
       config_file = feature(:mongo).core.server_config_files.first
       File.exist?(tiger_file) && File.open(config_file).grep(/^storage.engine:\s*mmapv1/).any?
+    end
+
+    def mongo_data_dir_exists?
+      File.directory?(feature(:mongp).data_dir)
     end
   end
 end

--- a/definitions/procedures/restore/ensure_mongo_engine_matches.rb
+++ b/definitions/procedures/restore/ensure_mongo_engine_matches.rb
@@ -26,7 +26,7 @@ module Procedures::Restore
     end
 
     def mongo_data_dir_exists?
-      File.directory?(feature(:mongp).data_dir)
+      File.directory?(feature(:mongo).data_dir)
     end
   end
 end

--- a/definitions/procedures/restore/ensure_mongo_engine_matches.rb
+++ b/definitions/procedures/restore/ensure_mongo_engine_matches.rb
@@ -12,6 +12,7 @@ module Procedures::Restore
           spinner.update('Clean MongoDB data')
           data_path = Dir[feature(:mongo).data_dir + '/*']
           FileUtils.rm_rf(data_path)
+          FileUtils.rm_rf('/var/tmp/mongodb_engine_upgrade')
           feature(:service).handle_services(spinner, 'start', :only => feature(:mongo).services)
         end
       end

--- a/definitions/procedures/restore/installer_reset.rb
+++ b/definitions/procedures/restore/installer_reset.rb
@@ -2,19 +2,11 @@ module Procedures::Restore
   class InstallerReset < ForemanMaintain::Procedure
     metadata do
       description 'Run installer reset'
-
-      param :incremental_backup,
-            'Is the backup incremental?'
     end
 
     def run
-      with_spinner('Resetting') do |spinner|
-        if @incremental_backup
-          spinner.update('Skipping installer reset for incremental update')
-        else
-          spinner.update('Installer reset')
-          execute!(installer_cmd)
-        end
+      with_spinner('Installer reset') do
+        execute!(installer_cmd)
       end
     end
 

--- a/definitions/scenarios/restore.rb
+++ b/definitions/scenarios/restore.rb
@@ -19,9 +19,12 @@ module ForemanMaintain::Scenarios
                              Procedures::Restore::Confirmation,
                              Checks::Restore::ValidateHostname,
                              Procedures::Selinux::SetFileSecurity,
-                             Procedures::Restore::Configs,
-                             Procedures::Restore::InstallerReset,
-                             Procedures::Service::Stop)
+                             Procedures::Restore::Configs)
+      unless backup.incremental?
+        add_steps_with_context(Procedures::Restore::EnsureMongoEngineMatches,
+                               Procedures::Restore::InstallerReset)
+      end
+      add_step_with_context(Procedures::Service::Stop)
       add_steps_with_context(Procedures::Restore::ExtractFiles) if backup.tar_backups_exist?
       drop_dbs(backup)
       if backup.sql_dump_files_exist? && feature(:instance).postgresql_local?
@@ -84,8 +87,7 @@ module ForemanMaintain::Scenarios
                   Procedures::Restore::MongoDump => :backup_dir)
 
       context.map(:incremental_backup,
-                  Procedures::Selinux::SetFileSecurity => :incremental_backup,
-                  Procedures::Restore::InstallerReset => :incremental_backup)
+                  Procedures::Selinux::SetFileSecurity => :incremental_backup)
     end
   end
 end


### PR DESCRIPTION
When we restore backup of MongoDB using MMapv1 storage engine
on a machine where MongoDB with WiredTiger exists at some point
we end up with old config and new data which breaks the service.
This patch makes sure this situation is detected and remediated.