### PR TITLE
Fixes #26043 - Remote Mongo SSL connection improvements

### DIFF
--- a/definitions/features/mongo.rb
+++ b/definitions/features/mongo.rb
@@ -72,19 +72,24 @@ class Features::Mongo < ForemanMaintain::Feature
     ['localhost', '127.0.0.1', hostname].include?(configuration['host'])
   end
 
+  # rubocop:disable Metrics/AbcSize
   def base_command(command, config = configuration, args = '')
     if config['ssl']
       ssl = ' --ssl'
-      if config['ca_path']
+      if config['ca_path'] && !config['ca_path'].empty?
         ca_cert = " --sslCAFile #{config['ca_path']}"
-        client_cert = " --sslPEMKeyFile #{config['ssl_certfile']}" if config['ssl_certfile']
       end
+      if config['ssl_certfile'] && !config['ssl_certfile'].empty?
+        client_cert = " --sslPEMKeyFile #{config['ssl_certfile']}"
+      end
+      verify_ssl = ' --sslAllowInvalidCertificates' if config['verify_ssl'] == false
     end
     username = " -u #{config['username']}" if config['username']
     password = " -p #{config['password']}" if config['password']
     host = "--host #{config['host']} --port #{config['port']}"
-    "#{command}#{username}#{password} #{host}#{ssl}#{ca_cert}#{client_cert} #{args}"
+    "#{command}#{username}#{password} #{host}#{ssl}#{verify_ssl}#{ca_cert}#{client_cert} #{args}"
   end
+  # rubocop:enable Metrics/AbcSize
 
   def mongo_command(args, config = configuration)
     base_command(core.client_command, config, "#{args} #{config['name']}")

--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -117,12 +117,9 @@ module ForemanMaintain
     end
 
     def init_logger
-      # Note - If timestamp added to filename then number of log files i.e second
-      # argument to Logger.new will not work as expected
-      filename = File.expand_path("#{config.log_dir}/foreman-maintain.log")
       # convert size in KB to Bytes
       log_fsize = config.log_file_size.to_i * 1024
-      @logger = Logger.new(filename, 10, log_fsize).tap do |logger|
+      @logger = Logger.new(config.log_filename, 10, log_fsize).tap do |logger|
         logger.level = LOGGER_LEVEL_MAPPING[config.log_level] || Logger::DEBUG
         logger.datetime_format = '%Y-%m-%d %H:%M:%S%z '
       end

--- a/lib/foreman_maintain/config.rb
+++ b/lib/foreman_maintain/config.rb
@@ -3,7 +3,7 @@ module ForemanMaintain
   class Config
     attr_accessor :pre_setup_log_messages,
                   :config_file, :definitions_dirs, :log_level, :log_dir, :log_file_size,
-                  :storage_file, :backup_dir, :foreman_proxy_cert_path,
+                  :log_filename, :storage_file, :backup_dir, :foreman_proxy_cert_path,
                   :db_backup_dir, :completion_cache_file, :disable_commands, :manage_crond
 
     def initialize(options)
@@ -28,6 +28,9 @@ module ForemanMaintain
       @log_level = @options.fetch(:log_level, ::Logger::DEBUG)
       @log_dir = find_dir_path(@options.fetch(:log_dir, 'log'))
       @log_file_size = @options.fetch(:log_file_size, 10_000)
+      # Note - If timestamp added to filename then number of log files i.e second
+      # argument to Logger.new will not work as expected
+      @log_filename = File.expand_path("#{@log_dir}/foreman-maintain.log")
     end
 
     def load_backup_dir_paths

--- a/lib/foreman_maintain/utils/service/remote_db.rb
+++ b/lib/foreman_maintain/utils/service/remote_db.rb
@@ -62,7 +62,9 @@ module ForemanMaintain::Utils
         if @db_feature.ping
           [0, "#{self} is remote and is UP.#{msg}"]
         else
-          [1, "#{self} is remote and is DOWN.#{msg}"]
+          [1, "#{self} is remote and is DOWN.#{msg}" \
+            "\n  Unable to connect to the remote database." \
+            "\n  See the log (#{ForemanMaintain.config.log_filename}) for more details.#{msg}"]
         end
       end
     end

--- a/test/data/mongo/self_signed_certs_server.conf
+++ b/test/data/mongo/self_signed_certs_server.conf
@@ -1,0 +1,12 @@
+# =========================
+# Pulp Server Configuration
+# =========================
+
+[database]
+name: pulp_database
+seeds: mymongo:27019
+ssl: true
+ssl_certfile:
+verify_ssl: false
+ca_path: /etc/pki/tls/certs/test_ca.pem
+

--- a/test/definitions/features/mongo_test.rb
+++ b/test/definitions/features/mongo_test.rb
@@ -47,5 +47,12 @@ describe Features::Mongo do
       stub_config_file("#{data_dir}/mongo/default_server.conf")
       subject.base_command('mongo').must_equal 'mongo --host mymongo --port 27019 '
     end
+
+    it 'produce command with right parameters for SSL without verification' do
+      stub_config_file("#{data_dir}/mongo/self_signed_certs_server.conf")
+      cmd = 'mongo --host mymongo --port 27019 --ssl --sslAllowInvalidCertificates' \
+            ' --sslCAFile /etc/pki/tls/certs/test_ca.pem '
+      subject.base_command('mongo').must_equal cmd
+    end
   end
 end

--- a/test/lib/utils/service/remote_db_test.rb
+++ b/test/lib/utils/service/remote_db_test.rb
@@ -85,12 +85,20 @@ module ForemanMaintain
 
     it 'can handle remote db start' do
       remote_db_service.start.must_equal [0, 'mongod (Pulp) is remote and is UP.']
-      remote_stopped_db_service.start.must_equal [1, 'mongod (Pulp) is remote and is DOWN.']
+      result = remote_stopped_db_service.start
+      result[0].must_equal 1
+      result[1].must_match 'mongod (Pulp) is remote and is DOWN'
+      result[1].must_match 'Unable to connect to the remote database'
+      result[1].must_match(/See the log \(.*\) for more details/)
     end
 
     it 'can handle remote db stop' do
       remote_db_service.stop.must_equal [0, 'mongod (Pulp) is remote and is UP.']
-      remote_stopped_db_service.stop.must_equal [0, 'mongod (Pulp) is remote and is DOWN.']
+      result = remote_stopped_db_service.stop
+      result[0].must_equal 0
+      result[1].must_match 'mongod (Pulp) is remote and is DOWN'
+      result[1].must_match 'Unable to connect to the remote database'
+      result[1].must_match(/See the log \(.*\) for more details/)
     end
 
     describe 'matches?' do


### PR DESCRIPTION
This patch fixes improper hamdling of empty entries in Pulp's
Mongo ssl configuration. Empty ssl_certfile and ca_path are ignored.
verify_ssl = false is now supported.

'service status' is printing the remote service is DOWN when it
can not connect to the remote DB. This is not helpful when the state
is not expected so some hints to look for the cause in logs were added.