### PR TITLE
Fixes #26207 - enable ansible repo for 6.5

### DIFF
--- a/definitions/features/downstream.rb
+++ b/definitions/features/downstream.rb
@@ -64,7 +64,7 @@ class Features::Downstream < ForemanMaintain::Feature
 
     rh_repos.concat(sat_and_tools_repos(rh_version_major, sat_version))
 
-    rh_repos << 'rhel-7-server-ansible-2.6-rpms' if sat_version.to_s == '6.4'
+    rh_repos << 'rhel-7-server-ansible-2.6-rpms' if sat_version >= version('6.4')
 
     if current_minor_version == '6.3' && sat_version.to_s != '6.4' && (
       feature(:puppet_server) && feature(:puppet_server).puppet_version.major == 4)


### PR DESCRIPTION
```
[root@qe-sat6-upgrade-rhel7 foreman_maintain]# ./bin/foreman-maintain advanced procedure run repositories-setup --version 6.5
Running ForemanMaintain::Scenario
================================================================================
Setup repositories: 
- Configuring repositories for 6.5                                    [OK]      
--------------------------------------------------------------------------------

[root@qe-sat6-upgrade-rhel7 foreman_maintain]# yum repolist
Loaded plugins: langpacks, product-id, search-disabled-repos, subscription-manager
repo id                                                      repo name                                                                      status
rhel-7-server-ansible-2.6-rpms/x86_64                        Red Hat Ansible Engine 2.6 RPMs for Red Hat Enterprise Linux 7 Server              19
rhel-7-server-rpms/x86_64                                    Red Hat Enterprise Linux 7 Server (RPMs)                                       23,704
rhel-7-server-satellite-maintenance-6-beta-rpms/x86_64       Red Hat Satellite Maintenance 6 Beta (for RHEL 7 Server) (RPMs)                     0
rhel-7-server-satellite-tools-6-beta-rpms/x86_64             Red Hat Satellite Tools 6 Beta (for RHEL 7 Server) (RPMs)                           0
rhel-server-7-satellite-6-beta-rpms/x86_64                   Red Hat Satellite 6 Beta (for RHEL 7 Server) (RPMs)                                 0
rhel-server-rhscl-7-rpms/x86_64                              Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 Server        10,935
repolist: 34,658
[root@qe-sat6-upgrade-rhel7 foreman_maintain]# ./bin/foreman-maintain advanced procedure run repositories-setup --version 6.4
Running ForemanMaintain::Scenario
================================================================================
Setup repositories: 
| Configuring repositories for 6.4                                    [OK]      
--------------------------------------------------------------------------------

[root@qe-sat6-upgrade-rhel7 foreman_maintain]# yum repolist
Loaded plugins: langpacks, product-id, search-disabled-repos, subscription-manager
repo id                                                    repo name                                                                        status
rhel-7-server-ansible-2.6-rpms/x86_64                      Red Hat Ansible Engine 2.6 RPMs for Red Hat Enterprise Linux 7 Server                19
rhel-7-server-rpms/x86_64                                  Red Hat Enterprise Linux 7 Server (RPMs)                                         23,704
rhel-7-server-satellite-6.4-rpms/x86_64                    Red Hat Satellite 6.4 (for RHEL 7 Server) (RPMs)                                    433
rhel-7-server-satellite-maintenance-6-rpms/x86_64          Red Hat Satellite Maintenance 6 (for RHEL 7 Server) (RPMs)                           26
rhel-7-server-satellite-tools-6.4-rpms/x86_64              Red Hat Satellite Tools 6.4 (for RHEL 7 Server) (RPMs)                               73
rhel-server-rhscl-7-rpms/x86_64                            Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 Server          10,935
repolist: 35,190
[root@qe-sat6-upgrade-rhel7 foreman_maintain]# ./bin/foreman-maintain advanced procedure run repositories-setup --version 6.3
Running ForemanMaintain::Scenario
================================================================================
Setup repositories: 
| Configuring repositories for 6.3                                    [OK]      
--------------------------------------------------------------------------------

[root@qe-sat6-upgrade-rhel7 foreman_maintain]# yum repolist
Loaded plugins: langpacks, product-id, search-disabled-repos, subscription-manager
repo id                                                    repo name                                                                        status
rhel-7-server-rpms/x86_64                                  Red Hat Enterprise Linux 7 Server (RPMs)                                         23,704
rhel-7-server-satellite-6.3-rpms/x86_64                    Red Hat Satellite 6.3 (for RHEL 7 Server) (RPMs)                                    533
rhel-7-server-satellite-maintenance-6-rpms/x86_64          Red Hat Satellite Maintenance 6 (for RHEL 7 Server) (RPMs)                           26
rhel-7-server-satellite-tools-6.3-rpms/x86_64              Red Hat Satellite Tools 6.3 (for RHEL 7 Server) (RPMs)                               94
rhel-server-rhscl-7-rpms/x86_64                            Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 Server          10,935
repolist: 35,292
```
