### PR TITLE
Fixes #26216 - Lock package versions to protect against unwanted upgrades

### DIFF
--- a/definitions/checks/version_locking_enabled.rb
+++ b/definitions/checks/version_locking_enabled.rb
@@ -1,0 +1,14 @@
+module Checks
+  class VersionLockingEnabled < ForemanMaintain::Check
+    metadata do
+      description 'Check if tooling for package version locking is installed'
+    end
+
+    def run
+      enabled = feature(:package_manager).version_locking_enabled?
+      enable_locking = Procedures::Packages::EnableVersionLocking.new(:assumeyes => assumeyes?)
+      assert(enabled, 'Tools for package version locking are not available on this system',
+             :next_steps => enable_locking)
+    end
+  end
+end

--- a/definitions/features/package_manager.rb
+++ b/definitions/features/package_manager.rb
@@ -1,0 +1,34 @@
+class Features::PackageManager < ForemanMaintain::Feature
+  metadata do
+    label :package_manager
+  end
+
+  extend Forwardable
+  def_delegators :manager, :lock_versions, :unlock_versions,
+                 :installed?, :find_installed_package, :install, :update,
+                 :version_locking_enabled?, :configure_version_locking,
+                 :foreman_related_packages, :version_locking_packages,
+                 :versions_locked?, :clean_cache
+
+  def self.type
+    @type ||= %w[dnf yum apt].find { |manager| command_present?(manager) }
+  end
+
+  def type
+    self.class.type
+  end
+
+  def manager
+    @manager ||= case type
+                 when 'dnf'
+                   ForemanMaintain::PackageManager::Dnf.new
+                 when 'yum'
+                   ForemanMaintain::PackageManager::Yum.new
+                 else
+                   raise 'No supported package manager was found'
+                 end
+  end
+
+  # TODO: DEB  grep ^Package: /var/lib/apt/lists/deb.theforeman.org_dists_*
+  # TODO DEB apt-mark hold/unhold <package>
+end

--- a/definitions/procedures/packages/enable_version_locking.rb
+++ b/definitions/procedures/packages/enable_version_locking.rb
@@ -1,0 +1,17 @@
+module Procedures::Packages
+  class EnableVersionLocking < ForemanMaintain::Procedure
+    metadata do
+      description 'Install and configure tools for version locking'
+      param :assumeyes, 'Do not ask for confirmation'
+    end
+
+    def run
+      packages = feature(:package_manager).version_locking_packages
+      feature(:package_manager).install(packages, :assumeyes => @assumeyes)
+      unless feature(:package_manager).installed?(packages)
+        raise "Unable to install some of the required dependences:  #{packages.join(' ')}"
+      end
+      feature(:package_manager).configure_version_locking
+    end
+  end
+end

--- a/definitions/procedures/packages/lock_versions.rb
+++ b/definitions/procedures/packages/lock_versions.rb
@@ -1,0 +1,17 @@
+module Procedures::Packages
+  class LockVersions < ForemanMaintain::Procedure
+    metadata do
+      for_feature :package_manager
+      description 'Lock versions of Foreman-related packages'
+      preparation_steps { [Checks::VersionLockingEnabled.new] }
+    end
+
+    def run
+      with_spinner('Collecting list of packages to lock') do |spinner|
+        package_list = feature(:package_manager).foreman_related_packages
+        spinner.update('Locking packages')
+        feature(:package_manager).lock_versions(package_list)
+      end
+    end
+  end
+end

--- a/definitions/procedures/packages/locking_status.rb
+++ b/definitions/procedures/packages/locking_status.rb
@@ -1,0 +1,17 @@
+module Procedures::Packages
+  class LockingStatus < ForemanMaintain::Procedure
+    metadata do
+      for_feature :package_manager
+      description 'Check status of version locking of Foreman-related packages'
+      preparation_steps { [Checks::VersionLockingEnabled.new] }
+    end
+
+    def run
+      if feature(:package_manager).versions_locked?
+        puts 'Packages are locked.'
+      else
+        puts 'Packages are not locked.'
+      end
+    end
+  end
+end

--- a/definitions/procedures/packages/unlock_versions.rb
+++ b/definitions/procedures/packages/unlock_versions.rb
@@ -1,0 +1,13 @@
+module Procedures::Packages
+  class UnlockVersions < ForemanMaintain::Procedure
+    metadata do
+      for_feature :package_manager
+      description 'Unlock versions of Foreman-related packages'
+      preparation_steps { [Checks::VersionLockingEnabled.new] }
+    end
+
+    def run
+      feature(:package_manager).unlock_versions
+    end
+  end
+end

--- a/definitions/procedures/packages/update.rb
+++ b/definitions/procedures/packages/update.rb
@@ -7,7 +7,7 @@ module Procedures::Packages
 
     def run
       assumeyes_val = @assumeyes.nil? ? assumeyes? : @assumeyes
-      clean_all_packages
+      feature(:package_manager).clean_cache
       packages_action(:update, @packages, :assumeyes => assumeyes_val)
     end
 

--- a/definitions/scenarios/upgrade_to_satellite_6_2.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_2.rb
@@ -45,6 +45,7 @@ module Scenarios::Satellite_6_2
 
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.2'))
+      add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step(Procedures::Installer::Upgrade.new)
     end

--- a/definitions/scenarios/upgrade_to_satellite_6_2_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_2_z.rb
@@ -45,6 +45,7 @@ module Scenarios::Satellite_6_2_z
 
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.2'))
+      add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step(Procedures::Installer::Upgrade.new)
     end

--- a/definitions/scenarios/upgrade_to_satellite_6_3.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_3.rb
@@ -46,6 +46,7 @@ module Scenarios::Satellite_6_3
 
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.3'))
+      add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step(Procedures::Installer::Upgrade.new)
     end

--- a/definitions/scenarios/upgrade_to_satellite_6_3_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_3_z.rb
@@ -45,6 +45,7 @@ module Scenarios::Satellite_6_3_z
 
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.3'))
+      add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step(Procedures::Installer::Upgrade.new)
     end

--- a/definitions/scenarios/upgrade_to_satellite_6_4.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_4.rb
@@ -46,6 +46,7 @@ module Scenarios::Satellite_6_4
 
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.4'))
+      add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step(Procedures::Installer::Upgrade.new)
     end

--- a/definitions/scenarios/upgrade_to_satellite_6_4_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_4_z.rb
@@ -45,6 +45,7 @@ module Scenarios::Satellite_6_4_z
 
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.4'))
+      add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step(Procedures::Installer::Upgrade.new)
     end

--- a/definitions/scenarios/upgrade_to_satellite_6_5.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_5.rb
@@ -45,6 +45,7 @@ module Scenarios::Satellite_6_5
 
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.5'))
+      add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step(Procedures::Installer::Upgrade.new)
     end

--- a/definitions/scenarios/upgrade_to_satellite_6_5_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_5_z.rb
@@ -45,6 +45,7 @@ module Scenarios::Satellite_6_5_z
 
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.5'))
+      add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step(Procedures::Installer::Upgrade.new)
     end

--- a/definitions/scenarios/upgrade_to_satellite_6_6.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_6.rb
@@ -45,6 +45,7 @@ module Scenarios::Satellite_6_6
 
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.6'))
+      add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step(Procedures::Installer::Upgrade.new)
     end

--- a/definitions/scenarios/version_locking.rb
+++ b/definitions/scenarios/version_locking.rb
@@ -1,0 +1,39 @@
+module ForemanMaintain::Scenarios
+  module VersionLocking
+    class Status < ForemanMaintain::Scenario
+      metadata do
+        label :version_locking_status
+        description 'detection of status of package version locking'
+        manual_detection
+      end
+
+      def compose
+        add_step(Procedures::Packages::LockingStatus)
+      end
+    end
+
+    class Unlock < ForemanMaintain::Scenario
+      metadata do
+        label :version_locking_unlock
+        description 'unlocking of package versions'
+        manual_detection
+      end
+
+      def compose
+        add_step(Procedures::Packages::UnlockVersions)
+      end
+    end
+
+    class Lock < ForemanMaintain::Scenario
+      metadata do
+        label :version_locking_lock
+        description 'locking of package versions'
+        manual_detection
+      end
+
+      def compose
+        add_step(Procedures::Packages::LockVersions)
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -37,6 +37,7 @@ module ForemanMaintain
   require 'foreman_maintain/reporter'
   require 'foreman_maintain/utils'
   require 'foreman_maintain/error'
+  require 'foreman_maintain/package_manager'
 
   class << self
     attr_accessor :config, :logger

--- a/lib/foreman_maintain/cli.rb
+++ b/lib/foreman_maintain/cli.rb
@@ -9,6 +9,7 @@ require 'foreman_maintain/cli/advanced_command'
 require 'foreman_maintain/cli/service_command'
 require 'foreman_maintain/cli/restore_command'
 require 'foreman_maintain/cli/maintenance_mode_command'
+require 'foreman_maintain/cli/packages_command'
 
 module ForemanMaintain
   module Cli
@@ -20,6 +21,7 @@ module ForemanMaintain
       subcommand 'service', 'Control applicable services', ServiceCommand
       subcommand 'backup', 'Backup server', BackupCommand
       subcommand 'restore', 'Restore a backup', RestoreCommand
+      subcommand 'packages', 'Lock/Unlock installed packages', PackagesCommand
       subcommand 'advanced', 'Advanced tools for server maintenance', AdvancedCommand
       subcommand 'maintenance-mode', 'Control maintenance-mode for application',
                  MaintenanceModeCommand

--- a/lib/foreman_maintain/cli/base.rb
+++ b/lib/foreman_maintain/cli/base.rb
@@ -64,6 +64,11 @@ module ForemanMaintain
         runner.run
       end
 
+      def run_scenarios_and_exit(scenarios, rescue_scenario: nil)
+        run_scenario(scenarios, rescue_scenario)
+        exit runner.exit_code
+      end
+
       def available_checks
         filter = {}
         filter[:tags] = tags if respond_to?(:tags)

--- a/lib/foreman_maintain/cli/packages_command.rb
+++ b/lib/foreman_maintain/cli/packages_command.rb
@@ -1,0 +1,36 @@
+module ForemanMaintain
+  module Cli
+    class PackagesCommand < Base
+      subcommand 'lock', 'Prevent Foreman-related packages from automatic update' do
+        interactive_option
+        def execute
+          run_scenarios_and_exit(Scenarios::VersionLocking::Lock.new)
+        end
+      end
+
+      subcommand 'unlock', 'Enable Foreman-related packages for automatic update' do
+        interactive_option
+        def execute
+          run_scenarios_and_exit(Scenarios::VersionLocking::Unlock.new)
+        end
+      end
+
+      subcommand 'status', 'Check if Foreman-related packages are protected against update' do
+        interactive_option
+        def execute
+          run_scenarios_and_exit(Scenarios::VersionLocking::Status.new)
+        end
+      end
+
+      subcommand 'is-locked', 'Check if update of Foreman-related packages is allowed' do
+        interactive_option
+        def execute
+          locked = feature(:package_manager).versions_locked?
+          puts "Foreman related packages are#{locked ? '' : ' not'} locked"
+          exit_code = locked ? 0 : 1
+          exit exit_code
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/package_manager.rb
+++ b/lib/foreman_maintain/package_manager.rb
@@ -1,0 +1,3 @@
+require 'foreman_maintain/package_manager/base'
+require 'foreman_maintain/package_manager/yum'
+require 'foreman_maintain/package_manager/dnf'

--- a/lib/foreman_maintain/package_manager/base.rb
+++ b/lib/foreman_maintain/package_manager/base.rb
@@ -1,0 +1,71 @@
+module ForemanMaintain::PackageManager
+  # rubocop:disable Lint/UnusedMethodArgument
+  class Base
+    def foreman_related_packages
+      raise NotImplementedError
+    end
+
+    # list of packages providing the version locking
+    def version_locking_packages
+      raise NotImplementedError
+    end
+
+    # check tools are installed and enabled
+    def version_locking_enabled?
+      raise NotImplementedError
+    end
+
+    # make sure the version locking tools are configured
+    # we can assume it is already installed
+    def configure_version_locking
+      raise NotImplementedError
+    end
+
+    # are the packages installed on the system?
+    def installed?(packages)
+      raise NotImplementedError
+    end
+
+    # find installed package and return full nvra or nil
+    def find_installed_package(name)
+      raise NotImplementedError
+    end
+
+    # install package
+    def install(packages, assumeyes: false)
+      raise NotImplementedError
+    end
+
+    # update package
+    def update(packages = [], assumeyes: false)
+      raise NotImplementedError
+    end
+
+    # prevent listed packages from update
+    def lock_versions(package_list)
+      raise NotImplementedError
+    end
+
+    # allow all packages we previously locked to update
+    def unlock_versions
+      raise NotImplementedError
+    end
+
+    # check if packages are locked
+    def versions_locked?
+      raise NotImplementedError
+    end
+
+    # clean the package manager cache
+    def clean_cache
+      raise NotImplementedError
+    end
+
+    private
+
+    def sys
+      ForemanMaintain::Utils::SystemHelpers
+    end
+  end
+  # rubocop:enable Lint/UnusedMethodArgument
+end

--- a/lib/foreman_maintain/package_manager/dnf.rb
+++ b/lib/foreman_maintain/package_manager/dnf.rb
@@ -1,0 +1,17 @@
+module ForemanMaintain::PackageManager
+  class Dnf < Yum
+    def clean_cache
+      dnf_action('clean', 'all')
+      super
+    end
+
+    private
+
+    def dnf_action(action, packages, assumeyes: false)
+      yum_options = []
+      yum_options << '-y' if assumeyes
+      sys.execute!("dnf #{yum_options.join(' ')} #{action} #{packages.join(' ')}",
+                   :interactive => true)
+    end
+  end
+end

--- a/lib/foreman_maintain/package_manager/yum.rb
+++ b/lib/foreman_maintain/package_manager/yum.rb
@@ -1,0 +1,126 @@
+module ForemanMaintain::PackageManager
+  class Yum < Base
+    VERSIONLOCK_START_CLAUSE = '## foreman-maintain - start'.freeze
+    VERSIONLOCK_END_CLAUSE = '## foreman-maintain - end'.freeze
+    VERSIONLOCK_CONFIG_FILE = '/etc/yum/pluginconf.d/versionlock.conf'.freeze
+    VERSIONLOCK_DEFAULT_LIST_FILE = '/etc/yum/pluginconf.d/versionlock.list'.freeze
+
+    def self.parse_envra(envra)
+      # envra format: 0:foreman-1.20.1.10-1.el7sat.noarch
+      parsed = envra.match(/\d*:?(?<name>.*)-[^-]+-[^-]+\.[^.]+/)
+      parsed ? Hash[parsed.names.zip(parsed.captures)].merge(:envra => envra) : nil
+    end
+
+    def foreman_related_packages
+      query = "repoquery -a --qf='%{envra} %{repo.id}' --search foreman-installer |head -n1"
+      foreman_repo = sys.execute(query).split[1]
+      query_installed = "repoquery -a --qf='%{envra}' --repoid='#{foreman_repo}'"
+      sys.execute(query_installed). split("\n").map do |pkg|
+        self.class.parse_envra(pkg)
+      end
+    end
+
+    def version_locking_packages
+      %w[yum-utils yum-plugin-versionlock]
+    end
+
+    def lock_versions(package_list)
+      unlock_versions
+      File.open(versionlock_file, 'a') do |f|
+        f.puts VERSIONLOCK_START_CLAUSE
+        f.puts '# The following packages are locked by foreman-maintain. Do not modify!'
+        package_list.each { |package| f.puts "#{package[:envra]}.*" }
+        f.puts '# End of list of packages locked by foreman-maintain'
+        f.puts VERSIONLOCK_END_CLAUSE
+      end
+    end
+
+    def unlock_versions
+      lock_file = versionlock_file
+      content = File.read(lock_file)
+      content = content.gsub(/#{VERSIONLOCK_START_CLAUSE}.*#{VERSIONLOCK_END_CLAUSE}\n/m, '')
+      File.open(lock_file, 'w') { |f| f.write content }
+    end
+
+    def versions_locked?
+      lock_file = versionlock_file
+      return false if lock_file.nil?
+      content = File.read(lock_file)
+      !!content.match(/#{VERSIONLOCK_START_CLAUSE}.*#{VERSIONLOCK_END_CLAUSE}\n/m)
+    end
+
+    def version_locking_enabled?
+      installed?(version_locking_packages) && versionlock_config =~ /^\s*enabled\s+=\s+1/ \
+        && File.exist?(versionlock_file)
+    end
+
+    # make sure the version locking tools are configured
+    #  enabled = 1
+    #  locklist = <list file>
+    # we can assume it is already installed
+    def configure_version_locking
+      config = versionlock_config
+      config += "\n" unless config[-1] == "\n"
+      enabled_re = /^\s*enabled\s*=.*$/
+      if enabled_re.match(config)
+        config = config.gsub(enabled_re, 'enabled = 1')
+      else
+        config += "enabled = 1\n"
+      end
+      unless config =~ /^\s*locklist\s*=.*$/
+        config += "locklist = #{VERSIONLOCK_DEFAULT_LIST_FILE}\n"
+      end
+      File.open(versionlock_config_file, 'w') { |file| file.puts config }
+      FileUtils.touch(versionlock_file)
+    end
+
+    def installed?(packages)
+      packages_list = [packages].flatten(1).map { |pkg| "'#{pkg}'" }.join(' ')
+      sys.execute?(%(rpm -q #{packages_list}))
+    end
+
+    def find_installed_package(name)
+      status, result = sys.execute_with_status(%(rpm -q '#{name}'))
+      if status == 0
+        result
+      end
+    end
+
+    def install(packages, assumeyes: false)
+      yum_action('install', packages, :assumeyes => assumeyes)
+    end
+
+    def update(packages = [], assumeyes: false)
+      yum_action('update', packages, :assumeyes => assumeyes)
+    end
+
+    def clean_cache
+      yum_action('clean', 'all')
+    end
+
+    private
+
+    def versionlock_config
+      File.exist?(versionlock_config_file) ? File.read(versionlock_config_file) : ''
+    end
+
+    def versionlock_config_file
+      VERSIONLOCK_CONFIG_FILE
+    end
+
+    def versionlock_file
+      result = versionlock_config.match(/^\s*locklist\s*=\s*(\S+)/)
+      result.nil? ? nil : File.expand_path(result.captures[0])
+    end
+
+    def yum_action(action, packages, assumeyes: false)
+      yum_options = []
+      packages = [packages].flatten(1)
+      yum_options << '-y' if assumeyes
+      yum_options_s = yum_options.empty? ? '' : ' ' + yum_options.join(' ')
+      packages_s = packages.empty? ? '' : ' ' + packages.join(' ')
+      sys.execute!("yum#{yum_options_s} #{action}#{packages_s}",
+                   :interactive => true)
+    end
+  end
+end

--- a/test/data/package_manager/yum/versionlock.conf.erb
+++ b/test/data/package_manager/yum/versionlock.conf.erb
@@ -1,0 +1,7 @@
+[main]
+#  Show a hint when any locked packages have updates available
+show_hint = 1
+#  Uncomment this to lock out "upgrade via. obsoletes" etc. (slower)
+# follow_obsoletes = 1
+enabled = 1
+locklist = <%= lock_list_path %>

--- a/test/data/package_manager/yum/versionlock_locked.list
+++ b/test/data/package_manager/yum/versionlock_locked.list
@@ -1,0 +1,10 @@
+# Some custom content
+0:some-package-0.11.6-17.el7.noarch.*
+## foreman-maintain - start
+# The following packages are locked by foreman-maintain. Do not modify!
+0:ansiblerole-insights-client-1.6-1.el7sat.noarch.*
+0:candlepin-2.5.14-1.el7sat.noarch.*
+0:candlepin-selinux-2.5.14-1.el7sat.noarch.*
+0:tfm-runtime-5.0-3.el7sat.x86_64.*
+# End of list of packages locked by foreman-maintain
+## foreman-maintain - end

--- a/test/data/package_manager/yum/versionlock_locked_alt.list
+++ b/test/data/package_manager/yum/versionlock_locked_alt.list
@@ -1,0 +1,9 @@
+# Some custom content
+0:some-package-0.11.6-17.el7.noarch.*
+## foreman-maintain - start
+# The following packages are locked by foreman-maintain. Do not modify!
+0:tfm-rubygem-hammer_cli-0.15.1.2-1.el7sat.noarch.*
+0:tfm-rubygem-hammer_cli_csv-2.3.1-3.el7sat.noarch.*
+0:tfm-rubygem-hammer_cli_foreman-0.15.1.1-1.el7sat.noarch.*
+# End of list of packages locked by foreman-maintain
+## foreman-maintain - end

--- a/test/data/package_manager/yum/versionlock_unlocked.list
+++ b/test/data/package_manager/yum/versionlock_unlocked.list
@@ -1,0 +1,2 @@
+# Some custom content
+0:some-package-0.11.6-17.el7.noarch.*

--- a/test/definitions/features/package_manager_test.rb
+++ b/test/definitions/features/package_manager_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+describe Features::PackageManager do
+  include DefinitionsTestHelper
+  subject { Class.new(Features::PackageManager).new }
+
+  before do
+    subject.class.stubs(:command_present?).returns(false)
+  end
+
+  describe 'type' do
+    it 'detects installed package manager' do
+      subject.class.stubs(:command_present?).with('yum').returns(true)
+      subject.type.must_equal 'yum'
+    end
+
+    it 'detects dnf package manager when dnf and yum are present' do
+      subject.class.stubs(:command_present?).with('yum').returns(true)
+      subject.class.stubs(:command_present?).with('dnf').returns(true)
+      subject.type.must_equal 'dnf'
+    end  end
+
+  describe 'manager' do
+    before do
+      Features::PackageManager.any_instance.unstub(:manager)
+    end
+
+    it 'instantiates correct yum manager implementation' do
+      subject.class.stubs(:command_present?).with('yum').returns(true)
+      subject.manager.must_be_instance_of ForemanMaintain::PackageManager::Yum
+    end
+
+    it 'instantiates correct dnf manager implementation' do
+      subject.class.stubs(:command_present?).with('yum').returns(true)
+      subject.class.stubs(:command_present?).with('dnf').returns(true)
+      subject.manager.must_be_instance_of ForemanMaintain::PackageManager::Dnf
+    end
+
+    it 'fail on unknown manager type' do
+      err = proc { subject.manager }.must_raise Exception
+      err.message.must_equal 'No supported package manager was found'
+    end
+  end
+end

--- a/test/definitions/procedures/hammer_setup_test.rb
+++ b/test/definitions/procedures/hammer_setup_test.rb
@@ -53,7 +53,7 @@ describe Procedures::HammerSetup do
       assert result.success?, 'the procedure was expected to succeed'
     end
 
-    it 'skipps setup_admin_access if httpd is down' do
+    it 'skips setup_admin_access if httpd is down' do
       assume_feature_present(:foreman_server)
       assume_service_stopped('httpd')
       hammer_ins.stubs(:_check_connection).returns(false)

--- a/test/definitions/test_helper.rb
+++ b/test/definitions/test_helper.rb
@@ -66,6 +66,7 @@ module DefinitionsTestHelper
 
   def setup
     reset_reporter
+    mock_package_manager
   end
 
   def teardown
@@ -159,6 +160,31 @@ module DefinitionsTestHelper
       service.stubs(:exist?).returns(false)
       yield service if block_given?
     end
+  end
+
+  class FakePackageManager < ForemanMaintain::PackageManager::Base
+    def initialize
+      @packages = []
+    end
+
+    def mock_packages(packages)
+      @packages = [packages].flatten(1)
+    end
+
+    def find_installed_package(name)
+      @packages.find { |package| package =~ /^#{name}/ }
+    end
+  end
+
+  def mock_package_manager(manager = FakePackageManager.new)
+    Features::PackageManager.any_instance.stubs(:manager).returns(manager)
+  end
+
+  def assume_package_exist(packages)
+    packages = [packages].flatten(1)
+    manager = FakePackageManager.new
+    manager.mock_packages(packages)
+    mock_package_manager(manager)
   end
 end
 

--- a/test/lib/cli/packages_command_test.rb
+++ b/test/lib/cli/packages_command_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+require 'foreman_maintain/cli'
+
+module ForemanMaintain
+  include CliAssertions
+  describe Cli::PackagesCommand do
+    include CliAssertions
+    let :command do
+      %w[packages]
+    end
+
+    it 'prints help' do
+      assert_cmd <<-OUTPUT.strip_heredoc
+        Usage:
+            foreman-maintain packages [OPTIONS] SUBCOMMAND [ARG] ...
+
+        Parameters:
+            SUBCOMMAND                    subcommand
+            [ARG] ...                     subcommand arguments
+
+        Subcommands:
+            lock                          Prevent Foreman-related packages from automatic update
+            unlock                        Enable Foreman-related packages for automatic update
+            status                        Check if Foreman-related packages are protected against update
+            is-locked                     Check if update of Foreman-related packages is allowed
+
+        Options:
+            -h, --help                    print help
+      OUTPUT
+    end
+  end
+end

--- a/test/lib/cli_test.rb
+++ b/test/lib/cli_test.rb
@@ -25,6 +25,7 @@ module ForemanMaintain
             service                       Control applicable services
             backup                        Backup server
             restore                       Restore a backup
+            packages                      Lock/Unlock installed packages
             advanced                      Advanced tools for server maintenance
             maintenance-mode              Control maintenance-mode for application
 

--- a/test/lib/package_manager/yum_test.rb
+++ b/test/lib/package_manager/yum_test.rb
@@ -1,0 +1,199 @@
+require 'test_helper'
+require 'tempfile'
+require 'foreman_maintain/package_manager'
+
+module ForemanMaintain
+  describe PackageManager::Yum do
+    def expect_sys_execute(command, via: :execute,
+                           execute_options: { :interactive => true }, response: 'OK')
+      ForemanMaintain::Utils::SystemHelpers.expects(via).
+        with(command, execute_options).returns(response)
+    end
+
+    def with_lock_config(lock_list_path)
+      template = ERB.new(File.read(File.join(config_dir, 'versionlock.conf.erb')))
+      Tempfile.open('test_versionlock.conf') do |tmp|
+        tmp.write(template.result(binding))
+        tmp.close
+        yield(tmp)
+      end
+    end
+
+    subject { PackageManager::Yum.new }
+    let(:config_dir) { File.expand_path('test/data/package_manager/yum') }
+    let(:unlocked_list_path) { File.join(config_dir, 'versionlock_unlocked.list') }
+    let(:locked_list_path) { File.join(config_dir, 'versionlock_locked.list') }
+    let(:locked_alt_list_path) { File.join(config_dir, 'versionlock_locked_alt.list') }
+    let(:packages_to_lock) do
+      [
+        '0:ansiblerole-insights-client-1.6-1.el7sat.noarch',
+        '0:candlepin-2.5.14-1.el7sat.noarch',
+        '0:candlepin-selinux-2.5.14-1.el7sat.noarch',
+        '0:tfm-runtime-5.0-3.el7sat.x86_64'
+      ].map { |p| PackageManager::Yum.parse_envra(p) }
+    end
+
+    describe 'lock_versions' do
+      it 'locks unlocked versions' do
+        original_list = File.read(unlocked_list_path)
+        Tempfile.open('lock.list') do |lock_list|
+          # prepare empty lock list
+          lock_list.write(original_list)
+          lock_list.rewind
+          # prepare lock config
+          with_lock_config(lock_list.path) do |lock_conf|
+            # stub yum to use our lock config
+            subject.stubs(:versionlock_config_file).returns(lock_conf.path)
+            subject.lock_versions(packages_to_lock)
+            lock_list.rewind
+            lock_list.read.must_equal File.read(locked_list_path)
+          end
+        end
+      end
+
+      it 'locks locked versions with new packages' do
+        original_list = File.read(locked_alt_list_path)
+        Tempfile.open('lock.list') do |lock_list|
+          lock_list.write(original_list)
+          lock_list.rewind
+          with_lock_config(lock_list.path) do |lock_conf|
+            subject.stubs(:versionlock_config_file).returns(lock_conf.path)
+            subject.lock_versions(packages_to_lock)
+            lock_list.rewind
+            lock_list.read.must_equal File.read(locked_list_path)
+          end
+        end
+      end
+    end
+
+    describe 'unlock_versions' do
+      it 'unlocks locked versions' do
+        original_list = File.read(locked_list_path)
+        Tempfile.open('lock.list') do |lock_list|
+          lock_list.write(original_list)
+          lock_list.rewind
+          with_lock_config(lock_list.path) do |lock_conf|
+            subject.stubs(:versionlock_config_file).returns(lock_conf.path)
+            subject.unlock_versions
+            lock_list.rewind
+            lock_list.read.must_equal File.read(unlocked_list_path)
+          end
+        end
+      end
+
+      it 'does nothing on unlocked versions' do
+        original_list = File.read(unlocked_list_path)
+        Tempfile.open('lock.list') do |lock_list|
+          lock_list.write(original_list)
+          lock_list.rewind
+          with_lock_config(lock_list.path) do |lock_conf|
+            subject.stubs(:versionlock_config_file).returns(lock_conf.path)
+            subject.unlock_versions
+            lock_list.rewind
+            lock_list.read.must_equal original_list
+          end
+        end
+      end
+    end
+
+    describe 'versions_locked?' do
+      it 'checks if packages were locked by lock_versions' do
+        with_lock_config(File.join(config_dir, 'versionlock_locked.list')) do |lock_conf|
+          subject.stubs(:versionlock_config_file).returns(lock_conf.path)
+          subject.versions_locked?.must_equal true
+        end
+      end
+
+      it 'checks if packages were not locked by lock_versions' do
+        with_lock_config(File.join(config_dir, 'versionlock_unlocked.list')) do |lock_conf|
+          subject.stubs(:versionlock_config_file).returns(lock_conf.path)
+          subject.versions_locked?.must_equal false
+        end
+      end
+    end
+
+    describe 'install' do
+      it 'invokes yum to install single package' do
+        expect_sys_execute('yum install package', :via => :execute!)
+        subject.install('package')
+      end
+
+      it 'invokes yum to install list of packages' do
+        expect_sys_execute('yum install package1 package2', :via => :execute!)
+        subject.install(%w[package1 package2])
+      end
+
+      it 'invokes yum to install package with yes enforced' do
+        expect_sys_execute('yum -y install package', :via => :execute!)
+        subject.install('package', :assumeyes => true)
+      end
+    end
+
+    describe 'update' do
+      it 'invokes yum to update single package' do
+        expect_sys_execute('yum update package', :via => :execute!)
+        subject.update('package')
+      end
+
+      it 'invokes yum to update list of packages' do
+        expect_sys_execute('yum update package1 package2', :via => :execute!)
+        subject.update(%w[package1 package2])
+      end
+
+      it 'invokes yum to update package with yes enforced' do
+        expect_sys_execute('yum -y update package', :via => :execute!)
+        subject.update('package', :assumeyes => true)
+      end
+
+      it 'invokes yum to update all packages' do
+        expect_sys_execute('yum update', :via => :execute!)
+        subject.update
+      end
+    end
+
+    describe 'clean_cache' do
+      it 'invokes yum to clean cache' do
+        expect_sys_execute('yum clean all', :via => :execute!)
+        subject.clean_cache
+      end
+    end
+
+    describe 'installed?' do
+      it 'returns true if all packages listed are installed' do
+        expect_sys_execute("rpm -q 'package1' 'package2'",
+                           :via => :execute?, :execute_options => nil, :response => true)
+        subject.installed?(%w[package1 package2]).must_equal true
+      end
+
+      it 'returns false if any of the packages is not installed' do
+        expect_sys_execute("rpm -q 'missing' 'package'",
+                           :via => :execute?, :execute_options => nil, :response => false)
+        subject.installed?(%w[missing package]).must_equal false
+      end
+
+      it 'handles single package too' do
+        expect_sys_execute("rpm -q 'package'", :via => :execute?, :execute_options => nil,
+                                               :response => true)
+        subject.installed?('package').must_equal true
+      end
+    end
+
+    describe 'find_installed_package' do
+      it 'invokes rpm to lookup the package and returns the pacakge' do
+        expect_sys_execute("rpm -q 'package'",
+                           :via => :execute_with_status,
+                           :execute_options => nil,
+                           :response => [0, 'package-3.4.3-161.el7.noarch'])
+        subject.find_installed_package('package').must_equal 'package-3.4.3-161.el7.noarch'
+      end
+
+      it 'invokes rpm to lookup the package and returns nil if not found' do
+        expect_sys_execute("rpm -q 'package'",
+                           :via => :execute_with_status,
+                           :execute_options => nil,
+                           :response => [1, 'package package is not insalled'])
+        assert_nil subject.find_installed_package('package')
+      end
+    end
+  end
+end

--- a/test/lib/support/definitions/features/package_manager.rb
+++ b/test/lib/support/definitions/features/package_manager.rb
@@ -1,0 +1,8 @@
+class Features::PackageManager < ForemanMaintain::Feature
+  metadata do
+    label :package_manager
+    confine do
+      true
+    end
+  end
+end

--- a/test/lib/system_helpers_test.rb
+++ b/test/lib/system_helpers_test.rb
@@ -10,6 +10,8 @@ module ForemanMaintain
 
     describe '.find_package' do
       it 'returns nil if package does not exist' do
+        Features::PackageManager.any_instance.stubs(:find_installed_package).
+          with('unknown').returns(nil)
         assert_nil system.find_package('unknown')
       end
     end


### PR DESCRIPTION
Adds ability to lock versions of packages of Foreman/Katello/Satellite
and its dependences to prevent it from partial upgrade during
common system update.

The locking consists of three parts:
 - make sure the tooling is installed and configured properly
 - collect list of packages to lock
 - do the actual locking

New commands were added to foreman_maintain:

 $ foreman-maintian installation lock
 $ foreman-maintian installation unlock

New feature :package_manager is introduced. It serves as a proxy
for package manipulation commands and dispatches the calls to
the PackageManager implementation that match what is installed.
In the initial version only yum is supported. Apt is in progress though
and will be added soon. The system helpers were redirected to
the package manager which should allow seamless support for
debian once the apt manager is added.

The version locking itself is implemented in the package manager
and should match what system supports The same pays for checks
and instalation of the related tooling.