### PR TITLE
Fixes #26017 - treat tar packing response code 1 as success

### DIFF
--- a/definitions/procedures/backup/config_files.rb
+++ b/definitions/procedures/backup/config_files.rb
@@ -11,6 +11,8 @@ module Procedures::Backup
       param :backup_dir, 'Directory where to backup to', :required => true
       param :proxy_features, 'List of proxy features to backup (default: all)',
             :array => true, :default => ['all']
+      param :ignore_changed_files, 'Should packing tar ignore changed files',
+            :flag => true, :default => false
     end
 
     def run
@@ -18,9 +20,10 @@ module Procedures::Backup
       increments = File.join(@backup_dir, '.config.snar')
       with_spinner('Collecting config files to backup') do
         configs = config_files.join(' ')
+        statuses = @ignore_changed_files ? [0, 1] : [0]
         execute!("tar --selinux --create --gzip --file=#{tarball} " \
           "--listed-incremental=#{increments} --ignore-failed-read " \
-          "#{configs}")
+          "#{configs}", :valid_exit_statuses => statuses)
       end
     end
 

--- a/definitions/scenarios/backup.rb
+++ b/definitions/scenarios/backup.rb
@@ -183,7 +183,7 @@ module ForemanMaintain::Scenarios
     # rubocop:enable  Metrics/MethodLength
 
     def add_online_backup_steps
-      add_step_with_context(Procedures::Backup::ConfigFiles)
+      add_step_with_context(Procedures::Backup::ConfigFiles, :ignore_changed_files => true)
       add_step_with_context(Procedures::Backup::Pulp, :ensure_unchanged => true)
       add_steps_with_context(
         Procedures::Backup::Online::Mongo,


### PR DESCRIPTION
During online backup, tar packages files changing on the fly.
It returns 1 if detecting so, while this is not a fatal error
for the backup. Therefore we should treat response code 1 as
success.

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>