### PR TITLE
Fixes #26598 - add support for ansible 2.8 repo

### DIFF
--- a/definitions/features/downstream.rb
+++ b/definitions/features/downstream.rb
@@ -64,7 +64,9 @@ class Features::Downstream < ForemanMaintain::Feature
 
     rh_repos.concat(sat_and_tools_repos(rh_version_major, sat_version))
 
-    enable_ansible_repo(sat_version, rh_repos, rh_version_major)
+    if sat_version > version('6.3')
+      rh_repos << enable_ansible_repo(sat_version, rh_version_major)
+    end
 
     if current_minor_version == '6.3' && sat_version.to_s != '6.4' && (
       feature(:puppet_server) && feature(:puppet_server).puppet_version.major == 4)
@@ -74,11 +76,11 @@ class Features::Downstream < ForemanMaintain::Feature
     rh_repos
   end
 
-  def enable_ansible_repo(sat_version, rh_repos, rh_version_major)
+  def enable_ansible_repo(sat_version, rh_version_major)
     if sat_version >= version('6.6')
-      rh_repos << "rhel-#{rh_version_major}-server-ansible-2.8-rpms"
+      "rhel-#{rh_version_major}-server-ansible-2.8-rpms"
     elsif sat_version >= version('6.4')
-      rh_repos << "rhel-#{rh_version_major}-server-ansible-2.6-rpms"
+      "rhel-#{rh_version_major}-server-ansible-2.6-rpms"
     end
   end
 

--- a/definitions/features/downstream.rb
+++ b/definitions/features/downstream.rb
@@ -64,7 +64,7 @@ class Features::Downstream < ForemanMaintain::Feature
 
     rh_repos.concat(sat_and_tools_repos(rh_version_major, sat_version))
 
-    rh_repos << 'rhel-7-server-ansible-2.6-rpms' if sat_version >= version('6.4')
+    enable_ansible_repo(sat_version, rh_repos, rh_version_major)
 
     if current_minor_version == '6.3' && sat_version.to_s != '6.4' && (
       feature(:puppet_server) && feature(:puppet_server).puppet_version.major == 4)
@@ -72,6 +72,14 @@ class Features::Downstream < ForemanMaintain::Feature
     end
 
     rh_repos
+  end
+
+  def enable_ansible_repo(sat_version, rh_repos, rh_version_major)
+    if [version('6.4'), version('6.5')].include?(sat_version)
+      rh_repos << "rhel-#{rh_version_major}-server-ansible-2.6-rpms"
+    elsif sat_version == version('6.6')
+      rh_repos << "rhel-#{rh_version_major}-server-ansible-2.8-rpms"
+    end
   end
 
   def sat_and_tools_repos(rh_version_major, sat_version)

--- a/definitions/features/downstream.rb
+++ b/definitions/features/downstream.rb
@@ -75,10 +75,10 @@ class Features::Downstream < ForemanMaintain::Feature
   end
 
   def enable_ansible_repo(sat_version, rh_repos, rh_version_major)
-    if [version('6.4'), version('6.5')].include?(sat_version)
-      rh_repos << "rhel-#{rh_version_major}-server-ansible-2.6-rpms"
-    elsif sat_version == version('6.6')
+    if sat_version >= version('6.6')
       rh_repos << "rhel-#{rh_version_major}-server-ansible-2.8-rpms"
+    elsif sat_version >= version('6.4')
+      rh_repos << "rhel-#{rh_version_major}-server-ansible-2.6-rpms"
     end
   end
 

--- a/definitions/features/downstream.rb
+++ b/definitions/features/downstream.rb
@@ -65,7 +65,7 @@ class Features::Downstream < ForemanMaintain::Feature
     rh_repos.concat(sat_and_tools_repos(rh_version_major, sat_version))
 
     if sat_version > version('6.3')
-      rh_repos << enable_ansible_repo(sat_version, rh_version_major)
+      rh_repos << ansible_repo(sat_version, rh_version_major)
     end
 
     if current_minor_version == '6.3' && sat_version.to_s != '6.4' && (
@@ -76,7 +76,7 @@ class Features::Downstream < ForemanMaintain::Feature
     rh_repos
   end
 
-  def enable_ansible_repo(sat_version, rh_version_major)
+  def ansible_repo(sat_version, rh_version_major)
     if sat_version >= version('6.6')
       "rhel-#{rh_version_major}-server-ansible-2.8-rpms"
     elsif sat_version >= version('6.4')


### PR DESCRIPTION
This adds support of ansible 2.8 repository for Satellite 6.6 . With this enables ansible 2.6 for Satellite 6.4 and 6.5 versions only.