### PR TITLE
Fixes #26502 - queries based on sync_plan changes in katello

### DIFF
--- a/definitions/procedures/sync_plans/disable.rb
+++ b/definitions/procedures/sync_plans/disable.rb
@@ -21,7 +21,7 @@ module Procedures::SyncPlans
       default_storage = ForemanMaintain.storage(:default)
       feature(:sync_plans).load_from_storage(default_storage)
       with_spinner('disabling sync plans') do |spinner|
-        ids = feature(:sync_plans).ids_by_status(true)
+        ids = feature(:sync_plans).sync_plan_ids_by_status(true)
         feature(:sync_plans).make_disable(ids)
         spinner.update "Total #{ids.length} sync plans are now disabled."
       end


### PR DESCRIPTION
In Katello, behavior of enabled field [changed](https://github.com/Katello/katello/commit/71f4d4a8871dc0448db674604f074a16b539804f).
It is not using `enabled` column from sync_plans table. 

I thought to use "hammer sync-plan list" command but `--organization-id` required there and which doesn't accept multiple values. so modified `sync_plans` feature to use SQL queries based on changes in Katello.