### PR TITLE
Fixes #26725 - Add upgrade scenario for 6.6

### DIFF
--- a/definitions/scenarios/upgrade_to_satellite_6_6.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_6.rb
@@ -1,0 +1,79 @@
+module Scenarios::Satellite_6_6
+  class Abstract < ForemanMaintain::Scenario
+    def self.upgrade_metadata(&block)
+      metadata do
+        tags :upgrade_to_satellite_6_6
+        confine do
+          feature(:downstream) && feature(:downstream).current_minor_version == '6.5'
+        end
+        instance_eval(&block)
+      end
+    end
+  end
+
+  class PreUpgradeCheck < Abstract
+    upgrade_metadata do
+      description 'Checks before upgrading to Satellite 6.6'
+      tags :pre_upgrade_checks
+      run_strategy :fail_slow
+    end
+
+    def compose
+      add_steps(find_checks(:default))
+      add_steps(find_checks(:pre_upgrade))
+      add_step(Checks::Repositories::Validate.new(:version => '6.6'))
+    end
+  end
+
+  class PreMigrations < Abstract
+    upgrade_metadata do
+      description 'Procedures before migrating to Satellite 6.6'
+      tags :pre_migrations
+    end
+
+    def compose
+      add_steps(find_procedures(:pre_migrations))
+      add_step(Procedures::Service::Stop.new)
+    end
+  end
+
+  class Migrations < Abstract
+    upgrade_metadata do
+      description 'Migration scripts to Satellite 6.6'
+      tags :migrations
+    end
+
+    def compose
+      add_step(Procedures::Repositories::Setup.new(:version => '6.6'))
+      add_step(Procedures::Packages::Update.new(:assumeyes => true))
+      add_step(Procedures::Installer::Upgrade.new)
+    end
+  end
+
+  class PostMigrations < Abstract
+    upgrade_metadata do
+      description 'Procedures after migrating to Satellite 6.6'
+      tags :post_migrations
+    end
+
+    def compose
+      add_step(Procedures::Service::Start.new)
+      add_steps(find_procedures(:post_migrations))
+    end
+  end
+
+  class PostUpgradeChecks < Abstract
+    upgrade_metadata do
+      description 'Checks after upgrading to Satellite 6.6'
+      tags :post_upgrade_checks
+      run_strategy :fail_slow
+    end
+
+    def compose
+      add_steps(find_checks(:default))
+      add_steps(find_checks(:post_upgrade))
+    end
+  end
+end
+
+ForemanMaintain::UpgradeRunner.register_version('6.6', :upgrade_to_satellite_6_6)


### PR DESCRIPTION
Base upgrade scenario for 6.6. Steps to [remove foreman_docker](https://github.com/theforeman/foreman_maintain/pull/259) will need to be added. 