### PR TITLE
Fixes #26502 - queries based on sync_plan changes in katello (#257)

### DIFF
--- a/definitions/features/sync_plans.rb
+++ b/definitions/features/sync_plans.rb
@@ -3,21 +3,34 @@ class Features::SyncPlans < ForemanMaintain::Feature
     label :sync_plans
   end
 
-  def active_sync_plans_count
-    feature(:foreman_database).query(
-      <<-SQL
-        SELECT count(*) AS count FROM katello_sync_plans WHERE enabled ='t'
-      SQL
-    ).first['count'].to_i
+  def required_new_implementation
+    @required_new_implementation ||=
+      feature(:foreman_database).query(
+        <<-SQL
+          SELECT COUNT(1) FROM information_schema.table_constraints
+          WHERE constraint_name='katello_sync_plan_foreman_tasks_recurring_logic_fk' AND table_name='katello_sync_plans'
+        SQL
+      ).first['count'].to_i > 0
   end
 
-  def ids_by_status(enabled = true)
-    enabled = enabled ? 't' : 'f'
-    feature(:foreman_database).query(
-      <<-SQL
-        SELECT id FROM katello_sync_plans WHERE enabled ='#{enabled}'
+  def sync_plan_ids_by_status(enabled = true, filter_ids = nil)
+    if filter_ids
+      return [] if filter_ids.empty?
+
+      ids_condition = filter_ids.map { |id| "'#{id}'" }.join(',')
+    end
+
+    if required_new_implementation
+      query = <<-SQL
+        select sp.id as id from katello_sync_plans sp inner join foreman_tasks_recurring_logics rl on sp.foreman_tasks_recurring_logic_id = rl.id
+        where rl.state='#{enabled ? 'active' : 'disabled'}' #{ids_condition ? " AND sp.id IN (#{ids_condition})" : ''}
       SQL
-    ).map { |r| r['id'].to_i }
+    else
+      query = <<-SQL
+        SELECT id FROM katello_sync_plans WHERE enabled ='#{enabled ? 't' : 'f'}' #{ids_condition ? " AND id IN (#{ids_condition})" : ''}
+      SQL
+    end
+    feature(:foreman_database).query(query).map { |r| r['id'].to_i }
   end
 
   def make_disable(ids)
@@ -39,8 +52,11 @@ class Features::SyncPlans < ForemanMaintain::Feature
   private
 
   def update_records(ids, enabled)
+    ids_not_required_update = sync_plan_ids_by_status(enabled, ids)
+    ids_required_update = ids - ids_not_required_update
+    make_data_key_empty(enabled) if !ids_not_required_update.empty? && ids_required_update.empty?
     updated_record_ids = []
-    ids.each do |sp_id|
+    ids_required_update.each do |sp_id|
       result = feature(:hammer).run("sync-plan update --id #{sp_id} --enabled #{enabled}")
       if result.include?('Sync plan updated')
         updated_record_ids << sp_id
@@ -55,7 +71,13 @@ class Features::SyncPlans < ForemanMaintain::Feature
 
   def data
     raise 'Use load_from_storage before accessing the data' unless defined? @data
+
     @data
+  end
+
+  def make_data_key_empty(enabled)
+    key_name = enabled ? 'disabled' : 'enabled'
+    @data[:"#{key_name}"] = []
   end
 
   def update_data(enabled, new_ids)
@@ -63,7 +85,9 @@ class Features::SyncPlans < ForemanMaintain::Feature
       @data[:disabled] -= new_ids
       @data[:enabled] = new_ids
     else
-      @data[:disabled].concat(new_ids)
+      @data[:disabled] = [] unless @data[:disabled]
+      @data[:enabled] = [] if @data[:disabled].empty?
+      @data[:disabled].concat(new_ids).uniq!
     end
   end
 end

--- a/definitions/procedures/sync_plans/disable.rb
+++ b/definitions/procedures/sync_plans/disable.rb
@@ -21,7 +21,7 @@ module Procedures::SyncPlans
       default_storage = ForemanMaintain.storage(:default)
       feature(:sync_plans).load_from_storage(default_storage)
       with_spinner('disabling sync plans') do |spinner|
-        ids = feature(:sync_plans).ids_by_status(true)
+        ids = feature(:sync_plans).sync_plan_ids_by_status(true)
         feature(:sync_plans).make_disable(ids)
         spinner.update "Total #{ids.length} sync plans are now disabled."
       end


### PR DESCRIPTION
* Fixes #26502 - queries based on sync_plan changes in katello
Conflicts:
	definitions/features/sync_plans.rb

@mbacovsky, @iNecas,

I have faced few conflicts for `:sync-plan` feature while doing cherry-pick as I have made sync-plans changes while working on maintenance-mode command change. maintenance-mode command changes are not present in this branch.

