### PR TITLE
Fixes #27051 add --include-db-dumps for snapshot backups

### DIFF
--- a/definitions/scenarios/backup.rb
+++ b/definitions/scenarios/backup.rb
@@ -156,6 +156,7 @@ module ForemanMaintain::Scenarios
 
     # rubocop:disable  Metrics/MethodLength
     def add_snapshot_backup_steps
+      include_dumps if include_db_dumps?
       add_steps_with_context(
         Procedures::Backup::Snapshot::PrepareMount,
         find_procedures(:maintenance_mode_on),

--- a/lib/foreman_maintain/cli/backup_command.rb
+++ b/lib/foreman_maintain/cli/backup_command.rb
@@ -130,6 +130,7 @@ module ForemanMaintain
       include BackupCommon
       interactive_option
       common_backup_options
+      option '--include-db-dumps', :flag, 'Also dump full database schema before snapshot backup'
       option ['-d', '--snapshot-mount-dir'], 'SNAPSHOT_MOUNT_DIR',
              "Override default directory ('/var/snap/') where the snapshots will be mounted",
              :default => '/var/snap/' do |dir|
@@ -144,7 +145,8 @@ module ForemanMaintain
       def execute
         perform_backup(:snapshot,
                        :snapshot_mount_dir => snapshot_mount_dir,
-                       :snapshot_block_size => snapshot_block_size)
+                       :snapshot_block_size => snapshot_block_size,
+                       :include_db_dumps => include_db_dumps?)
       end
     end
 


### PR DESCRIPTION
This adds the ability to build logical backups of the databases for the snapshot backup style.