### PR TITLE
Fixes #27070 - Proxy feature detection in backup

### DIFF
--- a/definitions/features/foreman_proxy.rb
+++ b/definitions/features/foreman_proxy.rb
@@ -33,7 +33,14 @@ class Features::ForemanProxy < ForemanMaintain::Feature
 
   def features
     # TODO: handle failures
-    run_curl_cmd("#{curl_cmd}/features").result
+    @features ||= run_curl_cmd("#{curl_cmd}/features").result
+    @features = [] if @features.is_a?(String)
+    @features
+  end
+
+  def refresh_features
+    @features = nil
+    features
   end
 
   def internal?

--- a/definitions/procedures/foreman_proxy/features.rb
+++ b/definitions/procedures/foreman_proxy/features.rb
@@ -1,0 +1,14 @@
+module Procedures::ForemanProxy
+  class Features < ForemanMaintain::Procedure
+    metadata do
+      param :load_only, 'Do not print the features', :default => false
+      description 'Detect features available in the local proxy'
+      for_feature :foreman_proxy
+    end
+
+    def run
+      features = feature(:foreman_proxy).refresh_features
+      puts features.join(', ') unless @load_only
+    end
+  end
+end

--- a/definitions/scenarios/backup.rb
+++ b/definitions/scenarios/backup.rb
@@ -126,6 +126,7 @@ module ForemanMaintain::Scenarios
 
     def add_offline_backup_steps
       include_dumps if include_db_dumps?
+      add_step_with_context(Procedures::ForemanProxy::Features, :load_only => true)
       add_steps_with_context(
         find_procedures(:maintenance_mode_on),
         Procedures::Service::Stop,
@@ -157,6 +158,7 @@ module ForemanMaintain::Scenarios
     # rubocop:disable  Metrics/MethodLength
     def add_snapshot_backup_steps
       include_dumps if include_db_dumps?
+      add_step_with_context(Procedures::ForemanProxy::Features, :load_only => true)
       add_steps_with_context(
         Procedures::Backup::Snapshot::PrepareMount,
         find_procedures(:maintenance_mode_on),


### PR DESCRIPTION
This patch fixes backups failing due to error
on Foreman proxy feature detection. The features were detected
in a phase when proxy service is down and the call failed.
The features in proxy are now cached and the cache is populated
when the proxy is up.
    
As a bonus we have new procedure printing the features:
```
$ foreman-maintain advanced produre run foreman-proxy-features
```