### PR TITLE
Fixes #27082 - Clean non-original assets

### DIFF
--- a/definitions/checks/original_assets.rb
+++ b/definitions/checks/original_assets.rb
@@ -1,0 +1,22 @@
+class Checks::OriginalAssets < ForemanMaintain::Check
+  metadata do
+    description 'Check if only installed assets are present on the system'
+    tags :post_upgrade
+  end
+
+  ASSETS_DIR = '/var/lib/foreman/public/assets'.freeze
+
+  def run
+    custom_assets = []
+    product_name = feature(:instance).product_name
+    with_spinner('Checking for presence of non-original assets...') do
+      custom_assets = feature(:package_manager).files_not_owned_by_package(ASSETS_DIR)
+      logger.info("Non-original assets detected:\n" + custom_assets.join("\n"))
+    end
+    remove_files = Procedures::Files::Remove.new(:files => custom_assets, :assumeyes => true)
+    assert(custom_assets.empty?,
+           "Some assets not owned by #{product_name} were detected on the system.\n" \
+             'Possible conflicting versions can affect operation of the Web UI.',
+           :next_steps => remove_files)
+  end
+end

--- a/definitions/features/foreman_proxy.rb
+++ b/definitions/features/foreman_proxy.rb
@@ -73,6 +73,10 @@ class Features::ForemanProxy < ForemanMaintain::Feature
     configs
   end
 
+  def config_files_to_exclude(_for_features = ['all'])
+    []
+  end
+
   def content_module
     return @content_module if @content_module_detected
     @content_module_detected = true

--- a/definitions/features/foreman_server.rb
+++ b/definitions/features/foreman_server.rb
@@ -35,6 +35,12 @@ module ForemanMaintain
           '/var/lib/foreman'
         ]
       end
+
+      def config_files_to_exclude
+        [
+          '/var/lib/foreman/public/assets'
+        ]
+      end
     end
   end
 end

--- a/definitions/features/package_manager.rb
+++ b/definitions/features/package_manager.rb
@@ -8,7 +8,7 @@ class Features::PackageManager < ForemanMaintain::Feature
                  :installed?, :find_installed_package, :install, :update,
                  :version_locking_enabled?, :configure_version_locking,
                  :foreman_related_packages, :version_locking_packages,
-                 :versions_locked?, :clean_cache, :remove
+                 :versions_locked?, :clean_cache, :remove, :files_not_owned_by_package
 
   def self.type
     @type ||= %w[dnf yum apt].find { |manager| command_present?(manager) }

--- a/definitions/features/tar.rb
+++ b/definitions/features/tar.rb
@@ -61,7 +61,7 @@ class Features::Tar < ForemanMaintain::Feature
       tar_command << options.fetch(:files, '*')
     end
 
-    logger.debug("Invoking tar from #{FileUtils.pwd}")
+    logger.debug("Invoking tar from #{options[:directory] || FileUtils.pwd}")
     statuses = options[:allow_changing_files] ? [0, 1] : [0]
     execute!(tar_command.join(' '), :valid_exit_statuses => statuses)
   end

--- a/definitions/procedures/files/remove.rb
+++ b/definitions/procedures/files/remove.rb
@@ -1,0 +1,13 @@
+module Procedures::Files
+  class Remove < ForemanMaintain::Procedure
+    metadata do
+      description 'Remove the files'
+      param :files, 'Files to remove', :array => true
+      param :assumeyes, 'Do not ask for confirmation', :default => false
+    end
+
+    def run
+      FileUtils.rm_r(@files, :force => @assumeyes, :secure => true)
+    end
+  end
+end

--- a/definitions/procedures/restore/configs.rb
+++ b/definitions/procedures/restore/configs.rb
@@ -19,13 +19,17 @@ module Procedures::Restore
     end
 
     def restore_configs(backup)
+      exclude = ForemanMaintain.available_features.each_with_object([]) do |feat, cfgs|
+        feat.config_files_to_exclude.each { |f| cfgs << f }
+      end
       tar_options = {
         :overwrite => true,
         :listed_incremental => '/dev/null',
         :command => 'extract',
         :directory => '/',
         :archive => backup.file_map[:config_files][:path],
-        :gzip => true
+        :gzip => true,
+        :exclude => exclude
       }
 
       feature(:tar).run(tar_options)

--- a/definitions/procedures/restore/configs.rb
+++ b/definitions/procedures/restore/configs.rb
@@ -20,7 +20,7 @@ module Procedures::Restore
 
     def restore_configs(backup)
       exclude = ForemanMaintain.available_features.each_with_object([]) do |feat, cfgs|
-        feat.config_files_to_exclude.each { |f| cfgs << f }
+        feat.config_files_to_exclude.each { |f| cfgs << f.gsub(%r{^/}, '') }
       end
       tar_options = {
         :overwrite => true,

--- a/lib/foreman_maintain/feature.rb
+++ b/lib/foreman_maintain/feature.rb
@@ -35,5 +35,11 @@ module ForemanMaintain
     def config_files
       []
     end
+
+    # list of config files to be excluded from the list of config files.
+    # Can be used to exclude subdir from whole config directory
+    def config_files_to_exclude
+      []
+    end
   end
 end

--- a/lib/foreman_maintain/package_manager/base.rb
+++ b/lib/foreman_maintain/package_manager/base.rb
@@ -66,6 +66,11 @@ module ForemanMaintain::PackageManager
       raise NotImplementedError
     end
 
+    # list all files not owned by installed package
+    def files_not_owned_by_package(directory)
+      raise NotImplementedError
+    end
+
     private
 
     def sys

--- a/lib/foreman_maintain/package_manager/yum.rb
+++ b/lib/foreman_maintain/package_manager/yum.rb
@@ -102,6 +102,11 @@ module ForemanMaintain::PackageManager
       yum_action('clean', 'all')
     end
 
+    def files_not_owned_by_package(directory)
+      find_cmd = "find #{directory} -exec /bin/sh -c 'rpm -qf {} &> /dev/null || echo {}' \\;"
+      sys.execute(find_cmd).split("\n")
+    end
+
     private
 
     def versionlock_config


### PR DESCRIPTION
Adds config_files_to_exclude into the feature so that
some specific files can be excluded when adding e.g. config
directory. Using this tool to exclude assets from backups.
Also restore ignore the asset files even when present in the backup.

There was new check added to locate the assets not installed
from a package. It offers to remove the assets as a remediation
procedure. The check is automatically run after upgrade
or can be run manually with:
```
 $ foreman-maintain health check --label original-assets
```