### PR TITLE
Fixes #27173 - fixes procedure hammer-setup 

### DIFF
--- a/definitions/features/hammer.rb
+++ b/definitions/features/hammer.rb
@@ -85,7 +85,7 @@ class Features::Hammer < ForemanMaintain::Feature
     if !ready? && custom_config[:foreman][:password].nil?
       msg = 'Invalid admin password was found in hammer configs. Looking into installer answers'
       logger.info(msg)
-      custom_config[:foreman][:password] = password_from_answers
+      custom_config[:foreman][:password] = feature(:installer).password_from_answers
       save_config_and_check(custom_config)
     end
     custom_config
@@ -107,7 +107,7 @@ class Features::Hammer < ForemanMaintain::Feature
     if admin_password_missing?
       msg = 'Admin password was not found in hammer configs. Looking into installer answers'
       logger.info(msg)
-      custom_config[:foreman][:password] = password_from_answers
+      custom_config[:foreman][:password] = feature(:installer).password_from_answers
     end
     save_config_and_check(custom_config)
     custom_config
@@ -145,15 +145,6 @@ class Features::Hammer < ForemanMaintain::Feature
         ForemanMaintain::Utils::HashTools.deep_merge!(@configuration, config)
         @config_files << file_path
       end
-    end
-  end
-
-  def password_from_answers
-    return nil unless feature(:installer)
-    if feature(:downstream).current_minor_version >= '6.6'
-      feature(:installer).answers['foreman']['initial_admin_password']
-    else
-      feature(:installer).answers['foreman']['admin_password']
     end
   end
 

--- a/definitions/features/hammer.rb
+++ b/definitions/features/hammer.rb
@@ -71,7 +71,7 @@ class Features::Hammer < ForemanMaintain::Feature
   end
 
   def admin_username
-    return nil unless feature(:installer)
+    return 'admin' unless feature(:installer)
     if check_min_version('foreman', '1.22')
       feature(:installer).answers['foreman']['initial_admin_username']
     else

--- a/definitions/features/hammer.rb
+++ b/definitions/features/hammer.rb
@@ -28,7 +28,7 @@ class Features::Hammer < ForemanMaintain::Feature
   def setup_admin_access
     return true if check_connection
     logger.info('Hammer setup is not valid. Fixing configuration.')
-    custom_config = { :foreman => { :username => 'admin' } }
+    custom_config = { :foreman => { :username => admin_username } }
     custom_config = on_invalid_host(custom_config)
     custom_config = on_missing_password(custom_config) # get password from answers
     custom_config = on_invalid_password(custom_config) # get password from answers
@@ -70,6 +70,15 @@ class Features::Hammer < ForemanMaintain::Feature
     execute("#{command_base} #{args}")
   end
 
+  def admin_username
+    return nil unless feature(:installer)
+    if check_min_version('foreman', '1.22')
+      feature(:installer).answers['foreman']['initial_admin_username']
+    else
+      feature(:installer).answers['foreman']['admin_username']
+    end
+  end
+
   private
 
   def on_invalid_host(custom_config)
@@ -99,7 +108,8 @@ class Features::Hammer < ForemanMaintain::Feature
 
   def config_error
     raise ForemanMaintain::HammerConfigurationError, 'Hammer configuration failed: '\
-                  "Is the admin password correct? (it was stored in #{custom_config_file})" \
+                  'Is the admin username and password correct? ' \
+                  "(it was stored in #{custom_config_file})" \
                   'Is the server down?'
   end
 

--- a/definitions/features/hammer.rb
+++ b/definitions/features/hammer.rb
@@ -117,7 +117,8 @@ class Features::Hammer < ForemanMaintain::Feature
 
   def admin_password_missing?
     configuration[:foreman][:password].nil? ||
-      configuration[:foreman][:password].empty?
+      configuration[:foreman][:password].empty? ||
+      configuration[:foreman][:username] != username
   end
 
   def exec_hammer_cmd(cmd, required_json = false)

--- a/definitions/features/hammer.rb
+++ b/definitions/features/hammer.rb
@@ -85,7 +85,7 @@ class Features::Hammer < ForemanMaintain::Feature
     if !ready? && custom_config[:foreman][:password].nil?
       msg = 'Invalid admin password was found in hammer configs. Looking into installer answers'
       logger.info(msg)
-      custom_config[:foreman][:password] = feature(:installer).password_from_answers
+      custom_config[:foreman][:password] = password_from_answers
       save_config_and_check(custom_config)
     end
     custom_config
@@ -107,7 +107,7 @@ class Features::Hammer < ForemanMaintain::Feature
     if admin_password_missing?
       msg = 'Admin password was not found in hammer configs. Looking into installer answers'
       logger.info(msg)
-      custom_config[:foreman][:password] = feature(:installer).password_from_answers
+      custom_config[:foreman][:password] = password_from_answers
     end
     save_config_and_check(custom_config)
     custom_config
@@ -145,6 +145,15 @@ class Features::Hammer < ForemanMaintain::Feature
         ForemanMaintain::Utils::HashTools.deep_merge!(@configuration, config)
         @config_files << file_path
       end
+    end
+  end
+
+  def password_from_answers
+    return nil unless feature(:installer)
+    if check_min_version('foreman', '1.22')
+      feature(:installer).answers['foreman']['initial_admin_password']
+    else
+      feature(:installer).answers['foreman']['admin_password']
     end
   end
 

--- a/definitions/features/hammer.rb
+++ b/definitions/features/hammer.rb
@@ -82,12 +82,11 @@ class Features::Hammer < ForemanMaintain::Feature
   end
 
   def on_invalid_password(custom_config)
-    if !ready? && custom_config[:foreman][:password] != password_from_answers(
-        custom_config[:foreman][:username]
-      )
+    admin_password = password_from_answers(custom_config[:foreman][:username])
+    if !ready? && custom_config[:foreman][:password] != admin_password
       msg = 'Invalid admin password was found in hammer configs. Looking into installer answers'
       logger.info(msg)
-      custom_config[:foreman][:password] = password_from_answers(custom_config[:foreman][:username])
+      custom_config[:foreman][:password] = admin_password
       save_config_and_check(custom_config)
     end
     custom_config
@@ -101,8 +100,8 @@ class Features::Hammer < ForemanMaintain::Feature
 
   def config_error
     raise ForemanMaintain::HammerConfigurationError, 'Hammer configuration failed: '\
-                  'Is the admin username and password correct? ' \
-                  "\n(it was stored in #{custom_config_file})\n" \
+                  'Is the admin credential from the file' \
+                  " #{custom_config_file} correct?\n" \
                   'Is the server down?'
   end
 

--- a/definitions/features/hammer.rb
+++ b/definitions/features/hammer.rb
@@ -150,7 +150,11 @@ class Features::Hammer < ForemanMaintain::Feature
 
   def password_from_answers
     return nil unless feature(:installer)
-    feature(:installer).answers['foreman']['admin_password']
+    if feature(:downstream).current_minor_version >= '6.6'
+      feature(:installer).answers['foreman']['initial_admin_password']
+    else
+      feature(:installer).answers['foreman']['admin_password']
+    end
   end
 
   def save_config_and_check(config)

--- a/definitions/features/installer.rb
+++ b/definitions/features/installer.rb
@@ -93,14 +93,6 @@ class Features::Installer < ForemanMaintain::Feature
     run(arguments, exec_options)
   end
 
-  def password_from_answers
-    if check_min_version('foreman', '1.22')
-      answers['foreman']['initial_admin_password']
-    else
-      answers['foreman']['admin_password']
-    end
-  end
-
   private
 
   def load_answers(config)

--- a/definitions/features/installer.rb
+++ b/definitions/features/installer.rb
@@ -93,6 +93,14 @@ class Features::Installer < ForemanMaintain::Feature
     run(arguments, exec_options)
   end
 
+  def password_from_answers
+    if check_min_version('foreman', '1.22')
+      answers['foreman']['initial_admin_password']
+    else
+      answers['foreman']['admin_password']
+    end
+  end
+
   private
 
   def load_answers(config)

--- a/definitions/features/installer.rb
+++ b/definitions/features/installer.rb
@@ -93,6 +93,16 @@ class Features::Installer < ForemanMaintain::Feature
     run(arguments, exec_options)
   end
 
+  def initial_admin_username
+    feature(:installer).answers['foreman']['initial_admin_username'] ||
+      feature(:installer).answers['foreman']['admin_username']
+  end
+
+  def initial_admin_password
+    feature(:installer).answers['foreman']['initial_admin_password'] ||
+      feature(:installer).answers['foreman']['admin_password']
+  end
+
   private
 
   def load_answers(config)

--- a/test/data/installer/simple_config/scenarios.d/foreman-answers.yaml
+++ b/test/data/installer/simple_config/scenarios.d/foreman-answers.yaml
@@ -1,3 +1,4 @@
 ---
 foreman:
+  admin_username: 'admin'
   admin_password: 'inspasswd'

--- a/test/definitions/features/hammer_test.rb
+++ b/test/definitions/features/hammer_test.rb
@@ -65,6 +65,7 @@ describe Features::Hammer do
     before do
       assume_feature_present(:installer)
       mock_installer_package('foreman-installer')
+      installer_config_dir("#{data_dir}/installer/simple_config")
     end
 
     it 'gets credentials from hammer configs' do
@@ -95,7 +96,6 @@ describe Features::Hammer do
       hammer_config_dirs(["#{data_dir}/hammer/sample_default_config"])
       stub_hostname
       stub_connection_check(false, true)
-      installer_config_dir("#{data_dir}/installer/simple_config")
 
       expect_custom_config(:foreman => { :username => 'admin', :password => 'inspasswd' })
       subject.setup_admin_access.must_equal true
@@ -106,7 +106,6 @@ describe Features::Hammer do
                            "#{data_dir}/hammer/sample_admin_config",
                            "#{data_dir}/hammer/sample_default_config"
                          ])
-      installer_config_dir("#{data_dir}/installer/simple_config")
       stub_hostname
       stub_connection_check(false, false, true)
       expect_custom_config(:foreman => { :username => 'admin' })
@@ -119,7 +118,6 @@ describe Features::Hammer do
                            "#{data_dir}/hammer/sample_user_config",
                            "#{data_dir}/hammer/sample_default_config"
                          ])
-      installer_config_dir("#{data_dir}/installer/simple_config")
       stub_hostname
       stub_connection_check(false, true)
       expect_custom_config(:foreman => { :username => 'admin', :password => 'inspasswd' })
@@ -130,7 +128,6 @@ describe Features::Hammer do
       hammer_config_dirs([
                            "#{data_dir}/hammer/sample_default_config"
                          ])
-      installer_config_dir("#{data_dir}/installer/simple_config")
       stub_hostname
       stub_connection_check(false, false, true)
       log_reporter.input << 'manual'
@@ -144,7 +141,6 @@ describe Features::Hammer do
       hammer_config_dirs([
                            "#{data_dir}/hammer/sample_default_config"
                          ])
-      installer_config_dir("#{data_dir}/installer/simple_config")
       stub_hostname
       stub_connection_check(false, false)
       log_reporter.input << 'manual'


### PR DESCRIPTION
This patch fixes hammer-setup failing because of unable to find password from satellite-answers.yaml file. In previous satellite versions, we were using variable admin_password. Now it has is been changed to initial_admin_password.