### PR TITLE
Fixes #27072 - remove extra confirm call

### DIFF
--- a/lib/foreman_maintain/runner.rb
+++ b/lib/foreman_maintain/runner.rb
@@ -92,7 +92,6 @@ module ForemanMaintain
 
     def execute_scenario_steps(scenario, force = false)
       scenario.before_scenarios.flatten.each { |before_scenario| run_scenario(before_scenario) }
-      confirm_scenario(scenario)
       return if !force && quit? # the before scenarios caused the stop of the execution
       @reporter.before_scenario_starts(scenario)
       run_steps(scenario, scenario.steps)

--- a/lib/foreman_maintain/runner.rb
+++ b/lib/foreman_maintain/runner.rb
@@ -31,6 +31,7 @@ module ForemanMaintain
       @scenarios.each do |scenario|
         run_scenario(scenario)
         next unless @quit
+
         if @rescue_scenario
           logger.debug('=== Rescue scenario found. Executing ===')
           execute_scenario_steps(@rescue_scenario, true)
@@ -60,6 +61,7 @@ module ForemanMaintain
 
     def confirm_scenario(scenario)
       return unless @last_scenario
+
       decision = if @last_scenario.steps_with_error(:whitelisted => false).any? ||
                     @last_scenario.steps_with_abort(:whitelisted => false).any?
                    :quit
@@ -92,7 +94,9 @@ module ForemanMaintain
 
     def execute_scenario_steps(scenario, force = false)
       scenario.before_scenarios.flatten.each { |before_scenario| run_scenario(before_scenario) }
+      confirm_scenario(scenario) if @rescue_scenario
       return if !force && quit? # the before scenarios caused the stop of the execution
+
       @reporter.before_scenario_starts(scenario)
       run_steps(scenario, scenario.steps)
       @reporter.after_scenario_finishes(scenario)


### PR DESCRIPTION
This removes the extra confirm_scenario() call in execute_scenario_steps() method . I feel its extra because,

1. The execute_scenario_steps is getting called by two methods, run and run_scenario.
2. The run_scenario is calling confirm_scenario() method.
3. If we see run method, then it calls run_scenario itself, this means we are running confirm_scenario there on condition.

** Only one thing I feel here is when @rescue_scenario is set we are not having confirm_scenario(), so maybe we can call confirm_scenario() when @rescue_scenario is set in execute_scenario_steps() .
** I can see  confirm_scenario() in execute_scenario_steps() added in pr https://github.com/theforeman/foreman_maintain/pull/164
~~~
    def run
      @scenarios.each do |scenario|
        run_scenario(scenario)
        next unless @quit
        if @rescue_scenario
          logger.debug('=== Rescue scenario found. Executing ===')
          execute_scenario_steps(@rescue_scenario, true)
        end
        break
      end
    end

    def run_scenario(scenario, confirm = true)
      return if scenario.steps.empty?
      raise 'The runner is already in quit state' if quit?

      if confirm
        confirm_scenario(scenario)
        return if quit?
      end

      execute_scenario_steps(scenario)
    ensure
      @last_scenario = scenario unless scenario.steps.empty?
      @exit_code = 1 if scenario.failed?
    end
~~~