### PR TITLE
Fixes #27291 - Make help tests whitespace insensitive

### DIFF
--- a/test/lib/cli/advanced_procedure_command_test.rb
+++ b/test/lib/cli/advanced_procedure_command_test.rb
@@ -16,7 +16,7 @@ module ForemanMaintain
     end
 
     it 'prints procedure' do
-      assert_cmd <<-OUTPUT.strip_heredoc
+      assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
         Usage:
             foreman-maintain advanced [OPTIONS] SUBCOMMAND [ARG] ...
 
@@ -39,7 +39,7 @@ module ForemanMaintain
       end
 
       it 'prints: run and by-tag subcommands' do
-        assert_cmd <<-OUTPUT.strip_heredoc
+        assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
           Usage:
               foreman-maintain advanced procedure [OPTIONS] SUBCOMMAND [ARG] ...
 
@@ -63,7 +63,7 @@ module ForemanMaintain
       end
 
       it 'prints: available subcommands for by-tag' do
-        assert_cmd <<-OUTPUT.strip_heredoc
+        assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
           Usage:
               foreman-maintain advanced procedure by-tag [OPTIONS] SUBCOMMAND [ARG] ...
 
@@ -92,7 +92,7 @@ module ForemanMaintain
       end
 
       it 'prints: available subcommands for run' do
-        assert_cmd <<-OUTPUT.strip_heredoc
+        assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
           Usage:
               foreman-maintain advanced procedure run [OPTIONS] SUBCOMMAND [ARG] ...
 

--- a/test/lib/cli/health_command_test.rb
+++ b/test/lib/cli/health_command_test.rb
@@ -11,7 +11,7 @@ module ForemanMaintain
     end
 
     it 'prints help' do
-      assert_cmd <<-OUTPUT.strip_heredoc
+      assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
         Usage:
             foreman-maintain health [OPTIONS] SUBCOMMAND [ARG] ...
 

--- a/test/lib/cli/maintenance_mode_command_test.rb
+++ b/test/lib/cli/maintenance_mode_command_test.rb
@@ -11,7 +11,7 @@ module ForemanMaintain
     end
 
     it 'prints help' do
-      assert_cmd <<-OUTPUT.strip_heredoc
+      assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
         Usage:
             foreman-maintain maintenance-mode [OPTIONS] SUBCOMMAND [ARG] ...
 

--- a/test/lib/cli/packages_command_test.rb
+++ b/test/lib/cli/packages_command_test.rb
@@ -11,7 +11,7 @@ module ForemanMaintain
     end
 
     it 'prints help' do
-      assert_cmd <<-OUTPUT.strip_heredoc
+      assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
         Usage:
             foreman-maintain packages [OPTIONS] SUBCOMMAND [ARG] ...
 

--- a/test/lib/cli/upgrade_command_test.rb
+++ b/test/lib/cli/upgrade_command_test.rb
@@ -15,7 +15,7 @@ module ForemanMaintain
     end
 
     it 'prints help' do
-      assert_cmd <<-OUTPUT.strip_heredoc
+      assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
         Usage:
             foreman-maintain upgrade [OPTIONS] SUBCOMMAND [ARG] ...
 

--- a/test/lib/cli_test.rb
+++ b/test/lib/cli_test.rb
@@ -11,7 +11,7 @@ module ForemanMaintain
     end
 
     it 'prints help' do
-      assert_cmd <<-OUTPUT.strip_heredoc
+      assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
         Usage:
             foreman-maintain [OPTIONS] SUBCOMMAND [ARG] ...
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,8 +7,12 @@ require File.dirname(__FILE__) + '/support/minitest_spec_context'
 require File.expand_path('../lib/support/log_reporter', __FILE__)
 
 module CliAssertions
-  def assert_cmd(expected_output, args = [])
+  def assert_cmd(expected_output, args = [], ignore_whitespace: false)
     output = run_cmd(args)
+    if ignore_whitespace
+      expected_output = expected_output.gsub(/\s+/, ' ')
+      output = output.gsub(/\s+/, ' ')
+    end
     assert_equal expected_output, remove_colors(simulate_carriage_returns(output))
   end
 


### PR DESCRIPTION
New version of clamp (1.3.1) changed help formating which makes our
output tests fail. assert_cmd was changed to optionaly ignore whitespace
to make the tests pass regardless of what clamp version is used.