### PR TITLE
Fixes #27842 - excludes foreman_auth when < katello-3.2.0

### DIFF
--- a/definitions/features/instance.rb
+++ b/definitions/features/instance.rb
@@ -112,6 +112,12 @@ class Features::Instance < ForemanMaintain::Feature
   end
 
   def pick_failing_components(components)
+    if feature(:katello).current_version < Gem::Version.new('3.2.0')
+      # Note that katello_ping returns an empty result against foreman_auth.
+      # https://github.com/Katello/katello/commit/95d7b9067d38f269a5ec121fb73b5c19d4422baf
+      components.reject! { |n| n.eql?('foreman_auth') }
+    end
+
     components.each_with_object([]) do |(name, data), failing|
       failing << name unless data['status'] == 'ok'
     end
@@ -129,7 +135,7 @@ class Features::Instance < ForemanMaintain::Feature
 
   def component_features_map
     {
-      'candlepin_auth' =>  %w[candlepin candlepin_database],
+      'candlepin_auth' => %w[candlepin candlepin_database],
       'candlepin' => %w[candlepin candlepin_database],
       'pulp_auth' => %w[pulp mongo],
       'pulp' => %w[pulp mongo],

--- a/test/definitions/features/instance_test.rb
+++ b/test/definitions/features/instance_test.rb
@@ -136,7 +136,9 @@ describe Features::Instance do
       let(:connection) { mock('connection') }
 
       before do
-        assume_feature_present(:katello)
+        assume_feature_present(:katello) do |feature_class|
+          feature_class.any_instance.stubs(:current_version => version('3.2.0'))
+        end
       end
 
       it 'fails when server is down' do


### PR DESCRIPTION
Getting an error `Couldn't connect to the server: undefined method 'to_sym' for nil:NilClass` on katello < 3.2.0.  Returning empty result for `foreman-auth` using katello ping.