### PR TITLE
Fixes #27871 - Don't restore /var/lib/foreman/public

### DIFF
--- a/definitions/features/foreman_server.rb
+++ b/definitions/features/foreman_server.rb
@@ -38,7 +38,7 @@ module ForemanMaintain
 
       def config_files_to_exclude
         [
-          '/var/lib/foreman/public/assets'
+          '/var/lib/foreman/public'
         ]
       end
     end


### PR DESCRIPTION
I (actually @johnpmitsch!) found this while testing satellite-clone for 6.6. Restoring the webpack assets breaks the symlinks and so some pages just don't work. I can't think of a scenario where we'd need to restore the webpack assets - but please let me know if I've overlooked something.

I think this would affect not only satellite-clone but restoring a backup in general if any of the plugins providing webpack assets have been upgraded since the backup was taken as the symlinks would get broken.