### PR TITLE
Fixes #28012 - Spelling mistake in backup procedure

### DIFF
--- a/definitions/procedures/backup/compress_data.rb
+++ b/definitions/procedures/backup/compress_data.rb
@@ -7,7 +7,7 @@ module Procedures::Backup
     end
 
     def run
-      compress_file('pgsql_data.tar', 'Postgress DB')
+      compress_file('pgsql_data.tar', 'Postgres DB')
       compress_file('mongo_data.tar', 'Mongo DB')
     end
 


### PR DESCRIPTION
I noticed when running backups that Postgres was incorrectly referred to as Postgress.

Small contribution but hopefully a useful one :)