### PR TITLE
Fixes #28097 - Allow packages update with no packages

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,7 +32,7 @@ Style/GuardClause:
     - 'lib/foreman_maintain/system_helpers.rb'
 
 Style/HashSyntax:
-  EnforcedStyle: hash_rockets
+  EnforcedStyle: 'no_mixed_keys'
 
 Style/GuardClause:
   Enabled: false

--- a/definitions/procedures/packages/installer_confirmation.rb
+++ b/definitions/procedures/packages/installer_confirmation.rb
@@ -5,7 +5,7 @@ module Procedures::Packages
     end
 
     def run
-      question = "WARNING: This script runs #{feature(:installer).installer_command} " \
+      question = "\nWARNING: This script runs #{feature(:installer).installer_command} " \
         "after the yum execution \n" \
         "to ensure the #{feature(:instance).product_name} " \
         "is in a consistent state.\n" \

--- a/definitions/procedures/packages/update_all_confirmation.rb
+++ b/definitions/procedures/packages/update_all_confirmation.rb
@@ -8,14 +8,15 @@ module Procedures::Packages
 
     def run
       if @packages.nil? || @packages.empty?
-        question = "\nWARNING: No speciffic packages to update were provided\n" \
+        question = "\nWARNING: No specific packages to update were provided\n" \
           "so we are going to update all available packages.\n" \
           "It is recommended to update everything only as part of upgrade\n" \
           "of the #{feature(:instance).product_name} to the next version. \n" \
           "To Upgrade to next version use 'foreman-maintain upgrade'.\n\n" \
+          "NOTE: --assumeyes is not applicable for this check\n\n" \
           "Do you want to proceed with update of everything regardless\n" \
           'of the recommendations?'
-        answer = ask_decision(question, 'y(yes), q(quit)')
+        answer = ask_decision(question, 'y(yes), q(quit)', ignore_assumeyes: true)
         abort! unless answer == :yes
       end
     end

--- a/definitions/procedures/packages/update_all_confirmation.rb
+++ b/definitions/procedures/packages/update_all_confirmation.rb
@@ -8,12 +8,13 @@ module Procedures::Packages
 
     def run
       if @packages.nil? || @packages.empty?
-        question = "\nWARNING: No speciffic packages to update were provided " \
+        question = "\nWARNING: No speciffic packages to update were provided\n" \
           "so we are going to update all available packages.\n" \
-          'It is recommended to update everything only as part of ' \
-          "upgrade of the #{feature(:instance).product_name} to the next version. \n" \
+          "It is recommended to update everything only as part of upgrade\n" \
+          "of the #{feature(:instance).product_name} to the next version. \n" \
           "To Upgrade to next version use 'foreman-maintain upgrade'.\n\n" \
-          'Do you want to proceed with update of everything regardless of the recommendations?'
+          "Do you want to proceed with update of everything regardless\n" \
+          'of the recommendations?'
         answer = ask_decision(question, 'y(yes), q(quit)')
         abort! unless answer == :yes
       end

--- a/definitions/procedures/packages/update_all_confirmation.rb
+++ b/definitions/procedures/packages/update_all_confirmation.rb
@@ -1,0 +1,22 @@
+module Procedures::Packages
+  class UpdateAllConfirmation < ForemanMaintain::Procedure
+    metadata do
+      param :packages, 'List of packages to update', :array => true
+
+      description 'Confirm update all is intentionall'
+    end
+
+    def run
+      if @packages.nil? or @packages.empty?
+        question = "\nWARNING: No speciffic packages to update were provided " \
+          "so we are going to update all available packages.\n" \
+          "It is recommended to update everything only as part of " \
+          "upgrade of the #{feature(:instance).product_name} to the next version. \n" \
+          "To Upgrade to next version use 'foreman-maintain upgrade'.\n\n" \
+          'Do you want to proceed with update of everything regardless of the recommendations?'
+        answer = ask_decision(question, 'y(yes), q(quit)')
+        abort! unless answer == :yes
+      end
+    end
+  end
+end

--- a/definitions/procedures/packages/update_all_confirmation.rb
+++ b/definitions/procedures/packages/update_all_confirmation.rb
@@ -7,10 +7,10 @@ module Procedures::Packages
     end
 
     def run
-      if @packages.nil? or @packages.empty?
+      if @packages.nil? || @packages.empty?
         question = "\nWARNING: No speciffic packages to update were provided " \
           "so we are going to update all available packages.\n" \
-          "It is recommended to update everything only as part of " \
+          'It is recommended to update everything only as part of ' \
           "upgrade of the #{feature(:instance).product_name} to the next version. \n" \
           "To Upgrade to next version use 'foreman-maintain upgrade'.\n\n" \
           'Do you want to proceed with update of everything regardless of the recommendations?'

--- a/definitions/procedures/packages/update_all_confirmation.rb
+++ b/definitions/procedures/packages/update_all_confirmation.rb
@@ -3,7 +3,7 @@ module Procedures::Packages
     metadata do
       param :packages, 'List of packages to update', :array => true
 
-      description 'Confirm update all is intentionall'
+      description 'Confirm update all is intentional'
     end
 
     def run

--- a/definitions/scenarios/packages.rb
+++ b/definitions/scenarios/packages.rb
@@ -71,8 +71,10 @@ module ForemanMaintain::Scenarios
       end
 
       def compose
-        add_step_with_context(Procedures::Packages::InstallerConfirmation)
-        add_step_with_context(Procedures::Packages::UnlockVersions)
+        add_steps_with_context(
+          Procedures::Packages::UpdateAllConfirmation,
+          Procedures::Packages::InstallerConfirmation,
+          Procedures::Packages::UnlockVersions)
         add_step_with_context(Procedures::Packages::Update, :force => true, :warn_on_errors => true)
         add_step_with_context(Procedures::Installer::Run,
                               :arguments => '--upgrade --disable-system-checks')
@@ -81,7 +83,8 @@ module ForemanMaintain::Scenarios
 
       def set_context_mapping
         context.map(:packages,
-                    Procedures::Packages::Update => :packages)
+                    Procedures::Packages::Update => :packages,
+                    Procedures::Packages::UpdateAllConfirmation => :packages)
         context.map(:assumeyes,
                     Procedures::Packages::Update => :assumeyes)
       end

--- a/definitions/scenarios/packages.rb
+++ b/definitions/scenarios/packages.rb
@@ -74,7 +74,8 @@ module ForemanMaintain::Scenarios
         add_steps_with_context(
           Procedures::Packages::UpdateAllConfirmation,
           Procedures::Packages::InstallerConfirmation,
-          Procedures::Packages::UnlockVersions)
+          Procedures::Packages::UnlockVersions
+        )
         add_step_with_context(Procedures::Packages::Update, :force => true, :warn_on_errors => true)
         add_step_with_context(Procedures::Installer::Run,
                               :arguments => '--upgrade --disable-system-checks')

--- a/lib/foreman_maintain/cli/packages_command.rb
+++ b/lib/foreman_maintain/cli/packages_command.rb
@@ -38,7 +38,7 @@ module ForemanMaintain
 
       subcommand 'update', 'Update packages in an unlocked session' do
         interactive_option
-        parameter 'PACKAGES ...', 'packages to update', :attribute_name => :packages
+        parameter '[PACKAGES ...]', 'packages to update', :attribute_name => :packages
 
         def execute
           run_scenarios_and_exit(

--- a/lib/foreman_maintain/reporter/cli_reporter.rb
+++ b/lib/foreman_maintain/reporter/cli_reporter.rb
@@ -186,7 +186,7 @@ module ForemanMaintain
 
       def ask_decision(message, options = 'y(yes), n(no), q(quit)')
         if assumeyes?
-          print("#{message} (assuming yes)")
+          print("#{message} (assuming yes)\n")
           return :yes
         end
         until_valid_decision do

--- a/lib/foreman_maintain/reporter/cli_reporter.rb
+++ b/lib/foreman_maintain/reporter/cli_reporter.rb
@@ -184,8 +184,8 @@ module ForemanMaintain
         ask_to_select('Select step to continue', steps, &:runtime_message)
       end
 
-      def ask_decision(message, options = 'y(yes), n(no), q(quit)')
-        if assumeyes?
+      def ask_decision(message, options = 'y(yes), n(no), q(quit)', ignore_assumeyes: false)
+        if !ignore_assumeyes && assumeyes?
           print("#{message} (assuming yes)\n")
           return :yes
         end


### PR DESCRIPTION
This patch lets packages update command to be invoked
without any args to update all packages.