### PR TITLE
Fixes #28089 - capsule upgrade support

### DIFF
--- a/definitions/checks/disk/performance.rb
+++ b/definitions/checks/disk/performance.rb
@@ -46,15 +46,15 @@ module Checks
       end
 
       def check_only_single_device?
-        @default_dirs.values do |dir|
+        default_dirs.values do |dir|
           ForemanMaintain::Utils::Disk::Device.new(dir).name
         end.uniq.length <= 1
       end
 
       def dirs_to_check
-        return @default_dirs.values.first(1) if check_only_single_device?
+        return default_dirs.values.first(1) if check_only_single_device?
 
-        @default_dirs.values
+        default_dirs.values
       end
 
       private

--- a/definitions/checks/disk/performance.rb
+++ b/definitions/checks/disk/performance.rb
@@ -1,9 +1,13 @@
 module Checks
   module Disk
     class Performance < ForemanMaintain::Check
+      DEFAULT_DIRS = [
+        '/var/lib/pulp', '/var/lib/mongodb', '/var/lib/pgsql'
+      ].select { |file_path| File.directory?(file_path) }.freeze
+
       metadata do
         label :disk_performance
-        description 'Check for recommended disk speed of pulp, mongodb, pgsql dir.'
+        description "Check recommended disk speed for #{DEFAULT_DIRS.join(',')} directories."
         tags :pre_upgrade
         preparation_steps { Procedures::Packages::Install.new(:packages => %w[fio]) }
 
@@ -14,9 +18,6 @@ module Checks
 
       EXPECTED_IO = 60
       DEFAULT_UNIT = 'MB/sec'.freeze
-      DEFAULT_DIRS = [
-        '/var/lib/pulp', '/var/lib/mongodb', '/var/lib/pgsql'
-      ].select { |file_path| File.directory?(file_path) }.freeze
 
       attr_reader :stats
 

--- a/definitions/checks/disk/performance.rb
+++ b/definitions/checks/disk/performance.rb
@@ -33,7 +33,7 @@ module Checks
       end
 
       def default_dirs
-        @default_dirs ||= %i[pulp mongo foreman_database].inject({}) do |dirs, f|
+        @default_dirs ||= %i[pulp2 pulpcore_database mongo foreman_database].inject({}) do |dirs, f|
           if feature(f) && File.directory?(feature(f).data_dir)
             dirs[feature(f).label_dashed] = feature(f).data_dir
           end

--- a/definitions/checks/original_assets.rb
+++ b/definitions/checks/original_assets.rb
@@ -2,6 +2,7 @@ class Checks::OriginalAssets < ForemanMaintain::Check
   metadata do
     description 'Check if only installed assets are present on the system'
     tags :post_upgrade
+    for_feature :foreman_server
   end
 
   ASSETS_DIR = '/var/lib/foreman/public/assets'.freeze

--- a/definitions/features/installer.rb
+++ b/definitions/features/installer.rb
@@ -92,7 +92,8 @@ class Features::Installer < ForemanMaintain::Feature
   end
 
   def upgrade(exec_options = {})
-    arguments = '--upgrade' if can_upgrade?
+    arguments = '--disable-system-checks'
+    arguments += ' --upgrade' if can_upgrade?
     run(arguments, exec_options)
   end
 

--- a/definitions/scenarios/upgrade_to_capsule_6_7.rb
+++ b/definitions/scenarios/upgrade_to_capsule_6_7.rb
@@ -1,23 +1,23 @@
-module Scenarios::Satellite_6_3
+module Scenarios::Capsule_6_7
   class Abstract < ForemanMaintain::Scenario
     def self.upgrade_metadata(&block)
       metadata do
         tags :upgrade_scenario
         confine do
-          feature(:satellite) && feature(:satellite).current_minor_version == '6.2'
+          feature(:capsule) && feature(:capsule).current_minor_version == '6.6'
         end
         instance_eval(&block)
       end
     end
 
     def target_version
-      '6.3'
+      '6.7'
     end
   end
 
   class PreUpgradeCheck < Abstract
     upgrade_metadata do
-      description 'Checks before upgrading to Satellite 6.3'
+      description 'Checks before upgrading to Capsule 6.7'
       tags :pre_upgrade_checks
       run_strategy :fail_slow
     end
@@ -25,14 +25,13 @@ module Scenarios::Satellite_6_3
     def compose
       add_steps(find_checks(:default))
       add_steps(find_checks(:pre_upgrade))
-      add_step(Checks::RemoteExecution::VerifySettingsFileAlreadyExists.new)
-      add_step(Checks::Repositories::Validate.new(:version => '6.3'))
+      add_step(Checks::Repositories::Validate.new(:version => '6.7'))
     end
   end
 
   class PreMigrations < Abstract
     upgrade_metadata do
-      description 'Procedures before migrating to Satellite 6.3'
+      description 'Procedures before migrating to Capsule 6.7'
       tags :pre_migrations
     end
 
@@ -44,12 +43,12 @@ module Scenarios::Satellite_6_3
 
   class Migrations < Abstract
     upgrade_metadata do
-      description 'Migration scripts to Satellite 6.3'
+      description 'Migration scripts to Capsule 6.7'
       tags :migrations
     end
 
     def compose
-      add_step(Procedures::Repositories::Setup.new(:version => '6.3'))
+      add_step(Procedures::Repositories::Setup.new(:version => '6.7'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step(Procedures::Installer::Upgrade.new)
@@ -58,7 +57,7 @@ module Scenarios::Satellite_6_3
 
   class PostMigrations < Abstract
     upgrade_metadata do
-      description 'Procedures after migrating to Satellite 6.3'
+      description 'Procedures after migrating to Capsule 6.7'
       tags :post_migrations
     end
 
@@ -70,7 +69,7 @@ module Scenarios::Satellite_6_3
 
   class PostUpgradeChecks < Abstract
     upgrade_metadata do
-      description 'Checks after upgrading to Satellite 6.3'
+      description 'Checks after upgrading to Capsule 6.7'
       tags :post_upgrade_checks
       run_strategy :fail_slow
     end

--- a/definitions/scenarios/upgrade_to_capsule_6_7.rb
+++ b/definitions/scenarios/upgrade_to_capsule_6_7.rb
@@ -4,7 +4,9 @@ module Scenarios::Capsule_6_7
       metadata do
         tags :upgrade_scenario
         confine do
-          feature(:capsule) && feature(:capsule).current_minor_version == '6.6'
+          feature(:capsule) &&
+            (feature(:capsule).current_minor_version == '6.6' || \
+            ForemanMaintain.upgrade_in_progress == '6.7')
         end
         instance_eval(&block)
       end

--- a/definitions/scenarios/upgrade_to_capsule_6_7_z.rb
+++ b/definitions/scenarios/upgrade_to_capsule_6_7_z.rb
@@ -4,7 +4,9 @@ module Scenarios::Capsule_6_7_z
       metadata do
         tags :upgrade_scenario
         confine do
-          feature(:capsule) && feature(:capsule).current_minor_version == '6.7'
+          feature(:capsule) &&
+            (feature(:capsule).current_minor_version == '6.7' || \
+              ForemanMaintain.upgrade_in_progress == '6.7.z')
         end
         instance_eval(&block)
       end

--- a/definitions/scenarios/upgrade_to_capsule_6_7_z.rb
+++ b/definitions/scenarios/upgrade_to_capsule_6_7_z.rb
@@ -1,23 +1,23 @@
-module Scenarios::Satellite_6_3
+module Scenarios::Capsule_6_7_z
   class Abstract < ForemanMaintain::Scenario
     def self.upgrade_metadata(&block)
       metadata do
         tags :upgrade_scenario
         confine do
-          feature(:satellite) && feature(:satellite).current_minor_version == '6.2'
+          feature(:capsule) && feature(:capsule).current_minor_version == '6.7'
         end
         instance_eval(&block)
       end
     end
 
     def target_version
-      '6.3'
+      '6.7.z'
     end
   end
 
   class PreUpgradeCheck < Abstract
     upgrade_metadata do
-      description 'Checks before upgrading to Satellite 6.3'
+      description 'Checks before upgrading to Capsule 6.7.z'
       tags :pre_upgrade_checks
       run_strategy :fail_slow
     end
@@ -25,14 +25,13 @@ module Scenarios::Satellite_6_3
     def compose
       add_steps(find_checks(:default))
       add_steps(find_checks(:pre_upgrade))
-      add_step(Checks::RemoteExecution::VerifySettingsFileAlreadyExists.new)
-      add_step(Checks::Repositories::Validate.new(:version => '6.3'))
+      add_step(Checks::Repositories::Validate.new(:version => '6.7'))
     end
   end
 
   class PreMigrations < Abstract
     upgrade_metadata do
-      description 'Procedures before migrating to Satellite 6.3'
+      description 'Procedures before migrating to Capsule 6.7.z'
       tags :pre_migrations
     end
 
@@ -44,12 +43,12 @@ module Scenarios::Satellite_6_3
 
   class Migrations < Abstract
     upgrade_metadata do
-      description 'Migration scripts to Satellite 6.3'
+      description 'Migration scripts to Capsule 6.7.z'
       tags :migrations
     end
 
     def compose
-      add_step(Procedures::Repositories::Setup.new(:version => '6.3'))
+      add_step(Procedures::Repositories::Setup.new(:version => '6.7'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step(Procedures::Installer::Upgrade.new)
@@ -58,7 +57,7 @@ module Scenarios::Satellite_6_3
 
   class PostMigrations < Abstract
     upgrade_metadata do
-      description 'Procedures after migrating to Satellite 6.3'
+      description 'Procedures after migrating to Capsule 6.7.z'
       tags :post_migrations
     end
 
@@ -70,7 +69,7 @@ module Scenarios::Satellite_6_3
 
   class PostUpgradeChecks < Abstract
     upgrade_metadata do
-      description 'Checks after upgrading to Satellite 6.3'
+      description 'Checks after upgrading to Capsule 6.7.z'
       tags :post_upgrade_checks
       run_strategy :fail_slow
     end

--- a/definitions/scenarios/upgrade_to_satellite_6_2.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_2.rb
@@ -4,7 +4,9 @@ module Scenarios::Satellite_6_2
       metadata do
         tags :upgrade_scenario
         confine do
-          feature(:satellite) && feature(:satellite).current_minor_version == '6.1'
+          feature(:satellite) &&
+            (feature(:satellite).current_minor_version == '6.1' || \
+            ForemanMaintain.upgrade_in_progress == '6.2')
         end
         instance_eval(&block)
       end

--- a/definitions/scenarios/upgrade_to_satellite_6_2.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_2.rb
@@ -2,12 +2,16 @@ module Scenarios::Satellite_6_2
   class Abstract < ForemanMaintain::Scenario
     def self.upgrade_metadata(&block)
       metadata do
-        tags :upgrade_to_satellite_6_2
+        tags :upgrade_scenario
         confine do
           feature(:satellite) && feature(:satellite).current_minor_version == '6.1'
         end
         instance_eval(&block)
       end
+    end
+
+    def target_version
+      '6.2'
     end
   end
 
@@ -76,5 +80,3 @@ module Scenarios::Satellite_6_2
     end
   end
 end
-
-ForemanMaintain::UpgradeRunner.register_version('6.2', :upgrade_to_satellite_6_2)

--- a/definitions/scenarios/upgrade_to_satellite_6_2_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_2_z.rb
@@ -2,12 +2,16 @@ module Scenarios::Satellite_6_2_z
   class Abstract < ForemanMaintain::Scenario
     def self.upgrade_metadata(&block)
       metadata do
-        tags :upgrade_to_satellite_6_2_z
+        tags :upgrade_scenario
         confine do
           feature(:satellite) && feature(:satellite).current_minor_version == '6.2'
         end
         instance_eval(&block)
       end
+    end
+
+    def target_version
+      '6.2.z'
     end
   end
 
@@ -76,5 +80,3 @@ module Scenarios::Satellite_6_2_z
     end
   end
 end
-
-ForemanMaintain::UpgradeRunner.register_version('6.2.z', :upgrade_to_satellite_6_2_z)

--- a/definitions/scenarios/upgrade_to_satellite_6_2_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_2_z.rb
@@ -4,7 +4,9 @@ module Scenarios::Satellite_6_2_z
       metadata do
         tags :upgrade_scenario
         confine do
-          feature(:satellite) && feature(:satellite).current_minor_version == '6.2'
+          feature(:satellite) &&
+            (feature(:satellite).current_minor_version == '6.2' || \
+            ForemanMaintain.upgrade_in_progress == '6.2.z')
         end
         instance_eval(&block)
       end

--- a/definitions/scenarios/upgrade_to_satellite_6_3.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_3.rb
@@ -4,7 +4,9 @@ module Scenarios::Satellite_6_3
       metadata do
         tags :upgrade_scenario
         confine do
-          feature(:satellite) && feature(:satellite).current_minor_version == '6.2'
+          feature(:satellite) &&
+            (feature(:satellite).current_minor_version == '6.2' || \
+            ForemanMaintain.upgrade_in_progress == '6.3')
         end
         instance_eval(&block)
       end

--- a/definitions/scenarios/upgrade_to_satellite_6_3_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_3_z.rb
@@ -4,7 +4,9 @@ module Scenarios::Satellite_6_3_z
       metadata do
         tags :upgrade_scenario
         confine do
-          feature(:satellite) && feature(:satellite).current_minor_version == '6.3'
+          feature(:satellite) &&
+            (feature(:satellite).current_minor_version == '6.3' || \
+            ForemanMaintain.upgrade_in_progress == '6.3.z')
         end
         instance_eval(&block)
       end

--- a/definitions/scenarios/upgrade_to_satellite_6_3_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_3_z.rb
@@ -2,12 +2,16 @@ module Scenarios::Satellite_6_3_z
   class Abstract < ForemanMaintain::Scenario
     def self.upgrade_metadata(&block)
       metadata do
-        tags :upgrade_to_satellite_6_3_z
+        tags :upgrade_scenario
         confine do
           feature(:satellite) && feature(:satellite).current_minor_version == '6.3'
         end
         instance_eval(&block)
       end
+    end
+
+    def target_version
+      '6.3.z'
     end
   end
 
@@ -76,5 +80,3 @@ module Scenarios::Satellite_6_3_z
     end
   end
 end
-
-ForemanMaintain::UpgradeRunner.register_version('6.3.z', :upgrade_to_satellite_6_3_z)

--- a/definitions/scenarios/upgrade_to_satellite_6_4.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_4.rb
@@ -2,12 +2,16 @@ module Scenarios::Satellite_6_4
   class Abstract < ForemanMaintain::Scenario
     def self.upgrade_metadata(&block)
       metadata do
-        tags :upgrade_to_satellite_6_4
+        tags :upgrade_scenario
         confine do
           feature(:satellite) && feature(:satellite).current_minor_version == '6.3'
         end
         instance_eval(&block)
       end
+    end
+
+    def target_version
+      '6.4'
     end
   end
 
@@ -77,5 +81,3 @@ module Scenarios::Satellite_6_4
     end
   end
 end
-
-ForemanMaintain::UpgradeRunner.register_version('6.4', :upgrade_to_satellite_6_4)

--- a/definitions/scenarios/upgrade_to_satellite_6_4.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_4.rb
@@ -4,7 +4,9 @@ module Scenarios::Satellite_6_4
       metadata do
         tags :upgrade_scenario
         confine do
-          feature(:satellite) && feature(:satellite).current_minor_version == '6.3'
+          feature(:satellite) &&
+            (feature(:satellite).current_minor_version == '6.3' || \
+            ForemanMaintain.upgrade_in_progress == '6.4')
         end
         instance_eval(&block)
       end

--- a/definitions/scenarios/upgrade_to_satellite_6_4_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_4_z.rb
@@ -2,12 +2,16 @@ module Scenarios::Satellite_6_4_z
   class Abstract < ForemanMaintain::Scenario
     def self.upgrade_metadata(&block)
       metadata do
-        tags :upgrade_to_satellite_6_4_z
+        tags :upgrade_scenario
         confine do
           feature(:satellite) && feature(:satellite).current_minor_version == '6.4'
         end
         instance_eval(&block)
       end
+    end
+
+    def target_version
+      '6.4.z'
     end
   end
 
@@ -76,5 +80,3 @@ module Scenarios::Satellite_6_4_z
     end
   end
 end
-
-ForemanMaintain::UpgradeRunner.register_version('6.4.z', :upgrade_to_satellite_6_4_z)

--- a/definitions/scenarios/upgrade_to_satellite_6_4_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_4_z.rb
@@ -4,7 +4,9 @@ module Scenarios::Satellite_6_4_z
       metadata do
         tags :upgrade_scenario
         confine do
-          feature(:satellite) && feature(:satellite).current_minor_version == '6.4'
+          feature(:satellite) &&
+            (feature(:satellite).current_minor_version == '6.4' || \
+            ForemanMaintain.upgrade_in_progress == '6.4.z')
         end
         instance_eval(&block)
       end

--- a/definitions/scenarios/upgrade_to_satellite_6_5.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_5.rb
@@ -2,12 +2,16 @@ module Scenarios::Satellite_6_5
   class Abstract < ForemanMaintain::Scenario
     def self.upgrade_metadata(&block)
       metadata do
-        tags :upgrade_to_satellite_6_5
+        tags :upgrade_scenario
         confine do
           feature(:satellite) && feature(:satellite).current_minor_version == '6.4'
         end
         instance_eval(&block)
       end
+    end
+
+    def target_version
+      '6.5'
     end
   end
 
@@ -76,5 +80,3 @@ module Scenarios::Satellite_6_5
     end
   end
 end
-
-ForemanMaintain::UpgradeRunner.register_version('6.5', :upgrade_to_satellite_6_5)

--- a/definitions/scenarios/upgrade_to_satellite_6_5.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_5.rb
@@ -4,7 +4,9 @@ module Scenarios::Satellite_6_5
       metadata do
         tags :upgrade_scenario
         confine do
-          feature(:satellite) && feature(:satellite).current_minor_version == '6.4'
+          feature(:satellite) &&
+            (feature(:satellite).current_minor_version == '6.4' || \
+            ForemanMaintain.upgrade_in_progress == '6.5')
         end
         instance_eval(&block)
       end

--- a/definitions/scenarios/upgrade_to_satellite_6_5_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_5_z.rb
@@ -4,7 +4,9 @@ module Scenarios::Satellite_6_5_z
       metadata do
         tags :upgrade_scenario
         confine do
-          feature(:satellite) && feature(:satellite).current_minor_version == '6.5'
+          feature(:satellite) &&
+            (feature(:satellite).current_minor_version == '6.5' || \
+            ForemanMaintain.upgrade_in_progress == '6.5.z')
         end
         instance_eval(&block)
       end

--- a/definitions/scenarios/upgrade_to_satellite_6_5_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_5_z.rb
@@ -2,12 +2,16 @@ module Scenarios::Satellite_6_5_z
   class Abstract < ForemanMaintain::Scenario
     def self.upgrade_metadata(&block)
       metadata do
-        tags :upgrade_to_satellite_6_5_z
+        tags :upgrade_scenario
         confine do
           feature(:satellite) && feature(:satellite).current_minor_version == '6.5'
         end
         instance_eval(&block)
       end
+    end
+
+    def target_version
+      '6.5.z'
     end
   end
 
@@ -76,5 +80,3 @@ module Scenarios::Satellite_6_5_z
     end
   end
 end
-
-ForemanMaintain::UpgradeRunner.register_version('6.5.z', :upgrade_to_satellite_6_5_z)

--- a/definitions/scenarios/upgrade_to_satellite_6_6.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_6.rb
@@ -4,7 +4,9 @@ module Scenarios::Satellite_6_6
       metadata do
         tags :upgrade_scenario
         confine do
-          feature(:satellite) && feature(:satellite).current_minor_version == '6.5'
+          feature(:satellite) &&
+            (feature(:satellite).current_minor_version == '6.5' || \
+            ForemanMaintain.upgrade_in_progress == '6.6')
         end
         instance_eval(&block)
       end

--- a/definitions/scenarios/upgrade_to_satellite_6_6.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_6.rb
@@ -2,12 +2,16 @@ module Scenarios::Satellite_6_6
   class Abstract < ForemanMaintain::Scenario
     def self.upgrade_metadata(&block)
       metadata do
-        tags :upgrade_to_satellite_6_6
+        tags :upgrade_scenario
         confine do
           feature(:satellite) && feature(:satellite).current_minor_version == '6.5'
         end
         instance_eval(&block)
       end
+    end
+
+    def target_version
+      '6.6'
     end
   end
 
@@ -78,5 +82,3 @@ module Scenarios::Satellite_6_6
     end
   end
 end
-
-ForemanMaintain::UpgradeRunner.register_version('6.6', :upgrade_to_satellite_6_6)

--- a/definitions/scenarios/upgrade_to_satellite_6_6_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_6_z.rb
@@ -2,12 +2,16 @@ module Scenarios::Satellite_6_6_z
   class Abstract < ForemanMaintain::Scenario
     def self.upgrade_metadata(&block)
       metadata do
-        tags :upgrade_to_satellite_6_6_z
+        tags :upgrade_scenario
         confine do
           feature(:satellite) && feature(:satellite).current_minor_version == '6.6'
         end
         instance_eval(&block)
       end
+    end
+
+    def target_version
+      '6.6.z'
     end
   end
 
@@ -78,5 +82,3 @@ module Scenarios::Satellite_6_6_z
     end
   end
 end
-
-ForemanMaintain::UpgradeRunner.register_version('6.6.z', :upgrade_to_satellite_6_6_z)

--- a/definitions/scenarios/upgrade_to_satellite_6_6_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_6_z.rb
@@ -4,7 +4,9 @@ module Scenarios::Satellite_6_6_z
       metadata do
         tags :upgrade_scenario
         confine do
-          feature(:satellite) && feature(:satellite).current_minor_version == '6.6'
+          feature(:satellite) &&
+            (feature(:satellite).current_minor_version == '6.6' || \
+            ForemanMaintain.upgrade_in_progress == '6.6.z')
         end
         instance_eval(&block)
       end

--- a/definitions/scenarios/upgrade_to_satellite_6_7.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_7.rb
@@ -2,12 +2,16 @@ module Scenarios::Satellite_6_7
   class Abstract < ForemanMaintain::Scenario
     def self.upgrade_metadata(&block)
       metadata do
-        tags :upgrade_to_satellite_6_7
+        tags :upgrade_scenario
         confine do
           feature(:satellite) && feature(:satellite).current_minor_version == '6.6'
         end
         instance_eval(&block)
       end
+    end
+
+    def target_version
+      '6.7'
     end
   end
 
@@ -76,5 +80,3 @@ module Scenarios::Satellite_6_7
     end
   end
 end
-
-ForemanMaintain::UpgradeRunner.register_version('6.7', :upgrade_to_satellite_6_7)

--- a/definitions/scenarios/upgrade_to_satellite_6_7.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_7.rb
@@ -4,7 +4,9 @@ module Scenarios::Satellite_6_7
       metadata do
         tags :upgrade_scenario
         confine do
-          feature(:satellite) && feature(:satellite).current_minor_version == '6.6'
+          feature(:satellite) &&
+            (feature(:satellite).current_minor_version == '6.6' || \
+            ForemanMaintain.upgrade_in_progress == '6.7')
         end
         instance_eval(&block)
       end

--- a/definitions/scenarios/upgrade_to_satellite_6_7_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_7_z.rb
@@ -2,12 +2,16 @@ module Scenarios::Satellite_6_7_z
   class Abstract < ForemanMaintain::Scenario
     def self.upgrade_metadata(&block)
       metadata do
-        tags :upgrade_to_satellite_6_7_z
+        tags :upgrade_scenario
         confine do
           feature(:satellite) && feature(:satellite).current_minor_version == '6.7'
         end
         instance_eval(&block)
       end
+    end
+
+    def target_version
+      '6.7.z'
     end
   end
 
@@ -76,5 +80,3 @@ module Scenarios::Satellite_6_7_z
     end
   end
 end
-
-ForemanMaintain::UpgradeRunner.register_version('6.7.z', :upgrade_to_satellite_6_7_z)

--- a/definitions/scenarios/upgrade_to_satellite_6_7_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_7_z.rb
@@ -4,7 +4,9 @@ module Scenarios::Satellite_6_7_z
       metadata do
         tags :upgrade_scenario
         confine do
-          feature(:satellite) && feature(:satellite).current_minor_version == '6.7'
+          feature(:satellite) &&
+            (feature(:satellite).current_minor_version == '6.7' || \
+            ForemanMaintain.upgrade_in_progress == '6.7.z')
         end
         instance_eval(&block)
       end

--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -139,5 +139,9 @@ module ForemanMaintain
     rescue StandardError => e
       logger.error "Invalid Storage label i.e #{label}. Error - #{e.message}"
     end
+
+    def upgrade_in_progress
+      storage[:upgrade_target_version]
+    end
   end
 end

--- a/lib/foreman_maintain/concerns/downstream.rb
+++ b/lib/foreman_maintain/concerns/downstream.rb
@@ -98,16 +98,21 @@ module ForemanMaintain
       end
 
       def common_repos(rh_version_major, full_version)
-        tools_repo_id = "rhel-#{rh_version_major}-server-satellite-tools-#{full_version}-rpms"
-        maintenance_repo_id = "rhel-#{rh_version_major}-server-satellite-maintenance-6-rpms"
+        repos_arrary = common_repos_array(rh_version_major, full_version)
+        return repos_arrary.first(1) if feature(:capsule)
 
-        # Override to use Beta repositories for sat version until GA
-        if ENV['FOREMAN_MAINTAIN_USE_BETA'] == '1'
-          tools_repo_id = "rhel-#{rh_version_major}-server-satellite-tools-6-beta-rpms"
-          maintenance_repo_id = "rhel-#{rh_version_major}-server-satellite-maintenance-6-beta-rpms"
-        end
+        repos_arrary
+      end
 
-        [tools_repo_id, maintenance_repo_id]
+      def common_repos_array(rh_version_major, full_version)
+        ["rhel-#{rh_version_major}-server-satellite-maintenance-6#{use_beta}-rpms",
+         "rhel-#{rh_version_major}-server-satellite-tools-#{full_version}#{use_beta}-rpms"]
+      end
+
+      def use_beta
+        return '-beta' if ENV['FOREMAN_MAINTAIN_USE_BETA'] == '1'
+
+        nil
       end
 
       def main_rh_repos(rh_version_major)

--- a/test/definitions/checks/disk_performance_test.rb
+++ b/test/definitions/checks/disk_performance_test.rb
@@ -7,8 +7,13 @@ describe Checks::Disk::Performance do
 
   before do
     assume_feature_absent(:mongo)
-    assume_feature_present(:pulp2) || assume_feature_present(:pulp3)
-    check_disk_performance.stubs(:default_dirs).returns(:pulp => '/var/lib/pulp')
+    current_feature = if file_nonzero?('/var/lib/pulp')
+                        :pulp2
+                      else
+                        :pulpcore_database
+                      end
+    assume_feature_present(current_feature)
+    check_disk_performance.stubs(:default_dirs).returns(:pulp => feature(current_feature).data_dir)
   end
 
   it 'should confine existence of fio' do

--- a/test/definitions/checks/disk_performance_test.rb
+++ b/test/definitions/checks/disk_performance_test.rb
@@ -7,13 +7,8 @@ describe Checks::Disk::Performance do
 
   before do
     assume_feature_absent(:mongo)
-    current_feature = if file_nonzero?('/var/lib/pulp')
-                        :pulp2
-                      else
-                        :pulpcore_database
-                      end
-    assume_feature_present(current_feature)
-    check_disk_performance.stubs(:default_dirs).returns(:pulp => feature(current_feature).data_dir)
+    assume_feature_present(:pulp2)
+    check_disk_performance.stubs(:default_dirs).returns(:pulp2 => '/var/lib/pulp')
   end
 
   it 'should confine existence of fio' do

--- a/test/definitions/checks/disk_performance_test.rb
+++ b/test/definitions/checks/disk_performance_test.rb
@@ -1,10 +1,15 @@
 require 'test_helper'
-
 describe Checks::Disk::Performance do
   include DefinitionsTestHelper
   include UnitTestHelper
 
   let(:check_disk_performance) { described_class.new }
+
+  before do
+    assume_feature_absent(:mongo)
+    assume_feature_present(:pulp2) || assume_feature_present(:pulp3)
+    check_disk_performance.stubs(:default_dirs).returns(:pulp => '/var/lib/pulp')
+  end
 
   it 'should confine existence of fio' do
     described_class.stubs(:execute?).with('which fio').returns(true)

--- a/test/definitions/features/installer_test.rb
+++ b/test/definitions/features/installer_test.rb
@@ -44,7 +44,8 @@ describe Features::Installer do
       it '#upgrade runs the installer with correct params' do
         assume_feature_absent(:satellite)
         installer_inst.expects(:'execute!').
-          with('LANG=en_US.utf-8 foreman-installer --upgrade', :interactive => true).
+          with('LANG=en_US.utf-8 foreman-installer --disable-system-checks --upgrade',
+               :interactive => true).
           returns(true)
         subject.upgrade(:interactive => true)
       end
@@ -52,7 +53,8 @@ describe Features::Installer do
       it '#upgrade runs the installer with correct params in satellite' do
         assume_feature_present(:satellite)
         installer_inst.expects(:'execute!').
-          with('LANG=en_US.utf-8 satellite-installer --upgrade', :interactive => true).
+          with('LANG=en_US.utf-8 satellite-installer --disable-system-checks --upgrade',
+               :interactive => true).
           returns(true)
         subject.upgrade(:interactive => true)
       end
@@ -73,106 +75,6 @@ describe Features::Installer do
           with('LANG=en_US.utf-8 satellite-installer --password=changeme', :interactive => true).
           returns(true)
         subject.run('--password=changeme', :interactive => true)
-      end
-    end
-  end
-
-  context 'legacy katello installer without scenarios (6.1)' do
-    before do
-      installer_config_dir(["#{data_dir}/installer/katello-installer"])
-      mock_installer_package('katello-installer')
-    end
-
-    it 'loads list of configs on the start' do
-      expected_config_files = [
-        "#{data_dir}/installer/katello-installer/answers.capsule-certs-generate.yaml",
-        "#{data_dir}/installer/katello-installer/answers.katello-installer.yaml",
-        "#{data_dir}/installer/katello-installer/capsule-certs-generate.yaml",
-        "#{data_dir}/installer/katello-installer/config_header.txt",
-        "#{data_dir}/installer/katello-installer/katello-installer.yaml",
-        '/usr/local/bin/validate_postgresql_connection.sh'
-      ].sort
-      subject.config_files.sort.must_equal(expected_config_files)
-    end
-
-    it 'can tell if we use scenarios or not' do
-      subject.with_scenarios?.must_equal false
-    end
-
-    it 'can tell last used scenario from the link' do
-      subject.last_scenario.must_be_nil
-    end
-
-    it 'returns the answers as a hash' do
-      subject.answers['foreman']['admin_password'].must_equal('changeme')
-    end
-
-    it 'has --upgrade' do
-      subject.can_upgrade?.must_equal true
-    end
-
-    context '#upgrade' do
-      it 'runs the installer with correct params' do
-        installer_inst.expects(:'execute!').
-          with('LANG=en_US.utf-8 katello-installer --upgrade', :interactive => true).
-          returns(true)
-        subject.upgrade(:interactive => true)
-      end
-    end
-
-    context '#run' do
-      it 'runs the installer with correct params' do
-        installer_inst.expects(:'execute!').
-          with('LANG=en_US.utf-8 katello-installer --password=changeme', :interactive => true).
-          returns(true)
-        subject.run('--password=changeme', :interactive => true)
-      end
-    end
-  end
-
-  context 'legacy capsule installer without scenarios (6.1)' do
-    before do
-      installer_config_dir(["#{data_dir}/installer/capsule-installer"])
-      mock_installer_package('capsule-installer')
-    end
-
-    it 'loads list of configs on the start' do
-      expected_config_files = [
-        "#{data_dir}/installer/capsule-installer/answers.capsule-installer.yaml",
-        "#{data_dir}/installer/capsule-installer/capsule-installer.yaml",
-        "#{data_dir}/installer/capsule-installer/config_header.txt",
-        '/usr/local/bin/validate_postgresql_connection.sh'
-      ].sort
-      subject.config_files.sort.must_equal(expected_config_files)
-    end
-
-    it 'can tell if we use scenarios or not' do
-      subject.with_scenarios?.must_equal false
-    end
-
-    it 'returns the answers as a hash' do
-      subject.answers['certs']['deploy'].must_equal(true)
-    end
-
-    it 'does not have --upgrade' do
-      subject.can_upgrade?.must_equal false
-    end
-
-    context '#upgrade' do
-      it 'runs the installer with correct params' do
-        installer_inst.expects(:'execute!').
-          with('LANG=en_US.utf-8 capsule-installer', :interactive => true).
-          returns(true)
-        subject.upgrade(:interactive => true)
-      end
-    end
-
-    context '#run' do
-      it 'runs the installer with correct params' do
-        installer_inst.expects(:'execute!').
-          with('LANG=en_US.utf-8 capsule-installer --certs=true', :interactive => true).
-          returns(true)
-        subject.run('--certs=true', :interactive => true)
       end
     end
   end

--- a/test/definitions/scenarios/upgrade_satellite_6_2_test.rb
+++ b/test/definitions/scenarios/upgrade_satellite_6_2_test.rb
@@ -14,43 +14,43 @@ module Scenarios
     end
 
     let :scenario do
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_2])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.2')
     end
 
     it 'is valid for 6.1.0 and 6.1.z version' do
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_2])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.2')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.1.0'))
       end
       detector.refresh
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_2])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.2')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.1.1'))
       end
       detector.refresh
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_2])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.2')
     end
 
     it 'is valid only for 6.1.z versions' do
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_2])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.2')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.0.8'))
       end
       detector.refresh
-      refute_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_2])
+      refute_scenario({ :tags => :pre_upgrade_checks }, '6.2')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.2.1'))
       end
       detector.refresh
-      refute_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_2])
+      refute_scenario({ :tags => :pre_upgrade_checks }, '6.2')
 
       assume_feature_absent(:satellite)
       detector.refresh
-      refute_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_2])
+      refute_scenario({ :tags => :pre_upgrade_checks }, '6.2')
     end
 
     it 'composes the pre upgrade checks for migration from satellite 6.1.z to 6.2' do

--- a/test/definitions/scenarios/upgrade_satellite_6_2_z_test.rb
+++ b/test/definitions/scenarios/upgrade_satellite_6_2_z_test.rb
@@ -13,23 +13,23 @@ module Scenarios
     end
 
     let :scenario do
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_2_z])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.2.z')
     end
 
     it 'is valid for 6.2.0 and 6.2.z version' do
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_2_z])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.2.z')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.2.0'))
       end
       detector.refresh
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_2_z])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.2.z')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.2.1'))
       end
       detector.refresh
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_2_z])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.2.z')
     end
 
     it 'is valid only for 6.2.z versions' do
@@ -37,17 +37,17 @@ module Scenarios
         feature_class.any_instance.stubs(:current_version => version('6.2.1'))
       end
       detector.refresh
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_2_z])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.2.z')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.1.9'))
       end
       detector.refresh
-      refute_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_2_z])
+      refute_scenario({ :tags => :pre_upgrade_checks }, '6.2.z')
 
       assume_feature_absent(:satellite)
       detector.refresh
-      refute_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_2_z])
+      refute_scenario({ :tags => :pre_upgrade_checks }, '6.2.z')
     end
 
     it 'composes the pre upgrade checks for migration from satellite 6.2.0 to 6.2.z' do

--- a/test/definitions/scenarios/upgrade_satellite_6_3_test.rb
+++ b/test/definitions/scenarios/upgrade_satellite_6_3_test.rb
@@ -13,43 +13,43 @@ module Scenarios
     end
 
     let :scenario do
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_3])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.3')
     end
 
     it 'is valid for 6.2.0 and 6.2.z version' do
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_3])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.3')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.2.0'))
       end
       detector.refresh
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_3])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.3')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.2.1'))
       end
       detector.refresh
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_3])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.3')
     end
 
     it 'is valid only for 6.2.z versions' do
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_3])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.3')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.1.9'))
       end
       detector.refresh
-      refute_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_3])
+      refute_scenario({ :tags => :pre_upgrade_checks }, '6.3')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.3.1'))
       end
       detector.refresh
-      refute_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_3])
+      refute_scenario({ :tags => :pre_upgrade_checks }, '6.3')
 
       assume_feature_absent(:satellite)
       detector.refresh
-      refute_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_3])
+      refute_scenario({ :tags => :pre_upgrade_checks }, '6.3')
     end
 
     it 'composes the pre upgrade checks for migration from satellite 6.2.z to 6.3' do

--- a/test/definitions/scenarios/upgrade_satellite_6_3_z_test.rb
+++ b/test/definitions/scenarios/upgrade_satellite_6_3_z_test.rb
@@ -13,23 +13,23 @@ module Scenarios
     end
 
     let :scenario do
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_3_z])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.3.z')
     end
 
     it 'is valid for 6.3.0 and 6.3.z version' do
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_3_z])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.3.z')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.3.0'))
       end
       detector.refresh
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_3_z])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.3.z')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.3.1'))
       end
       detector.refresh
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_3_z])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.3.z')
     end
 
     it 'is valid only for 6.3.z versions' do
@@ -37,17 +37,17 @@ module Scenarios
         feature_class.any_instance.stubs(:current_version => version('6.3.1'))
       end
       detector.refresh
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_3_z])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.3.z')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.1.9'))
       end
       detector.refresh
-      refute_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_3_z])
+      refute_scenario({ :tags => :pre_upgrade_checks }, '6.3.z')
 
       assume_feature_absent(:satellite)
       detector.refresh
-      refute_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_3_z])
+      refute_scenario({ :tags => :pre_upgrade_checks }, '6.3.z')
     end
 
     it 'composes the pre upgrade checks for migration from satellite 6.3.0 to 6.3.z' do

--- a/test/definitions/scenarios/upgrade_satellite_6_4_test.rb
+++ b/test/definitions/scenarios/upgrade_satellite_6_4_test.rb
@@ -13,43 +13,43 @@ module Scenarios
     end
 
     let :scenario do
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_4])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.4')
     end
 
     it 'is valid for 6.3.0 and 6.3.z version' do
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_4])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.4')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.3.0'))
       end
       detector.refresh
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_4])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.4')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.3.1'))
       end
       detector.refresh
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_4])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.4')
     end
 
     it 'is valid only for 6.3.z versions' do
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_4])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.4')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.1.9'))
       end
       detector.refresh
-      refute_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_4])
+      refute_scenario({ :tags => :pre_upgrade_checks }, '6.4')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.4.1'))
       end
       detector.refresh
-      refute_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_4])
+      refute_scenario({ :tags => :pre_upgrade_checks }, '6.4')
 
       assume_feature_absent(:satellite)
       detector.refresh
-      refute_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_4])
+      refute_scenario({ :tags => :pre_upgrade_checks }, '6.4')
     end
 
     it 'composes the pre upgrade checks for migration from satellite 6.3.z to 6.4' do

--- a/test/definitions/scenarios/upgrade_satellite_6_4_z_test.rb
+++ b/test/definitions/scenarios/upgrade_satellite_6_4_z_test.rb
@@ -13,23 +13,23 @@ module Scenarios
     end
 
     let :scenario do
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_4_z])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.4.z')
     end
 
     it 'is valid for 6.4.0 and 6.4.z version' do
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_4_z])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.4.z')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.4.0'))
       end
       detector.refresh
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_4_z])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.4.z')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.4.1'))
       end
       detector.refresh
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_4_z])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.4.z')
     end
 
     it 'is valid only for 6.4.z versions' do
@@ -37,17 +37,17 @@ module Scenarios
         feature_class.any_instance.stubs(:current_version => version('6.4.1'))
       end
       detector.refresh
-      assert_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_4_z])
+      assert_scenario({ :tags => :pre_upgrade_checks }, '6.4.z')
 
       assume_satellite_present do |feature_class|
         feature_class.any_instance.stubs(:current_version => version('6.2.9'))
       end
       detector.refresh
-      refute_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_4_z])
+      refute_scenario({ :tags => :pre_upgrade_checks }, '6.4.z')
 
       assume_feature_absent(:satellite)
       detector.refresh
-      refute_scenario(:tags => [:pre_upgrade_checks, :upgrade_to_satellite_6_4_z])
+      refute_scenario({ :tags => :pre_upgrade_checks }, '6.4.z')
     end
 
     it 'composes the pre upgrade checks for migration from satellite 6.4.0 to 6.4.z' do

--- a/test/definitions/test_helper.rb
+++ b/test/definitions/test_helper.rb
@@ -79,17 +79,23 @@ module DefinitionsTestHelper
   # given the current feature assumptions (see assume_feature_present and
   # assume_feature_absent), assert the scenario with given filter is considered
   # present
-  def assert_scenario(filter)
-    scenario = find_scenarios(filter).first
+  def assert_scenario(filter, sat_version)
+    scenario = find_scenarios(filter).select(&matching_version_check(sat_version)).first
     assert scenario, "Expected the scenario #{filter} to be present"
     scenario
+  end
+
+  def matching_version_check(sat_version)
+    proc do |scenario|
+      scenario.respond_to?(:target_version) && scenario.target_version == sat_version
+    end
   end
 
   # given the current feature assumptions (see assume_feature_present and
   # assume_feature_absent), assert the scenario with given filter is considered
   # absent
-  def refute_scenario(filter)
-    scenario = find_scenarios(filter).first
+  def refute_scenario(filter, version)
+    scenario = find_scenarios(filter).select(&matching_version_check(version)).first
     refute scenario, "Expected the scenario #{filter} to be absent"
   end
 

--- a/test/definitions/test_helper.rb
+++ b/test/definitions/test_helper.rb
@@ -4,6 +4,7 @@ require File.expand_path('assume_feature_dependencies_helper', File.dirname(__FI
 module DefinitionsTestHelper
   include ForemanMaintain::Concerns::Finders
   include ForemanMaintain::Concerns::SystemService
+  include ForemanMaintain::Concerns::SystemHelpers
   include AssumeFeatureDependenciesHelper
 
   def detector

--- a/test/lib/support/definitions/scenarios/missing_upgrade.rb
+++ b/test/lib/support/definitions/scenarios/missing_upgrade.rb
@@ -17,5 +17,3 @@ module Scenarios::MissingUpgrade
     end
   end
 end
-
-# ForemanMaintain::UpgradeRunner.register_version('1.14', :missing_upgrade)

--- a/test/lib/support/definitions/scenarios/missing_upgrade.rb
+++ b/test/lib/support/definitions/scenarios/missing_upgrade.rb
@@ -1,10 +1,14 @@
 module Scenarios::MissingUpgrade
   class PreUpgradeChecks < ForemanMaintain::Scenario
     metadata do
-      tags :upgrade, :missing_upgrade, :pre_upgrade_checks
+      tags :upgrade, :missing_upgrade, :pre_upgrade_checks, :upgrade_scenario
       description 'missing_service upgrade scenario'
       confine do
         feature(:missing_service)
+      end
+
+      def target_version
+        '1.14'
       end
     end
 
@@ -14,4 +18,4 @@ module Scenarios::MissingUpgrade
   end
 end
 
-ForemanMaintain::UpgradeRunner.register_version('1.14', :missing_upgrade)
+# ForemanMaintain::UpgradeRunner.register_version('1.14', :missing_upgrade)

--- a/test/lib/support/definitions/scenarios/present_upgrade.rb
+++ b/test/lib/support/definitions/scenarios/present_upgrade.rb
@@ -2,12 +2,16 @@ module Scenarios::PresentUpgrade
   class PreUpgradeChecks < ForemanMaintain::Scenario
     metadata do
       description 'present_service pre_upgrade_checks scenario'
-      tags :upgrade, :present_upgrade, :pre_upgrade_checks
+      tags :upgrade, :present_upgrade, :pre_upgrade_checks, :upgrade_scenario
       run_strategy :fail_slow
 
       confine do
         feature(:present_service)
       end
+    end
+
+    def target_version
+      '1.15'
     end
 
     def compose
@@ -19,11 +23,15 @@ module Scenarios::PresentUpgrade
   class PreMigrations < ForemanMaintain::Scenario
     metadata do
       description 'present_service pre_migrations scenario'
-      tags :upgrade, :present_upgrade, :pre_migrations
+      tags :upgrade, :present_upgrade, :pre_migrations, :upgrade_scenario
 
       confine do
         feature(:present_service)
       end
+    end
+
+    def target_version
+      '1.15'
     end
 
     def compose
@@ -34,11 +42,15 @@ module Scenarios::PresentUpgrade
   class Migrations < ForemanMaintain::Scenario
     metadata do
       description 'present_service migrations scenario'
-      tags :upgrade, :present_upgrade, :migrations
+      tags :upgrade, :present_upgrade, :migrations, :upgrade_scenario
 
       confine do
         feature(:present_service)
       end
+    end
+
+    def target_version
+      '1.15'
     end
 
     def compose
@@ -49,11 +61,15 @@ module Scenarios::PresentUpgrade
   class PostMigrations < ForemanMaintain::Scenario
     metadata do
       description 'present_service post_migrations scenario'
-      tags :upgrade, :present_upgrade, :post_migrations
+      tags :upgrade, :present_upgrade, :post_migrations, :upgrade_scenario
 
       confine do
         feature(:present_service)
       end
+    end
+
+    def target_version
+      '1.15'
     end
 
     def compose
@@ -64,11 +80,15 @@ module Scenarios::PresentUpgrade
   class PostUpgradeChecks < ForemanMaintain::Scenario
     metadata do
       description 'present_service post_migrations scenario'
-      tags :upgrade, :present_upgrade, :post_upgrade_checks
+      tags :upgrade, :present_upgrade, :post_upgrade_checks, :upgrade_scenario
 
       confine do
         feature(:present_service)
       end
+    end
+
+    def target_version
+      '1.15'
     end
 
     def compose
@@ -77,4 +97,4 @@ module Scenarios::PresentUpgrade
   end
 end
 
-ForemanMaintain::UpgradeRunner.register_version('1.15', :present_upgrade)
+# ForemanMaintain::UpgradeRunner.register_version('1.15', :present_upgrade)

--- a/test/lib/support/definitions/scenarios/present_upgrade.rb
+++ b/test/lib/support/definitions/scenarios/present_upgrade.rb
@@ -96,5 +96,3 @@ module Scenarios::PresentUpgrade
     end
   end
 end
-
-# ForemanMaintain::UpgradeRunner.register_version('1.15', :present_upgrade)


### PR DESCRIPTION
This adds the scenario for Capsule upgrade and below are changes,

1. The performance check is already designed to run on drives for which corresponding directories are available, i.e if pgsql is not available on Capsule skip check for that. The description of check was generic. Its dynamic now to show spinner message for Capsule and Satellite.
2. The original asset check was not guarded to run on system which has foreman package installed, it has changed to avoid running it on Capsule.
3. The downstream concern now handles satellite-tools repo conditionally for Satellite and Capsule.
4. This PR changes the way to register scenarios for upgrade. New changes only allow either Satellite or Capsule scenarios to be registered for upgrade. The scenario registration logic is in one file instead of having it in every scenario file.