### PR TITLE
Fixes #28193 - Handle pulp3 services

### DIFF
--- a/definitions/checks/disk/performance.rb
+++ b/definitions/checks/disk/performance.rb
@@ -8,7 +8,7 @@ module Checks
         preparation_steps { Procedures::Packages::Install.new(:packages => %w[fio]) }
 
         confine do
-          feature(:pulp)
+          feature(:instance).pulp
         end
       end
 

--- a/definitions/features/foreman_proxy.rb
+++ b/definitions/features/foreman_proxy.rb
@@ -17,7 +17,7 @@ class Features::ForemanProxy < ForemanMaintain::Feature
   end
 
   def with_content?
-    !!feature(:pulp)
+    !!feature(:instance).pulp
   end
 
   def dhcpd_conf_exist?

--- a/definitions/features/instance.rb
+++ b/definitions/features/instance.rb
@@ -64,6 +64,10 @@ class Features::Instance < ForemanMaintain::Feature
     net
   end
 
+  def pulp
+    feature(:pulp2) || feature(:pulp3)
+  end
+
   private
 
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
@@ -137,8 +141,8 @@ class Features::Instance < ForemanMaintain::Feature
     {
       'candlepin_auth' => %w[candlepin candlepin_database],
       'candlepin' => %w[candlepin candlepin_database],
-      'pulp_auth' => %w[pulp mongo],
-      'pulp' => %w[pulp mongo],
+      'pulp_auth' => %w[pulp2 mongo],
+      'pulp' => %w[pulp2 mongo],
       'foreman_tasks' => %w[foreman_tasks]
     }
   end

--- a/definitions/features/mongo.rb
+++ b/definitions/features/mongo.rb
@@ -9,7 +9,7 @@ class Features::Mongo < ForemanMaintain::Feature
     label :mongo
 
     confine do
-      feature(:pulp)
+      feature(:pulp2)
     end
   end
 

--- a/definitions/features/pulp2.rb
+++ b/definitions/features/pulp2.rb
@@ -2,7 +2,7 @@ class Features::Pulp < ForemanMaintain::Feature
   include ForemanMaintain::Concerns::DirectoryMarker
 
   metadata do
-    label :pulp
+    label :pulp2
 
     confine do
       find_package('pulp-server')

--- a/definitions/features/pulp3.rb
+++ b/definitions/features/pulp3.rb
@@ -1,0 +1,22 @@
+require 'foreman_maintain/utils/service/systemd'
+
+class Features::Pulp3 < ForemanMaintain::Feature
+  metadata do
+    label :pulp3
+
+    confine do
+      ForemanMaintain::Utils::Service::Systemd.new('pulpcore-api', 0).exist?
+    end
+  end
+
+  def services
+    [
+      system_service('pulpcore-api', 10),
+      system_service('pulpcore-content', 10),
+      system_service('pulpcore-resource-manager', 10),
+      system_service('pulpcore-worker@*', 20, :all => true),
+      system_service('redis', 30),
+      system_service('httpd', 30)
+    ]
+  end
+end

--- a/definitions/features/pulp3.rb
+++ b/definitions/features/pulp3.rb
@@ -14,7 +14,7 @@ class Features::Pulp3 < ForemanMaintain::Feature
       system_service('pulpcore-api', 10),
       system_service('pulpcore-content', 10),
       system_service('pulpcore-resource-manager', 10),
-      system_service('pulpcore-worker@*', 20, :all => true),
+      system_service('pulpcore-worker@*', 20, :all => true, :skip_enablement => true),
       system_service('redis', 30),
       system_service('httpd', 30)
     ]

--- a/definitions/procedures/backup/pulp.rb
+++ b/definitions/procedures/backup/pulp.rb
@@ -3,7 +3,7 @@ module Procedures::Backup
     metadata do
       description 'Backup Pulp data'
       tags :backup
-      for_feature :pulp
+      for_feature :pulp2
       param :backup_dir, 'Directory where to backup to', :required => true
       param :tar_volume_size, 'Size of tar volume (indicates splitting)'
       param :ensure_unchanged, 'Ensure the data did not change during backup'
@@ -39,9 +39,9 @@ module Procedures::Backup
     end
 
     def pulp_dir
-      return feature(:pulp).data_dir if @mount_dir.nil?
+      return feature(:pulp2).data_dir if @mount_dir.nil?
       mount_point = File.join(@mount_dir, 'pulp')
-      dir = feature(:pulp).find_marked_directory(mount_point)
+      dir = feature(:pulp2).find_marked_directory(mount_point)
       unless dir
         raise ForemanMaintain::Error::Fail,
               "Pulp base directory not found in the mount point (#{mount_point})"

--- a/definitions/procedures/backup/snapshot/logical_volume_confirmation.rb
+++ b/definitions/procedures/backup/snapshot/logical_volume_confirmation.rb
@@ -12,7 +12,7 @@ module Procedures::Backup
         backup_lv = get_lv_info(@backup_dir)
 
         dbs = {}
-        dbs[:pulp] = 'Pulp' if feature(:pulp) && !@skip_pulp
+        dbs[:pulp] = 'Pulp' if feature(:pulp2) && !@skip_pulp
         dbs[:mongo] = 'Mongo' if db_local?(:mongo)
         dbs[:candlepin_database] = 'Candlepin' if db_local?(:candlepin_database)
         dbs[:foreman_database] = 'Foreman' if db_local?(:foreman_database)

--- a/definitions/procedures/backup/snapshot/mount_pulp.rb
+++ b/definitions/procedures/backup/snapshot/mount_pulp.rb
@@ -5,7 +5,7 @@ module Procedures::Backup
       metadata do
         description 'Create and mount snapshot of Pulp data'
         tags :backup
-        for_feature :pulp
+        for_feature :pulp2
         MountBase.common_params(self)
         param :skip, 'Skip Pulp content during backup'
       end
@@ -13,8 +13,8 @@ module Procedures::Backup
       def run
         skip if @skip
         with_spinner('Creating snapshot of Pulp') do |spinner|
-          feature(:pulp).with_marked_directory(feature(:pulp).data_dir) do
-            lv_info = get_lv_info(feature(:pulp).data_dir)
+          feature(:pulp2).with_marked_directory(feature(:pulp2).data_dir) do
+            lv_info = get_lv_info(feature(:pulp2).data_dir)
             create_lv_snapshot('pulp-snap', @block_size, lv_info[0])
             spinner.update("Mounting snapshot of Pulp on #{mount_location('pulp')}")
             mount_snapshot('pulp', lv_info[1])

--- a/definitions/procedures/pulp/migrate.rb
+++ b/definitions/procedures/pulp/migrate.rb
@@ -4,7 +4,7 @@ module Procedures::Pulp
 
     metadata do
       description 'Migrate pulp db'
-      for_feature :pulp
+      for_feature :pulp2
     end
 
     def run

--- a/definitions/procedures/restore/mongo_dump.rb
+++ b/definitions/procedures/restore/mongo_dump.rb
@@ -2,7 +2,7 @@ module Procedures::Restore
   class MongoDump < ForemanMaintain::Procedure
     metadata do
       description 'Restore mongo dump'
-      for_feature :pulp
+      for_feature :pulp2
       param :backup_dir,
             'Path to backup directory',
             :required => true
@@ -10,7 +10,7 @@ module Procedures::Restore
         [Checks::Mongo::DBUp.new, Checks::Mongo::ToolsInstalled.new]
       end
       confine do
-        feature(:mongo) && feature(:pulp)
+        feature(:mongo) && feature(:pulp2)
       end
     end
 

--- a/definitions/procedures/service/base.rb
+++ b/definitions/procedures/service/base.rb
@@ -15,7 +15,7 @@ module Procedures
 
       def run_service_action(action, options)
         action_noun = feature(:service).action_noun(action).capitalize
-        puts "#{action_noun} the following service(s):\n"
+        puts "\n#{action_noun} the following service(s):"
         services = feature(:service).filtered_services(options)
         print_services(services)
 

--- a/lib/foreman_maintain/utils/service/abstract.rb
+++ b/lib/foreman_maintain/utils/service/abstract.rb
@@ -4,9 +4,10 @@ module ForemanMaintain::Utils
       include Comparable
       attr_reader :name, :priority
 
-      def initialize(name, priority, _options = {})
+      def initialize(name, priority, options = {})
         @name = name
         @priority = priority
+        @options = options
       end
 
       def <=>(other)

--- a/lib/foreman_maintain/utils/service/systemd.rb
+++ b/lib/foreman_maintain/utils/service/systemd.rb
@@ -9,6 +9,12 @@ module ForemanMaintain::Utils
       def command(action, options = {})
         do_wait = options.fetch(:wait, true) # wait for service to start
         all = @options.fetch(:all, false)
+        skip_enablement = @options.fetch(:skip_enablement, false)
+
+        if skip_enablement && %w[enable disable].include?(action)
+          return skip_enablement_message(action, @name)
+        end
+
         if do_wait && File.exist?('/usr/sbin/service-wait')
           "service-wait #{@name} #{action}"
         else
@@ -55,6 +61,21 @@ module ForemanMaintain::Utils
 
       def execute(action, options = {})
         @sys.execute_with_status(command(action, options))
+      end
+
+      def skip_enablement_message(action, name)
+        # Enable and disable does not work well with globs since they treat them literally.
+        # We are skipping the pulpcore-workers@* for these actions until they are configured in
+        # a more managable way with systemd
+        # rubocop:disable Layout/IndentAssignment
+        msg =
+"
+\nWARNING: Skipping #{action} for #{name} as there are a variable amount of services to manage
+and this command will not respond to glob operators. These services have been configured by
+the installer and it is recommended to keep them enabled to prevent misconfiguration.\n
+"
+        # rubocop:enable Layout/IndentAssignment
+        puts msg
       end
     end
   end

--- a/lib/foreman_maintain/utils/service/systemd.rb
+++ b/lib/foreman_maintain/utils/service/systemd.rb
@@ -1,14 +1,14 @@
 module ForemanMaintain::Utils
   module Service
     class Systemd < Abstract
-      def initialize(name, priority, _options = {})
+      def initialize(name, priority, options = {})
         super
         @sys = SystemHelpers.new
       end
 
       def command(action, options = {})
         do_wait = options.fetch(:wait, true) # wait for service to start
-        all = options.fetch(:all, false)
+        all = @options.fetch(:all, false)
         if do_wait && File.exist?('/usr/sbin/service-wait')
           "service-wait #{@name} #{action}"
         else

--- a/lib/foreman_maintain/utils/service/systemd.rb
+++ b/lib/foreman_maintain/utils/service/systemd.rb
@@ -8,10 +8,13 @@ module ForemanMaintain::Utils
 
       def command(action, options = {})
         do_wait = options.fetch(:wait, true) # wait for service to start
+        all = options.fetch(:all, false)
         if do_wait && File.exist?('/usr/sbin/service-wait')
           "service-wait #{@name} #{action}"
         else
-          "systemctl #{action} #{@name}"
+          cmd = "systemctl #{action} #{@name}"
+          cmd += ' --all' if all
+          cmd
         end
       end
 

--- a/test/definitions/features/instance_test.rb
+++ b/test/definitions/features/instance_test.rb
@@ -164,7 +164,7 @@ describe Features::Instance do
       end
 
       it 'fails when some of the components fail' do
-        assume_feature_present(:pulp) do |feature_class|
+        assume_feature_present(:pulp2) do |feature_class|
           feature_class.any_instance.stubs(:services).returns(existing_httpd)
         end
         assume_feature_present(:mongo) do |feature_class|

--- a/test/lib/utils/service/systemd_test.rb
+++ b/test/lib/utils/service/systemd_test.rb
@@ -5,6 +5,9 @@ module ForemanMaintain
     let(:httpd_service) { ForemanMaintain::Utils::Service::Systemd.new('httpd', 30) }
     let(:crond_service) { ForemanMaintain::Utils::Service::Systemd.new('crond', 20) }
     let(:ntpd_service) { ForemanMaintain::Utils::Service::Systemd.new('ntpd', 10) }
+    let(:http_all_service) do
+      ForemanMaintain::Utils::Service::Systemd.new('http*', 30, :all => true)
+    end
 
     it 'has name' do
       httpd_service.name.must_equal 'httpd'
@@ -94,6 +97,12 @@ module ForemanMaintain
       disable_response = [0, '']
       httpd_service.stubs(:execute).with('disable', :wait => false).returns(disable_response)
       httpd_service.disable.must_equal disable_response
+    end
+
+    it 'starts service with --all' do
+      start_response = [0, '']
+      http_all_service.stubs(:execute).with('start').returns(start_response)
+      http_all_service.start.must_equal start_response
     end
 
     describe 'matches?' do


### PR DESCRIPTION
This adds the ability to handle pulp3 services. A service is used to determine if pulp3 is present as it currently does not run off rpm's in our environment. This could change to be based off an RPM later on when pulp3 is packaged and included with Katello. This also adds the ability to handle glob operators for services and optionally use the `--all` flag for systemctl