### PR TITLE
Fixes #28281 - no spinner on non-tty output

### DIFF
--- a/lib/foreman_maintain/reporter/cli_reporter.rb
+++ b/lib/foreman_maintain/reporter/cli_reporter.rb
@@ -16,7 +16,6 @@ module ForemanMaintain
           @spinner_chars = %w[| / - \\]
           @current_line = ''
           @puts_needed = false
-          start_spinner
         end
 
         def update(line)
@@ -42,8 +41,6 @@ module ForemanMaintain
           end
         end
 
-        private
-
         def start_spinner
           @thread = Thread.new do
             loop do
@@ -52,6 +49,8 @@ module ForemanMaintain
             end
           end
         end
+
+        private
 
         def spin
           @mutex.synchronize do
@@ -80,6 +79,7 @@ module ForemanMaintain
         @line_char = '-'
         @cell_char = '|'
         @spinner = Spinner.new(self)
+        @spinner.start_spinner if @stdout.tty?
         @last_line = ''
       end
 


### PR DESCRIPTION
When the tool is executed with redirected output (to a pipe or a file) the spinner thing makes thing terrible and unreadable. The process should detect if it's running a tty and then avoid spinning (e.g. when executed from cron).

Reproducer:

    foreman-maintain service status > /tmp/test.log

See the ^M characeters in the log file. If the action takes a lot of time (e.g. restart) there will be a lots of these.