### PR TITLE
Fixes #28337 - Move qpid backup to katello feature

### DIFF
--- a/definitions/features/katello.rb
+++ b/definitions/features/katello.rb
@@ -32,7 +32,11 @@ class Features::Katello < ForemanMaintain::Feature
       '/etc/sysconfig/tomcat*',
       '/etc/tomcat*',
       '/var/lib/candlepin',
-      '/usr/share/foreman/bundler.d/katello.rb'
+      '/usr/share/foreman/bundler.d/katello.rb',
+      '/etc/qpid',
+      '/etc/qpid-dispatch',
+      '/var/lib/qpidd',
+      '/etc/qpid-dispatch'
     ]
 
     if installer_scenario_answers['certs']

--- a/definitions/features/pulp.rb
+++ b/definitions/features/pulp.rb
@@ -30,12 +30,8 @@ class Features::Pulp < ForemanMaintain::Feature
     [
       '/etc/pki/pulp',
       '/etc/pulp',
-      '/etc/qpid',
-      '/etc/qpid-dispatch',
       '/etc/crane.conf',
-      '/etc/default/pulp_workers',
-      '/var/lib/qpidd',
-      '/etc/qpid-dispatch'
+      '/etc/default/pulp_workers'
     ]
   end
 end


### PR DESCRIPTION
@johnpmitsch here is the pr to fix the qpid issue that is causing sat-clone to fail.

@mbacovsky I moved qpid backup to katello instead of pulp. Should we put it in the Candlepin feature instead or is katello fine? Read more on the issue to see the reasoning. 