### PR TITLE
Fixes #28439 - update travis ruby versions & removed 1.8.7 config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: ruby
 sudo: false
 before_install: >-
-  if ruby -v | grep 'ruby 2.0';then
-    gem install bundler -v '~> 1.3'
+  if ruby -v | grep 'ruby 2.2'; then
+    gem install bundler -v '~> 1.17'
   fi
 rvm:
-  - 2.0.0
+  - 2.2.10
   - 2.3.3
+  - 2.5.3
+  - 2.6.0
 script:
   - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: ruby
 sudo: false
 before_install: >-
-  if ruby -v | grep 'ruby 2.2'; then
-    gem install bundler -v '~> 1.17'
+  if ruby -v | grep 'ruby 2.0';then
+    gem install bundler -v '~> 1.3'
   fi
 rvm:
-  - 2.2.10
+  - 2.0.0
   - 2.3.3
-  - 2.5.3
-  - 2.6.0
 script:
   - bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -8,13 +8,6 @@ if File.exist? "#{__FILE__}.local"
 end
 # rubocop:enable  Security/Eval
 
-if RUBY_VERSION <= '1.8.7'
-  gem 'json'
-end
-
 if RUBY_VERSION >= '2.0'
   gem 'rubocop', '0.50.0'
-else
-  gem 'clamp', '~> 0.6.2'
-  gem 'highline', '~> 1.6.21'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -18,12 +18,6 @@ namespace :test do
 end
 task :test => ['test:lib', 'test:definitions']
 
-if RUBY_VERSION >= '2.0'
-  # Latest ruobcop doesn't work with Ruby 1.8.7, but unless it let's us to
-  # write 1.8.7-compatible code, we are ok
-  require 'rubocop/rake_task'
-  RuboCop::RakeTask.new
-  task :default => [:rubocop, :test]
-else
-  task :default => [:test]
-end
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
+task :default => [:rubocop, :test]

--- a/foreman_maintain.gemspec
+++ b/foreman_maintain.gemspec
@@ -24,7 +24,6 @@ the Foreman/Satellite up and running."
   s.add_dependency 'clamp'
   s.add_dependency 'highline'
 
-  s.add_development_dependency 'bundler', '~> 1.3'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'rake', '< 11.0.0' # rake >= 11.0.0 drops support for ruby 1.8.7

--- a/foreman_maintain.gemspec
+++ b/foreman_maintain.gemspec
@@ -23,7 +23,7 @@ the Foreman/Satellite up and running."
 
   s.add_dependency 'clamp'
   s.add_dependency 'highline'
-
+  s.add_development_dependency 'bundler', '~> 1.3'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'rake', '< 11.0.0' # rake >= 11.0.0 drops support for ruby 1.8.7

--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -1,7 +1,3 @@
-if RUBY_VERSION <= '1.8.7'
-  require 'rubygems'
-end
-
 require 'forwardable'
 require 'json'
 require 'logger'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 require 'foreman_maintain'
 require 'minitest/spec'
 require 'minitest/autorun'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'stringio'
 require File.dirname(__FILE__) + '/support/minitest_spec_context'
 require File.expand_path('../lib/support/log_reporter', __FILE__)


### PR DESCRIPTION
@upadhyeammit,
I have updated ruby versions in travis. 
For Sat 6.4 upgrade scenario, I will confirm ruby version that is needed.