### PR TITLE
Fixes #28462 - Clean up qpid jrnl on restore

### DIFF
--- a/definitions/procedures/restore/configs.rb
+++ b/definitions/procedures/restore/configs.rb
@@ -14,6 +14,7 @@ module Procedures::Restore
         spinner.update('Restoring configs')
         clean_conflicting_data
         restore_configs(backup)
+        reset_qpid_jrnls
         reload_configs
       end
     end
@@ -44,6 +45,12 @@ module Procedures::Restore
     def clean_conflicting_data
       # tar is unable to --overwrite dir with symlink
       execute('rm -rf /usr/share/foreman-proxy/.ssh')
+    end
+
+    def reset_qpid_jrnls
+      # on restore without pulp data qpid fails to start
+      # https://access.redhat.com/solutions/4645231
+      execute('rm -rf /var/lib/qpidd/.qpidd/qls/dat2/__db.00*')
     end
   end
 end


### PR DESCRIPTION
This PR addresses an issue with restoring a satellite and qpid starting but not listening due to the jrnl files being corrupted.

I reached out to @pmoravec and this is the work-around for [BZ 1781386](https://bugzilla.redhat.com/show_bug.cgi?id=1781386)

Let me know if that looks correct @pmoravec I tested it here on a 6.6 satellite and the restore worked correctly and qpid started up correctly. 