### PR TITLE
Fixes #28473 - Use minitest

### DIFF
--- a/foreman_maintain.gemspec
+++ b/foreman_maintain.gemspec
@@ -24,7 +24,7 @@ the Foreman/Satellite up and running."
   s.add_dependency 'clamp'
   s.add_dependency 'highline'
 
-  s.add_development_dependency 'bundler', '~> 1.3'
+  s.add_development_dependency 'bundler', '>= 1.17'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'rake', '< 11.0.0' # rake >= 11.0.0 drops support for ruby 1.8.7

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 require 'foreman_maintain'
 require 'minitest/spec'
 require 'minitest/autorun'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'stringio'
 require File.dirname(__FILE__) + '/support/minitest_spec_context'
 require File.expand_path('../lib/support/log_reporter', __FILE__)


### PR DESCRIPTION
Changes:
  - As per mocha version change 'minitest' should be required instead of 'mini_test'
  - Bump bundler minimum version to 1.17
