### PR TITLE
Fixes #28517 - Whitelist virt-who package

### DIFF
--- a/extras/foreman_protector/foreman-protector.whitelist
+++ b/extras/foreman_protector/foreman-protector.whitelist
@@ -15,5 +15,6 @@ librdmacm
 rdma-core
 boost-random
 boost-iostreams
+virt-who
 # foreman-maintain
 rubygem-foreman_maintain


### PR DESCRIPTION
virt-who package should be whitelisted in the foreman-protector plugin
so that hammer virt-who-config procedure does not need package unlocking
to install virt-who.

Signed-off-by: Rohan Arora <roarora@redhat.com>