### PR TITLE
Adding content prepare procedure

### DIFF
--- a/definitions/procedures/content/prepare.rb
+++ b/definitions/procedures/content/prepare.rb
@@ -1,0 +1,12 @@
+module Procedures::Content
+  class Prepare < ForemanMaintain::Procedure
+    metadata do
+      description 'Prepare content for Pulp 3'
+      for_feature :pulp3
+    end
+
+    def run
+      execute!('foreman-rake katello:pulp3_migration')
+    end
+  end
+end


### PR DESCRIPTION
This adds a procedure to run a rake task to prepare for pulp3. This is part of a larger series of commands that will be used to help prepare for pulp3, more will be added later.

It can be run with `foreman-maintain advanced procedure run content-prepare`