### PR TITLE
Fixes #28562 - Fix fio deps issue

### DIFF
--- a/extras/foreman_protector/foreman-protector.whitelist
+++ b/extras/foreman_protector/foreman-protector.whitelist
@@ -15,5 +15,6 @@ librdmacm
 rdma-core
 boost-random
 boost-iostreams
+boost-thread
 # foreman-maintain
 rubygem-foreman_maintain


### PR DESCRIPTION
If Satellite/Capsule does not have foreman-discovery-image package installed the boost-thread package is missing on system. In this case installation of fio package fails because boost-thread is not whitelisted package. To avoid this situation added boost-thread package in whitelist.