### PR TITLE
Fixes #28579 - reload hammer cache in latest upgrade sat scenarios

### DIFF
--- a/definitions/procedures/hammer/reload_cache.rb
+++ b/definitions/procedures/hammer/reload_cache.rb
@@ -1,0 +1,15 @@
+module Procedures::Hammer
+  class ReloadCache < ForemanMaintain::Procedure
+    metadata do
+      advanced_run false
+      description 'Reload Hammer cache'
+      for_feature :hammer
+    end
+
+    def run
+      with_spinner('Reloading Hammer cache') do |_spinner|
+        feature(:hammer).run('--reload-cache')
+      end
+    end
+  end
+end

--- a/definitions/scenarios/upgrade_to_satellite_6_7.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_7.rb
@@ -59,6 +59,7 @@ module Scenarios::Satellite_6_7
 
     def compose
       add_step(Procedures::Service::Start.new)
+      add_step(Procedures::Hammer::ReloadCache.new)
       add_steps(find_procedures(:post_migrations))
     end
   end

--- a/definitions/scenarios/upgrade_to_satellite_6_7_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_7_z.rb
@@ -59,6 +59,7 @@ module Scenarios::Satellite_6_7_z
 
     def compose
       add_step(Procedures::Service::Start.new)
+      add_step(Procedures::Hammer::ReloadCache.new)
       add_steps(find_procedures(:post_migrations))
     end
   end


### PR DESCRIPTION
@jameerpathan111,

I have separated out two changes i.e hammer reload cache change and paused task check from #298. After discussion with @upadhyeammit, I have created this PR to track hammer reload cache change. It would be good if you test these changes manually instead of automation job. There are two scenarios to test:
- On old sat, enable hammer csv plugin and perform upgrade
- On old sat, no csv plugin is enabled then perform upgrade

Please share your observations with us.