### PR TITLE
Fixes #28649 - self upgrade foreman-maintain

### DIFF
--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -140,6 +140,18 @@ module ForemanMaintain
       logger.error "Invalid Storage label i.e #{label}. Error - #{e.message}"
     end
 
+    def perform_self_upgrade
+      puts 'Checking for new version of foreman-maintain...'
+      if ForemanMaintain.package_manager.update_available?('rubygem-foreman_maintain')
+        puts "\nUpdating rubygem-foreman_maintain package."
+        ForemanMaintain.package_manager.update('rubygem-foreman_maintain', :assumeyes => true)
+        puts "\nThe rubygem-foreman_maintain package successfully updated."\
+            "\nRe-run satellite-maintain or foreman-maintain with required options!"
+        exit 0
+      end
+      puts "Nothing to update, can't find new version of rubygem-foreman_maintain!"
+    end
+
     def upgrade_in_progress
       storage[:upgrade_target_version]
     end

--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -140,16 +140,26 @@ module ForemanMaintain
       logger.error "Invalid Storage label i.e #{label}. Error - #{e.message}"
     end
 
+    def pkg_and_cmd_name
+      instance_feature = ForemanMaintain.available_features(:label => :instance).first
+      if instance_feature.downstream
+        return %w[satellite-maintain satellite-maintain]
+      end
+
+      %w[rubygem-foreman_maintain foreman-maintain]
+    end
+
     def perform_self_upgrade
-      puts 'Checking for new version of foreman-maintain...'
+      package_name, command = pkg_and_cmd_name
+      puts "Checking for new version of #{package_name}..."
       if ForemanMaintain.package_manager.update_available?('rubygem-foreman_maintain')
-        puts "\nUpdating rubygem-foreman_maintain package."
+        puts "\nUpdating #{package_name} package."
         ForemanMaintain.package_manager.update('rubygem-foreman_maintain', :assumeyes => true)
-        puts "\nThe rubygem-foreman_maintain package successfully updated."\
-            "\nRe-run satellite-maintain or foreman-maintain with required options!"
+        puts "\nThe #{package_name} package successfully updated."\
+            "\nRe-run #{command} with required options!"
         exit 0
       end
-      puts "Nothing to update, can't find new version of rubygem-foreman_maintain!"
+      puts "Nothing to update, can't find new version of #{package_name}."
     end
 
     def upgrade_in_progress

--- a/lib/foreman_maintain/cli/upgrade_command.rb
+++ b/lib/foreman_maintain/cli/upgrade_command.rb
@@ -7,7 +7,7 @@ module ForemanMaintain
       end
 
       def self.disable_self_upgrade_option
-        option '--disable-self-upgrade', :flag, "Don't auto update rubygem-foreman_maintain",
+        option '--disable-self-upgrade', :flag, 'Disable foreman-maintain auto-upgrade',
                :default => false
       end
 
@@ -52,20 +52,6 @@ module ForemanMaintain
         target_versions.sort.each { |version| puts version }
       end
 
-      def self_upgrade
-        unless disable_self_upgrade?
-          puts 'Checking if new version of rubygem-foreman_maintain is available?'
-          if ForemanMaintain.package_manager.update_available?('rubygem-foreman_maintain')
-            puts "\nUpdating rubygem-foreman_maintain package."
-            ForemanMaintain.package_manager.update('rubygem-foreman_maintain', :assumeyes => true)
-            puts "\nThe rubygem-foreman_maintain package successfully updated."\
-                "\nRe-run satellite-maintain or foreman-maintain with required options!"
-            exit 0
-          end
-          puts "Nothing to update, can't find new version of rubygem-foreman_maintain!"
-        end
-      end
-
       subcommand 'list-versions', 'List versions this system is upgradable to' do
         def execute
           print_versions(UpgradeRunner.available_targets)
@@ -78,7 +64,7 @@ module ForemanMaintain
         disable_self_upgrade_option
 
         def execute
-          self_upgrade
+          ForemanMaintain.perform_self_upgrade unless disable_self_upgrade?
           upgrade_runner.run_phase(:pre_upgrade_checks)
           exit upgrade_runner.exit_code
         end
@@ -97,7 +83,7 @@ module ForemanMaintain
         end
 
         def execute
-          self_upgrade
+          ForemanMaintain.perform_self_upgrade unless disable_self_upgrade?
           if phase
             upgrade_runner.run_phase(phase.to_sym)
           else

--- a/lib/foreman_maintain/cli/upgrade_command.rb
+++ b/lib/foreman_maintain/cli/upgrade_command.rb
@@ -7,7 +7,7 @@ module ForemanMaintain
       end
 
       def self.disable_self_upgrade_option
-        option '--disable-self-upgrade', :flag, 'Disable foreman-maintain auto-upgrade',
+        option '--disable-self-upgrade', :flag, 'Disable automatic self upgrade',
                :default => false
       end
 

--- a/lib/foreman_maintain/package_manager/yum.rb
+++ b/lib/foreman_maintain/package_manager/yum.rb
@@ -63,9 +63,7 @@ module ForemanMaintain::PackageManager
 
     def update_available?(package)
       cmd_output = yum_action('check-update -q', package, :with_status => true, :assumeyes => false)
-      return true if cmd_output[0] == 100
-
-      false
+      cmd_output[0] == 100
     end
 
     def files_not_owned_by_package(directory)
@@ -109,12 +107,12 @@ module ForemanMaintain::PackageManager
       yum_options << '-y' if assumeyes
       yum_options_s = yum_options.empty? ? '' : ' ' + yum_options.join(' ')
       packages_s = packages.empty? ? '' : ' ' + packages.join(' ')
-      if !with_status
-        sys.execute!("yum#{yum_options_s} #{action}#{packages_s}",
-                     :interactive => true)
-      else
+      if with_status
         sys.execute_with_status("yum#{yum_options_s} #{action}#{packages_s}",
                                 :interactive => true)
+      else
+        sys.execute!("yum#{yum_options_s} #{action}#{packages_s}",
+                     :interactive => true)
       end
     end
 

--- a/test/lib/cli/upgrade_command_test.rb
+++ b/test/lib/cli/upgrade_command_test.rb
@@ -46,7 +46,7 @@ module ForemanMaintain
 
     describe 'check' do
       let :command do
-        %w[upgrade check]
+        %w[upgrade check --disable-self-upgrade]
       end
 
       it 'runs the upgrade checks for version' do
@@ -63,7 +63,7 @@ module ForemanMaintain
 
     describe 'run' do
       let :command do
-        %w[upgrade run]
+        %w[upgrade run --disable-self-upgrade]
       end
 
       it 'runs the full upgrade for version' do
@@ -73,7 +73,6 @@ module ForemanMaintain
 
       it 'remembers the current target version' do
         Cli::MainCommand.any_instance.expects(:exit!)
-
         assert_cmd <<-OUTPUT.strip_heredoc
           --target-version not specified
           Possible target versions are:


### PR DESCRIPTION
This adds functionality to auto upgrade foreman-maintain, 

1. The auto upgrade happens only when using upgrade command with check and run options. This is to avoid calling upgrade every time foreman-maintain is being used. i.e to restart services.
2. This introduces a new method update_available? for Yum Class. This method accepts a package name as argument and returns true if update is available for same.
3. New flag for check and run command, which is '--disable-self-upgrade' . One can disable the auto upgrade using this.