### PR TITLE
Fixes #28674 - whitelist covering virt-who

### DIFF
--- a/extras/foreman_protector/foreman-protector.whitelist
+++ b/extras/foreman_protector/foreman-protector.whitelist
@@ -18,3 +18,8 @@ boost-iostreams
 boost-thread
 # foreman-maintain
 rubygem-foreman_maintain
+# virt-who
+virt-who
+python-suds
+libvirt-python
+systemd-python


### PR DESCRIPTION
whitelist covering virt-who in order to `hammer deploy` works correctly.