### PR TITLE
Fixes #28673 - Add SCL redis service name

### DIFF
--- a/definitions/features/pulp3.rb
+++ b/definitions/features/pulp3.rb
@@ -15,7 +15,7 @@ class Features::Pulp3 < ForemanMaintain::Feature
       system_service('pulpcore-content', 10),
       system_service('pulpcore-resource-manager', 10),
       system_service('pulpcore-worker@*', 20, :all => true, :skip_enablement => true),
-      system_service('redis', 30),
+      system_service('rh-redis5-redis', 30),
       system_service('httpd', 30)
     ]
   end


### PR DESCRIPTION
In production we will use redis from the Red Hat SCL. This commit adds this service to the pulp3 feature.