### PR TITLE
Fixes #28500 - Pulp 3 backup/restore

### DIFF
--- a/definitions/checks/pulpcore/db_up.rb
+++ b/definitions/checks/pulpcore/db_up.rb
@@ -1,0 +1,29 @@
+module Checks
+  module Pulpcore
+    class DBUp < ForemanMaintain::Check
+      metadata do
+        description 'Make sure Pulpcore DB is up'
+        label :pulpcore_db_up
+        for_feature :pulpcore_database
+      end
+
+      def run
+        status = false
+        with_spinner('Checking connection to the Pulpcore DB') do
+          status = feature(:pulpcore_database).ping
+        end
+        assert(status, 'Pulpcore DB is not responding. ' \
+          'It needs to be up and running to perform the following steps',
+               :next_steps => next_steps)
+      end
+
+      def next_steps
+        if feature(:pulpcore_database).local?
+          [Procedures::Service::Start.new(:only => 'postgresql')]
+        else
+          [] # there is nothing we can do for remote db
+        end
+      end
+    end
+  end
+end

--- a/definitions/features/foreman_database.rb
+++ b/definitions/features/foreman_database.rb
@@ -16,9 +16,11 @@ class Features::ForemanDatabase < ForemanMaintain::Feature
   end
 
   def config_files
-    [
-      '/var/lib/pgsql/data/postgresql.conf'
-    ]
+    if check_min_version('foreman', '1.25')
+      ['/var/opt/rh/rh-postgresql10/lib/pgsql/data/postgresql.conf']
+    else
+      ['/var/lib/pgsql/data/postgresql.conf']
+    end
   end
 
   def services

--- a/definitions/features/instance.rb
+++ b/definitions/features/instance.rb
@@ -37,7 +37,9 @@ class Features::Instance < ForemanMaintain::Feature
   end
 
   def postgresql_local?
-    database_local?(:candlepin_database) || database_local?(:foreman_database)
+    database_local?(:candlepin_database) ||
+      database_local?(:foreman_database) ||
+      database_local?(:pulpcore_database)
   end
 
   def foreman_proxy_with_content?
@@ -65,7 +67,7 @@ class Features::Instance < ForemanMaintain::Feature
   end
 
   def pulp
-    feature(:pulp2) || feature(:pulp3)
+    feature(:pulp2) || feature(:pulpcore)
   end
 
   private
@@ -143,6 +145,7 @@ class Features::Instance < ForemanMaintain::Feature
       'candlepin' => %w[candlepin candlepin_database],
       'pulp_auth' => %w[pulp2 mongo],
       'pulp' => %w[pulp2 mongo],
+      'pulpcore' => %w[pulpcore pulpcore_database],
       'foreman_tasks' => %w[foreman_tasks]
     }
   end

--- a/definitions/features/pulpcore.rb
+++ b/definitions/features/pulpcore.rb
@@ -1,8 +1,8 @@
 require 'foreman_maintain/utils/service/systemd'
 
-class Features::Pulp3 < ForemanMaintain::Feature
+class Features::Pulpcore < ForemanMaintain::Feature
   metadata do
-    label :pulp3
+    label :pulpcore
 
     confine do
       ForemanMaintain::Utils::Service::Systemd.new('pulpcore-api', 0).exist?
@@ -17,6 +17,12 @@ class Features::Pulp3 < ForemanMaintain::Feature
       system_service('pulpcore-worker@*', 20, :all => true, :skip_enablement => true),
       system_service('rh-redis5-redis', 30),
       system_service('httpd', 30)
+    ]
+  end
+
+  def config_files
+    [
+      '/etc/pulp/settings.py'
     ]
   end
 end

--- a/definitions/features/pulpcore_database.rb
+++ b/definitions/features/pulpcore_database.rb
@@ -1,0 +1,39 @@
+class Features::PulpcoreDatabase < ForemanMaintain::Feature
+  PULPCORE_DB_CONFIG = '/etc/pulp/settings.py'.freeze
+
+  include ForemanMaintain::Concerns::BaseDatabase
+
+  metadata do
+    label :pulpcore_database
+
+    confine do
+      file_nonzero?(PULPCORE_DB_CONFIG)
+    end
+  end
+
+  def configuration
+    @configuration || load_configuration
+  end
+
+  def services
+    [
+      system_service('postgresql', 10, :component => 'pulpcore',
+                                       :db_feature => feature(:pulpcore_database))
+    ]
+  end
+
+  private
+
+  def load_configuration
+    full_config = File.read(PULPCORE_DB_CONFIG).split(/[\s,':]/).reject(&:empty?)
+
+    @configuration = {}
+    @configuration['adapter'] = 'postgresql'
+    @configuration['host'] = full_config[full_config.index('HOST') + 1]
+    @configuration['port'] = full_config[full_config.index('PORT') + 1]
+    @configuration['database'] = full_config[full_config.index('NAME') + 1]
+    @configuration['username'] = full_config[full_config.index('USER') + 1]
+    @configuration['password'] = full_config[full_config.index('PASSWORD') + 1]
+    @configuration
+  end
+end

--- a/definitions/procedures/backup/offline/pulpcore_db.rb
+++ b/definitions/procedures/backup/offline/pulpcore_db.rb
@@ -1,0 +1,57 @@
+module Procedures::Backup
+  module Offline
+    class PulpcoreDB < ForemanMaintain::Procedure
+      metadata do
+        description 'Backup Pulpcore DB offline'
+        tags :backup
+        label :backup_offline_pulpcore_db
+        for_feature :pulpcore_database
+        preparation_steps { Checks::Pulpcore::DBUp.new unless feature(:pulpcore_database).local? }
+        param :backup_dir, 'Directory where to backup to', :required => true
+        param :tar_volume_size, 'Size of tar volume (indicates splitting)'
+        param :mount_dir, 'Snapshot mount directory'
+      end
+
+      def run
+        if feature(:pulpcore_database).local?
+          if File.exist?(pg_backup_file)
+            puts 'Already done'
+          else
+            local_backup
+          end
+        else
+          puts "Backup of #{pg_data_dir} is not supported for remote databases." \
+            ' Doing postgres dump instead...'
+          with_spinner('Getting Pulpcore DB dump') do
+            feature(:pulpcore_database).dump_db(File.join(@backup_dir, 'pulpcore.dump'))
+          end
+        end
+      end
+
+      private
+
+      def local_backup
+        with_spinner("Collecting data from #{pg_data_dir}") do
+          feature(:pulpcore_database).backup_local(
+            pg_backup_file,
+            :listed_incremental => File.join(@backup_dir, '.postgres.snar'),
+            :volume_size => @tar_volume_size,
+            :data_dir => pg_data_dir
+          )
+        end
+      end
+
+      def pg_backup_file
+        File.join(@backup_dir, 'pgsql_data.tar')
+      end
+
+      def pg_data_dir
+        return feature(:pulpcore_database).data_dir if @mount_dir.nil?
+        mount_point = File.join(@mount_dir, 'pgsql')
+        dir = feature(:pulpcore_database).find_base_directory(mount_point)
+        fail!("Snapshot of Pulpcore DB was not found mounted in #{mount_point}") if dir.nil?
+        dir
+      end
+    end
+  end
+end

--- a/definitions/procedures/backup/online/pulpcore_db.rb
+++ b/definitions/procedures/backup/online/pulpcore_db.rb
@@ -1,0 +1,20 @@
+module Procedures::Backup
+  module Online
+    class PulpcoreDB < ForemanMaintain::Procedure
+      metadata do
+        description 'Backup Pulpcore database online'
+        tags :backup
+        label :backup_online_pulpcore_db
+        for_feature :pulpcore_database
+        preparation_steps { Checks::Pulpcore::DBUp.new }
+        param :backup_dir, 'Directory where to backup to', :required => true
+      end
+
+      def run
+        with_spinner('Getting Pulpcore DB dump') do
+          feature(:pulpcore_database).dump_db(File.join(@backup_dir, 'pulpcore.dump'))
+        end
+      end
+    end
+  end
+end

--- a/definitions/procedures/backup/snapshot/logical_volume_confirmation.rb
+++ b/definitions/procedures/backup/snapshot/logical_volume_confirmation.rb
@@ -16,6 +16,7 @@ module Procedures::Backup
         dbs[:mongo] = 'Mongo' if db_local?(:mongo)
         dbs[:candlepin_database] = 'Candlepin' if db_local?(:candlepin_database)
         dbs[:foreman_database] = 'Foreman' if db_local?(:foreman_database)
+        dbs[:pulpcore_database] = 'Pulpcore' if db_local?(:pulpcore_database)
 
         shared_lv = dbs.inject([]) do |list, (db_label, db_name)|
           db_lv = get_lv_info(feature(db_label).data_dir)

--- a/definitions/procedures/backup/snapshot/mount_pulpcore_db.rb
+++ b/definitions/procedures/backup/snapshot/mount_pulpcore_db.rb
@@ -1,0 +1,48 @@
+require 'procedures/backup/snapshot/mount_base'
+module Procedures::Backup
+  module Snapshot
+    class MountPulpcoreDB < MountBase
+      metadata do
+        description 'Create and mount snapshot of Pulpcore DB'
+        tags :backup
+        label :backup_snapshot_mount_pulpcore_db
+        for_feature :pulpcore_database
+        preparation_steps { Checks::Pulpcore::DBUp.new unless feature(:pulpcore_database).local? }
+        MountBase.common_params(self)
+        param :backup_dir, 'Directory where to backup to'
+      end
+
+      def run
+        if feature(:pulpcore_database).local?
+          snapshot
+        else
+          dump_pulpcore
+        end
+      end
+
+      private
+
+      def dump_pulpcore
+        puts 'LV snapshots are not supported for remote databases. Doing postgres dump instead... '
+        with_spinner('Getting Pulpcore DB dump') do
+          feature(:pulpcore_database).dump_db(File.join(@backup_dir, 'pulpcore.dump'))
+        end
+      end
+
+      def snapshot
+        mount_point = mount_location('pgsql')
+        FileUtils.mkdir_p(mount_point) unless File.directory?(mount_point)
+        if directory_empty?(mount_point)
+          with_spinner('Creating snapshot of Postgres') do |spinner|
+            lv_info = get_lv_info(feature(:pulpcore_database).data_dir)
+            create_lv_snapshot('pgsql-snap', @block_size, lv_info[0])
+            spinner.update("Mounting snapshot of Postgres on #{mount_point}")
+            mount_snapshot('pgsql', lv_info[1])
+          end
+        else
+          puts 'Snapshot of Postgres is already mounted'
+        end
+      end
+    end
+  end
+end

--- a/definitions/procedures/content/prepare.rb
+++ b/definitions/procedures/content/prepare.rb
@@ -2,7 +2,7 @@ module Procedures::Content
   class Prepare < ForemanMaintain::Procedure
     metadata do
       description 'Prepare content for Pulp 3'
-      for_feature :pulp3
+      for_feature :pulpcore
     end
 
     def run

--- a/definitions/procedures/pulpcore/migrate.rb
+++ b/definitions/procedures/pulpcore/migrate.rb
@@ -1,0 +1,25 @@
+module Procedures::Pulpcore
+  class Migrate < ForemanMaintain::Procedure
+    include ForemanMaintain::Concerns::SystemService
+
+    metadata do
+      description 'Migrate pulpcore db'
+      for_feature :pulpcore
+    end
+
+    def run
+      with_spinner('Migrating pulpcore') do |spinner|
+        necessary_services = feature(:pulpcore_database).services
+        pulp_services = feature(:pulpcore).services
+
+        feature(:service).handle_services(spinner, 'start', :only => necessary_services)
+        feature(:service).handle_services(spinner, 'stop', :only => pulp_services)
+
+        spinner.update('Migrating pulpcore database')
+        execute!('sudo PULP_SETTINGS=/etc/pulp/settings.py '\
+          'DJANGO_SETTINGS_MODULE=pulpcore.app.settings '\
+          'python3-django-admin migrate --noinput')
+      end
+    end
+  end
+end

--- a/definitions/procedures/restore/drop_databases.rb
+++ b/definitions/procedures/restore/drop_databases.rb
@@ -8,7 +8,7 @@ module Procedures::Restore
             :required => true
 
       confine do
-        feature(:foreman_database) || feature(:candlepin_database)
+        feature(:foreman_database) || feature(:candlepin_database) || feature(:pulpcore_database)
       end
     end
 
@@ -19,6 +19,9 @@ module Procedures::Restore
         feature(:service).handle_services(spinner, 'start', :only => ['postgresql'])
         drop_foreman(backup, spinner)
         drop_candlepin(backup, spinner)
+        if feature(:pulpcore)
+          drop_pulpcore(backup, spinner)
+        end
       end
     end
 
@@ -33,6 +36,13 @@ module Procedures::Restore
       if backup.file_map[:candlepin_dump][:present]
         spinner.update('Dropping candlepin database')
         feature(:candlepin_database).dropdb
+      end
+    end
+
+    def drop_pulpcore(backup, spinner)
+      if backup.file_map[:pulpcore_dump][:present]
+        spinner.update('Dropping pulpcore database')
+        feature(:pulpcore_database).dropdb
       end
     end
   end

--- a/definitions/procedures/restore/pulpcore_dump.rb
+++ b/definitions/procedures/restore/pulpcore_dump.rb
@@ -1,0 +1,30 @@
+module Procedures::Restore
+  class PulpcoreDump < ForemanMaintain::Procedure
+    metadata do
+      description 'Restore pulpcore postgresql dump from backup'
+      param :backup_dir,
+            'Path to backup directory',
+            :required => true
+      preparation_steps { Checks::Pulpcore::DBUp.new }
+      confine do
+        feature(:pulpcore_database)
+      end
+    end
+
+    def run
+      backup = ForemanMaintain::Utils::Backup.new(@backup_dir)
+
+      with_spinner('Restoring pulpcore postgresql dump') do |spinner|
+        restore_pulpcore_dump(backup, spinner)
+      end
+    end
+
+    def restore_pulpcore_dump(backup, spinner)
+      if backup.file_map[:pulpcore_dump][:present]
+        spinner.update('Restoring pulpcore dump')
+        local = feature(:pulpcore_database).local?
+        feature(:pulpcore_database).restore_dump(backup.file_map[:pulpcore_dump][:path], local)
+      end
+    end
+  end
+end

--- a/definitions/scenarios/backup.rb
+++ b/definitions/scenarios/backup.rb
@@ -51,12 +51,15 @@ module ForemanMaintain::Scenarios
                   Procedures::Backup::Online::PgGlobalObjects => :backup_dir,
                   Procedures::Backup::Online::CandlepinDB => :backup_dir,
                   Procedures::Backup::Online::ForemanDB => :backup_dir,
+                  Procedures::Backup::Online::PulpcoreDB => :backup_dir,
                   Procedures::Backup::Offline::CandlepinDB => :backup_dir,
                   Procedures::Backup::Offline::ForemanDB => :backup_dir,
+                  Procedures::Backup::Offline::PulpcoreDB => :backup_dir,
                   Procedures::Backup::Offline::Mongo => :backup_dir,
                   Procedures::Backup::Snapshot::LogicalVolumeConfirmation => :backup_dir,
                   Procedures::Backup::Snapshot::MountCandlepinDB => :backup_dir,
                   Procedures::Backup::Snapshot::MountForemanDB => :backup_dir,
+                  Procedures::Backup::Snapshot::MountPulpcoreDB => :backup_dir,
                   Procedures::Backup::Snapshot::MountMongo => :backup_dir)
       context.map(:preserve_dir,
                   Checks::Backup::DirectoryReady => :preserve_dir,
@@ -73,15 +76,18 @@ module ForemanMaintain::Scenarios
                   Procedures::Backup::Snapshot::CleanMount => :mount_dir,
                   Procedures::Backup::Snapshot::MountCandlepinDB => :mount_dir,
                   Procedures::Backup::Snapshot::MountForemanDB => :mount_dir,
+                  Procedures::Backup::Snapshot::MountPulpcoreDB => :mount_dir,
                   Procedures::Backup::Offline::Mongo => :mount_dir,
                   Procedures::Backup::Pulp => :mount_dir,
                   Procedures::Backup::Offline::CandlepinDB => :mount_dir,
-                  Procedures::Backup::Offline::ForemanDB => :mount_dir)
+                  Procedures::Backup::Offline::ForemanDB => :mount_dir,
+                  Procedures::Backup::Offline::PulpcoreDB => :mount_dir)
       context.map(:snapshot_block_size,
                   Procedures::Backup::Snapshot::MountMongo => :block_size,
                   Procedures::Backup::Snapshot::MountPulp => :block_size,
                   Procedures::Backup::Snapshot::MountForemanDB => :block_size,
-                  Procedures::Backup::Snapshot::MountCandlepinDB => :block_size)
+                  Procedures::Backup::Snapshot::MountCandlepinDB => :block_size,
+                  Procedures::Backup::Snapshot::MountPulpcoreDB => :block_size)
       context.map(:skip_pulp_content,
                   Procedures::Backup::Pulp => :skip,
                   Procedures::Backup::Snapshot::LogicalVolumeConfirmation => :skip_pulp,
@@ -135,6 +141,7 @@ module ForemanMaintain::Scenarios
         Procedures::Backup::Offline::Mongo,
         Procedures::Backup::Offline::CandlepinDB,
         Procedures::Backup::Offline::ForemanDB,
+        Procedures::Backup::Offline::PulpcoreDB,
         Procedures::Service::Start,
         find_procedures(:maintenance_mode_off)
       )
@@ -149,6 +156,9 @@ module ForemanMaintain::Scenarios
       end
       if feature(:instance).database_local?(:foreman_database)
         add_step_with_context(Procedures::Backup::Online::ForemanDB)
+      end
+      if feature(:instance).database_local?(:pulpcore_database)
+        add_step_with_context(Procedures::Backup::Online::PulpcoreDB)
       end
       if feature(:instance).database_local?(:mongo)
         add_step_with_context(Procedures::Backup::Online::Mongo)
@@ -168,6 +178,7 @@ module ForemanMaintain::Scenarios
         Procedures::Backup::Snapshot::MountPulp,
         Procedures::Backup::Snapshot::MountCandlepinDB,
         Procedures::Backup::Snapshot::MountForemanDB,
+        Procedures::Backup::Snapshot::MountPulpcoreDB,
         Procedures::Service::Start,
         find_procedures(:maintenance_mode_off),
         Procedures::Backup::Pulp
@@ -177,6 +188,9 @@ module ForemanMaintain::Scenarios
       end
       if feature(:instance).database_local?(:foreman_database)
         add_step_with_context(Procedures::Backup::Offline::ForemanDB)
+      end
+      if feature(:instance).database_local?(:pulpcore_database)
+        add_step_with_context(Procedures::Backup::Offline::PulpcoreDB)
       end
       if feature(:instance).database_local?(:mongo)
         add_step_with_context(Procedures::Backup::Offline::Mongo)
@@ -192,7 +206,8 @@ module ForemanMaintain::Scenarios
         Procedures::Backup::Online::Mongo,
         Procedures::Backup::Online::PgGlobalObjects,
         Procedures::Backup::Online::CandlepinDB,
-        Procedures::Backup::Online::ForemanDB
+        Procedures::Backup::Online::ForemanDB,
+        Procedures::Backup::Online::PulpcoreDB
       )
     end
 

--- a/definitions/scenarios/restore.rb
+++ b/definitions/scenarios/restore.rb
@@ -36,6 +36,7 @@ module ForemanMaintain::Scenarios
       end
       restore_mongo_dump(backup)
       add_steps_with_context(Procedures::Pulp::Migrate,
+                             Procedures::Pulpcore::Migrate,
                              Procedures::Service::Start,
                              Procedures::Service::DaemonReload)
     end
@@ -43,7 +44,8 @@ module ForemanMaintain::Scenarios
 
     def drop_dbs(backup)
       if backup.file_map[:candlepin_dump][:present] ||
-         backup.file_map[:foreman_dump][:present]
+         backup.file_map[:foreman_dump][:present] ||
+         (feature(:pulpcore) && backup.file_map[:pulpcore_dump][:present])
         add_steps_with_context(Procedures::Restore::DropDatabases)
       end
     end
@@ -57,6 +59,9 @@ module ForemanMaintain::Scenarios
       end
       if backup.file_map[:foreman_dump][:present]
         add_steps_with_context(Procedures::Restore::ForemanDump)
+      end
+      if feature(:pulpcore) && backup.file_map[:pulpcore_dump][:present]
+        add_steps_with_context(Procedures::Restore::PulpcoreDump)
       end
     end
 
@@ -83,6 +88,7 @@ module ForemanMaintain::Scenarios
                   Procedures::Restore::PgGlobalObjects => :backup_dir,
                   Procedures::Restore::CandlepinDump => :backup_dir,
                   Procedures::Restore::ForemanDump => :backup_dir,
+                  Procedures::Restore::PulpcoreDump => :backup_dir,
                   Procedures::Restore::ExtractFiles => :backup_dir,
                   Procedures::Restore::MongoDump => :backup_dir)
 

--- a/lib/foreman_maintain/concerns/base_database.rb
+++ b/lib/foreman_maintain/concerns/base_database.rb
@@ -2,7 +2,11 @@ module ForemanMaintain
   module Concerns
     module BaseDatabase
       def data_dir
-        '/var/lib/pgsql/data/'
+        if check_min_version('foreman', '1.25')
+          '/var/opt/rh/rh-postgresql10/lib/pgsql/data/'
+        else
+          '/var/lib/pgsql/data/'
+        end
       end
 
       def configuration

--- a/test/lib/utils/backup_test.rb
+++ b/test/lib/utils/backup_test.rb
@@ -40,6 +40,7 @@ module ForemanMaintain
     end
 
     it 'Validates katello standard backup' do
+      ForemanMaintain.detector.stubs(:feature).with(:pulpcore).returns(true)
       kat_stand_backup = subject.new(katello_standard)
       assert kat_stand_backup.katello_standard_backup?
       assert !kat_stand_backup.katello_online_backup?
@@ -53,6 +54,7 @@ module ForemanMaintain
     end
 
     it 'Validates katello online backup' do
+      ForemanMaintain.detector.stubs(:feature).with(:pulpcore).returns(true)
       kat_online_backup = subject.new(katello_online)
       assert !kat_online_backup.katello_standard_backup?
       assert kat_online_backup.katello_online_backup?
@@ -66,6 +68,7 @@ module ForemanMaintain
     end
 
     it 'Validates katello logical backup' do
+      ForemanMaintain.detector.stubs(:feature).with(:pulpcore).returns(true)
       kat_logical_backup = subject.new(katello_logical)
       assert !kat_logical_backup.katello_standard_backup?
       assert !kat_logical_backup.katello_online_backup?
@@ -79,6 +82,7 @@ module ForemanMaintain
     end
 
     it 'Validates foreman standard backup' do
+      ForemanMaintain.detector.stubs(:feature).with(:pulpcore).returns(true)
       foreman_standard_backup = subject.new(foreman_standard)
       assert !foreman_standard_backup.katello_standard_backup?
       assert !foreman_standard_backup.katello_online_backup?
@@ -92,6 +96,7 @@ module ForemanMaintain
     end
 
     it 'Validates foreman online backup' do
+      ForemanMaintain.detector.stubs(:feature).with(:pulpcore).returns(true)
       foreman_online_backup = subject.new(foreman_online)
       assert !foreman_online_backup.katello_standard_backup?
       assert !foreman_online_backup.katello_online_backup?
@@ -105,6 +110,7 @@ module ForemanMaintain
     end
 
     it 'Validates foreman logical backup' do
+      ForemanMaintain.detector.stubs(:feature).with(:pulpcore).returns(true)
       foreman_logical_backup = subject.new(foreman_logical)
       assert !foreman_logical_backup.katello_standard_backup?
       assert !foreman_logical_backup.katello_online_backup?
@@ -118,6 +124,7 @@ module ForemanMaintain
     end
 
     it 'Validates fpc standard backup' do
+      ForemanMaintain.detector.stubs(:feature).with(:pulpcore).returns(true)
       fpc_standard_backup = subject.new(fpc_standard)
       assert !fpc_standard_backup.katello_standard_backup?
       assert !fpc_standard_backup.katello_online_backup?
@@ -131,6 +138,7 @@ module ForemanMaintain
     end
 
     it 'Validates fpc online backup' do
+      ForemanMaintain.detector.stubs(:feature).with(:pulpcore).returns(true)
       fpc_online_backup = subject.new(fpc_online)
       assert !fpc_online_backup.katello_standard_backup?
       assert !fpc_online_backup.katello_online_backup?
@@ -144,6 +152,7 @@ module ForemanMaintain
     end
 
     it 'Validates fpc logical backup' do
+      ForemanMaintain.detector.stubs(:feature).with(:pulpcore).returns(true)
       fpc_logical_backup = subject.new(fpc_logical)
       assert !fpc_logical_backup.katello_standard_backup?
       assert !fpc_logical_backup.katello_online_backup?


### PR DESCRIPTION
This adds backup and restore support for Pulpcore (Pulp 3).

One question I still have is how to tell which `pgsql` folder to use for the `data_dir`.  Is it okay to assume to use the PostgreSQL 10 folder if PostgreSQL is installed?  There's a few ways I can check, either by checking the package, the existence of the postgres config file, or by reading the output of `postgres -V`.  I have the middle option commented out and the last option applied currently.

I've tested `online` and `offline` backups and restoring.  `snapshot` backups don't seem to work at the moment (`undefined method `data_dir' for nil:NilClass` during `backup-snapshot-logical-volume-confirmation`)

TO TEST:
1) Make a nightly production environment (this has been tricky lately, let me know if you're having issues).
2) Install Pulp 3 with `foreman-installer --foreman-proxy-plugin-pulp-pulpcore-enabled`
3) Checkout this PR
4) Try `foreman-maintain backup` with `online` and `offline`
5) Try `foreman-maintain restore` on all of the backups created
6) Ensure the databases restored okay, especially the Pulp 3 database.