### PR TITLE
Fixes #28040 - Unknown Puppet subcommand 'master'

### DIFF
--- a/definitions/features/puppet_server.rb
+++ b/definitions/features/puppet_server.rb
@@ -29,7 +29,7 @@ class Features::PuppetServer < ForemanMaintain::Feature
   end
 
   def puppet_version
-    version(execute!('/opt/puppetlabs/bin/puppet --version'))
+    version(execute!("#{puppet_path} --version"))
   end
 
   def find_empty_cacert_request_files
@@ -56,10 +56,14 @@ class Features::PuppetServer < ForemanMaintain::Feature
   end
 
   def puppet_ssldir_path
-    if puppet_version.version.to_i >= 6
-      execute!('/opt/puppetlabs/bin/puppet config print ssldir')
+    if puppet_version.major >= 6
+      execute!("#{puppet_path} config print ssldir")
     else
-      execute!('/opt/puppetlabs/bin/puppet master --configprint ssldir')
+      execute!("#{puppet_path} master --configprint ssldir")
     end
+  end
+
+  def puppet_path
+    '/opt/puppetlabs/bin/puppet'
   end
 end

--- a/definitions/features/puppet_server.rb
+++ b/definitions/features/puppet_server.rb
@@ -56,11 +56,7 @@ class Features::PuppetServer < ForemanMaintain::Feature
   end
 
   def puppet_ssldir_path
-    if puppet_version.major >= 6
-      execute!("#{puppet_path} config print ssldir")
-    else
-      execute!("#{puppet_path} master --configprint ssldir")
-    end
+    execute!("#{puppet_path} config print ssldir")
   end
 
   def puppet_path

--- a/definitions/features/puppet_server.rb
+++ b/definitions/features/puppet_server.rb
@@ -29,7 +29,7 @@ class Features::PuppetServer < ForemanMaintain::Feature
   end
 
   def puppet_version
-    version(execute!('puppet --version'))
+    version(execute!('/opt/puppetlabs/bin/puppet --version'))
   end
 
   def find_empty_cacert_request_files
@@ -56,6 +56,10 @@ class Features::PuppetServer < ForemanMaintain::Feature
   end
 
   def puppet_ssldir_path
-    execute!('puppet master --configprint ssldir')
+    if puppet_version.version.to_i >= 6
+      execute!('/opt/puppetlabs/bin/puppet config print ssldir')
+    else
+      execute!('/opt/puppetlabs/bin/puppet master --configprint ssldir')
+    end
   end
 end

--- a/lib/foreman_maintain/utils/facter.rb
+++ b/lib/foreman_maintain/utils/facter.rb
@@ -5,7 +5,7 @@ module ForemanMaintain::Utils
     FACTER_FILES = %w[/usr/bin/facter /opt/puppetlabs/bin/facter].freeze
 
     def self.package
-      puppet_version = version(execute!('puppet --version'))
+      puppet_version = version(execute!('/opt/puppetlabs/bin/puppet --version'))
 
       puppet_version.major >= 4 ? 'puppet-agent' : 'facter'
     end


### PR DESCRIPTION
puppet master command and its subcommands have been removed from puppet 6.
I have changed the puppet path to absolute because installation of puppet 6 package does not create symbolic link /usr/bin/puppet and /opt/puppetlabs/bin/puppet is not added to the $PATH. 