### PR TITLE
Refs #28948 - Make pulp settings parsing more robust

### DIFF
--- a/definitions/features/pulpcore_database.rb
+++ b/definitions/features/pulpcore_database.rb
@@ -25,7 +25,7 @@ class Features::PulpcoreDatabase < ForemanMaintain::Feature
   private
 
   def load_configuration
-    full_config = File.read(PULPCORE_DB_CONFIG).split(/[\s,':]/).reject(&:empty?)
+    full_config = File.read(PULPCORE_DB_CONFIG).split(/[\s,'":]/).reject(&:empty?)
 
     @configuration = {}
     @configuration['adapter'] = 'postgresql'


### PR DESCRIPTION
There is some more detail in the issue, but basically we are parsing a python file to get the pulp db settings. We should come up with a better solution but this change will make things more robust for now and fix the 'service' commands in the development environment.