### PR TITLE
Fixes #26017 - Skip qpidd under load

### DIFF
--- a/definitions/scenarios/backup.rb
+++ b/definitions/scenarios/backup.rb
@@ -200,7 +200,8 @@ module ForemanMaintain::Scenarios
     # rubocop:enable  Metrics/MethodLength
 
     def add_online_backup_steps
-      add_step_with_context(Procedures::Backup::ConfigFiles, :ignore_changed_files => true)
+      add_step_with_context(Procedures::Backup::ConfigFiles, 
+                            :exclude_qpidd_data => true)
       add_step_with_context(Procedures::Backup::Pulp, :ensure_unchanged => true)
       add_steps_with_context(
         Procedures::Backup::Online::Mongo,


### PR DESCRIPTION
The foreman-maintain already had logic to try taking config file backup 3 times. With this PR,

1. We try the to collect backup 2 times with qpidd data. Here 10 seconds delay between each run.
2. If backup fails then we skip qpidd data in third run,
~~~
WARNING: Attempt 1/3 to collect all config files failed!
Some files were modified during creation of the archive.
Waiting 10 seconds before re-try
/ Collecting config files to backup                                             
WARNING: Attempt 2/3 to collect all config files failed!
Some files were modified during creation of the archive.
Waiting 10 seconds before re-try
| Collecting config files to backup                                             
WARNING: Attempt 3/3 to collect all config files failed!
Some files were modified during creation of the archive.
- Collecting config files to backup, skipping /var/lib/qpidd                    
| Collecting config files to backup                                   [OK]      
~~