### PR TITLE
Fixes #29227 - Add content commands to the top level

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Subcommands:
       stop                          Stop maintenance-mode
       status                        Get maintenance-mode status
       is-enabled                    Get maintenance-mode status code
+
+    content                       Content related commands
+      prepare                       Prepare content for Pulp 3 
+      switchover                    Switch support for certain content from Pulp 2 to Pulp 3
 ```
 
 ### Upgrades

--- a/definitions/procedures/content/prepare.rb
+++ b/definitions/procedures/content/prepare.rb
@@ -6,7 +6,7 @@ module Procedures::Content
     end
 
     def run
-      execute!('foreman-rake katello:pulp3_migration')
+      puts execute!('foreman-rake katello:pulp3_migration')
     end
   end
 end

--- a/definitions/procedures/content/switchover.rb
+++ b/definitions/procedures/content/switchover.rb
@@ -6,9 +6,13 @@ module Procedures::Content
     end
 
     def run
-      execute!('foreman-rake katello:pulp3_migration')
-      execute!('foreman-rake katello:pulp3_post_migration_check')
-      execute!('foreman-rake katello:pulp3_content_switchover')
+      puts 'Performing final content migration before switching content'
+      puts execute!('foreman-rake katello:pulp3_migration')
+      puts 'Performing a check to verify everything that is needed has been migrated'
+      puts execute!('foreman-rake katello:pulp3_post_migration_check')
+      puts 'Switching specified content over to pulp 3'
+      puts execute!('foreman-rake katello:pulp3_content_switchover')
+      puts 'Re-running the installer to switch specified content over to pulp3'
       args = ['--foreman-proxy-content-proxy-pulp-isos-to-pulpcore=true',
               '--katello-use-pulp-2-for-file=false',
               '--katello-use-pulp-2-for-docker=false']

--- a/definitions/scenarios/content.rb
+++ b/definitions/scenarios/content.rb
@@ -1,0 +1,27 @@
+module ForemanMaintain::Scenarios
+  module Content
+    class Prepare < ForemanMaintain::Scenario
+      metadata do
+        label :content_prepare
+        description 'Prepare content for Pulp 3'
+        manual_detection
+      end
+
+      def compose
+        add_step(Procedures::Content::Prepare)
+      end
+    end
+
+    class Switchover < ForemanMaintain::Scenario
+      metadata do
+        label :content_switchover
+        description 'Switch support for certain content from Pulp 2 to Pulp 3'
+        manual_detection
+      end
+
+      def compose
+        add_step(Procedures::Content::Switchover)
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/cli.rb
+++ b/lib/foreman_maintain/cli.rb
@@ -10,6 +10,7 @@ require 'foreman_maintain/cli/service_command'
 require 'foreman_maintain/cli/restore_command'
 require 'foreman_maintain/cli/maintenance_mode_command'
 require 'foreman_maintain/cli/packages_command'
+require 'foreman_maintain/cli/content_command'
 
 module ForemanMaintain
   module Cli
@@ -23,6 +24,7 @@ module ForemanMaintain
       subcommand 'restore', 'Restore a backup', RestoreCommand
       subcommand 'packages', 'Lock/Unlock package protection, install, update', PackagesCommand
       subcommand 'advanced', 'Advanced tools for server maintenance', AdvancedCommand
+      subcommand 'content', 'Content related commands', ContentCommand
       subcommand 'maintenance-mode', 'Control maintenance-mode for application',
                  MaintenanceModeCommand
 

--- a/lib/foreman_maintain/cli/content_command.rb
+++ b/lib/foreman_maintain/cli/content_command.rb
@@ -1,0 +1,17 @@
+module ForemanMaintain
+  module Cli
+    class ContentCommand < Base
+      subcommand 'prepare', 'Prepare content for Pulp 3' do
+        def execute
+          run_scenarios_and_exit(Scenarios::Content::Prepare.new)
+        end
+      end
+
+      subcommand 'switchover', 'Switch support for certain content from Pulp 2 to Pulp 3' do
+        def execute
+          run_scenarios_and_exit(Scenarios::Content::Switchover.new)
+        end
+      end
+    end
+  end
+end

--- a/test/lib/cli_test.rb
+++ b/test/lib/cli_test.rb
@@ -27,6 +27,7 @@ module ForemanMaintain
             restore                       Restore a backup
             packages                      Lock/Unlock package protection, install, update
             advanced                      Advanced tools for server maintenance
+            content                       Content related commands
             maintenance-mode              Control maintenance-mode for application
 
         Options:


### PR DESCRIPTION
This adds content commands to the top level so they are easier to use and find. This will help during the pulp 2 to 3 migration