### PR TITLE
Fixes #26017 - Exclude certain files for online backup

### DIFF
--- a/definitions/features/katello.rb
+++ b/definitions/features/katello.rb
@@ -52,6 +52,13 @@ class Features::Katello < ForemanMaintain::Feature
   end
   # rubocop:enable  Metrics/MethodLength
 
+  def config_files_exclude_for_online
+    [
+      '/var/lib/qpidd',
+      '/var/lib/candlepin/activemq-artemis'
+    ]
+  end
+
   private
 
   def installer_scenario_answers

--- a/definitions/procedures/backup/config_files.rb
+++ b/definitions/procedures/backup/config_files.rb
@@ -17,6 +17,8 @@ module Procedures::Backup
             :array => true, :default => ['all']
       param :ignore_changed_files, 'Should packing tar ignore changed files',
             :flag => true, :default => false
+      param :online_backup, 'The config files are being prepared for an online backup',
+            :flag => true, :default => false
     end
 
     # rubocop:disable Metrics/MethodLength
@@ -55,6 +57,7 @@ module Procedures::Backup
 
         configs += feature.config_files
         exclude_configs += feature.config_files_to_exclude
+        exclude_configs += feature.config_files_exclude_for_online if @online_backup
       end
 
       if feature(:foreman_proxy)

--- a/definitions/scenarios/backup.rb
+++ b/definitions/scenarios/backup.rb
@@ -200,7 +200,8 @@ module ForemanMaintain::Scenarios
     # rubocop:enable  Metrics/MethodLength
 
     def add_online_backup_steps
-      add_step_with_context(Procedures::Backup::ConfigFiles, :ignore_changed_files => true)
+      add_step_with_context(Procedures::Backup::ConfigFiles, :ignore_changed_files => true,
+                                                             :online_backup => true)
       add_step_with_context(Procedures::Backup::Pulp, :ensure_unchanged => true)
       add_steps_with_context(
         Procedures::Backup::Online::Mongo,

--- a/lib/foreman_maintain/feature.rb
+++ b/lib/foreman_maintain/feature.rb
@@ -41,5 +41,9 @@ module ForemanMaintain
     def config_files_to_exclude
       []
     end
+
+    def config_files_exclude_for_online
+      []
+    end
   end
 end


### PR DESCRIPTION
These candlepin and qpid files cause issues when included in an online backup due to the services running.