### PR TITLE
Fixes #29533 - add qpidd activemq queue generation procedure

### DIFF
--- a/definitions/procedures/backup/metadata.rb
+++ b/definitions/procedures/backup/metadata.rb
@@ -6,7 +6,7 @@ module Procedures::Backup
       preparation_steps { Checks::Foreman::DBUp.new if feature(:foreman_server) }
       param :backup_dir, 'Directory where to backup to', :required => true
       param :incremental_dir, 'Changes since specified backup only'
-      param :online_backup, 'Selected online backup ?'
+      param :online_backup, 'Selected online backup ?', :flag => true, :default => false
     end
 
     def run
@@ -17,7 +17,7 @@ module Procedures::Backup
         metadata['proxy_features'] = proxy_feature_list(spinner) || []
         metadata['rpms'] = rpms(spinner)
         metadata['incremental'] = @incremental_dir || false
-        metadata['online'] = @online_backup || false
+        metadata['online'] = @online_backup
         save_metadata(metadata, spinner)
       end
     end

--- a/definitions/procedures/backup/metadata.rb
+++ b/definitions/procedures/backup/metadata.rb
@@ -6,7 +6,7 @@ module Procedures::Backup
       preparation_steps { Checks::Foreman::DBUp.new if feature(:foreman_server) }
       param :backup_dir, 'Directory where to backup to', :required => true
       param :incremental_dir, 'Changes since specified backup only'
-      param :online_backup, 'Selected online backup ?', :flag => true, :default => false
+      param :online_backup, 'Select for online backup', :flag => true, :default => false
     end
 
     def run

--- a/definitions/procedures/backup/metadata.rb
+++ b/definitions/procedures/backup/metadata.rb
@@ -6,6 +6,7 @@ module Procedures::Backup
       preparation_steps { Checks::Foreman::DBUp.new if feature(:foreman_server) }
       param :backup_dir, 'Directory where to backup to', :required => true
       param :incremental_dir, 'Changes since specified backup only'
+      param :online_backup, 'Selected online backup ?'
     end
 
     def run
@@ -16,6 +17,7 @@ module Procedures::Backup
         metadata['proxy_features'] = proxy_feature_list(spinner) || []
         metadata['rpms'] = rpms(spinner)
         metadata['incremental'] = @incremental_dir || false
+        metadata['online'] = @online_backup || false
         save_metadata(metadata, spinner)
       end
     end

--- a/definitions/procedures/restore/configs.rb
+++ b/definitions/procedures/restore/configs.rb
@@ -22,7 +22,7 @@ module Procedures::Restore
     # rubocop:disable  Metrics/MethodLength
     def restore_configs(backup)
       exclude = ForemanMaintain.available_features.each_with_object([]) do |feat, cfgs|
-        if online_backup?
+        if backup.online_backup?
           feat.config_files_exclude_for_online.each { |f| cfgs << f.gsub(%r{^/}, '') }
         end
         feat.config_files_to_exclude.each { |f| cfgs << f.gsub(%r{^/}, '') }
@@ -44,11 +44,6 @@ module Procedures::Restore
 
     def reload_configs
       feature(:mongo).reload_db_config if feature(:mongo)
-    end
-
-    def online_backup?
-      metadata_file = YAML.load(File.read(options['backup_dir'] + 'metadata.yml'))
-      @online_flag = metadata_file['online']
     end
 
     private

--- a/definitions/procedures/restore/regenerate_queues.rb
+++ b/definitions/procedures/restore/regenerate_queues.rb
@@ -1,7 +1,10 @@
 module Procedures::Restore
   class RegenerateQueues < ForemanMaintain::Procedure
     metadata do
-      description 'Regenerate required qpidd and activemq queues while restoring online backup'
+      description 'Regenerate required activemq and qpidd queues while restoring online backup'
+      confine do
+        feature(:pulp2)
+      end
     end
 
     def ssl_cert
@@ -28,6 +31,7 @@ module Procedures::Restore
       with_spinner('Resetting the queues') do |spinner|
         regenerate_activemq_queues(spinner)
         regenerate_qpidd_queues(spinner)
+        spinner.update('Queues created successfully')
       end
     end
 
@@ -50,7 +54,7 @@ module Procedures::Restore
       execute!('rm -rf /var/lib/qpidd/.qpidd/qls')
       spinner.update('Starting qpidd service')
       feature(:service).handle_services(spinner, 'start', :only => ['qpidd'])
-      spinner.update('Service qpidd started, waiting 60 seconds to start it completely.')
+      spinner.update('Service qpidd started, waiting 60 seconds to start it completely')
       sleep 60
       spinner.update('Recreating qpidd queues')
       run_qpid_command('add exchange topic event --durable')

--- a/definitions/procedures/restore/regenerate_queues.rb
+++ b/definitions/procedures/restore/regenerate_queues.rb
@@ -1,6 +1,7 @@
 module Procedures::Restore
   class RegenerateQueues < ForemanMaintain::Procedure
     metadata do
+      advanced_run false
       description 'Regenerate required activemq and qpidd queues while restoring online backup'
       confine do
         feature(:pulp2)

--- a/definitions/procedures/restore/regenerate_queues.rb
+++ b/definitions/procedures/restore/regenerate_queues.rb
@@ -1,0 +1,63 @@
+module Procedures::Restore
+  class RegenerateQueues < ForemanMaintain::Procedure
+    metadata do
+      description 'Regenerate required qpidd and activemq queues while restoring online backup'
+    end
+
+    def ssl_cert
+      "/etc/pki/katello/certs/#{hostname}-qpid-broker.crt"
+    end
+
+    def ssl_key
+      "/etc/pki/katello/private/#{hostname}-qpid-broker.key"
+    end
+
+    def amqps_url
+      'amqps://localhost:5671'
+    end
+
+    def katello_events
+      %w[compliance.created
+         entitlement.created
+         entitlement.deleted
+         pool.created
+         pool.deleted]
+    end
+
+    def run
+      with_spinner('Resetting the queues') do |spinner|
+        regenerate_activemq_queues(spinner)
+        regenerate_qpidd_queues(spinner)
+      end
+    end
+
+    def regenerate_activemq_queues(spinner)
+      # The activemq queues(/var/lib/candlepin/activemq-artemis) regenerate on tomcat restart.
+      # After stopping the tomcat here, service start is triggered from the restore scenario.
+      spinner.update('Stopping tomcat service')
+      feature(:candlepin).services.select(&:exist?).first.stop
+      spinner.update('Recreating activemq queues')
+      execute!('rm -rf /var/lib/candlepin/activemq-artemis/')
+    end
+
+    def run_qpid_command(opts)
+      execute!("qpid-config --ssl-certificate #{ssl_cert} \\
+                --ssl-key #{ssl_key} -b #{amqps_url} #{opts}")
+    end
+
+    def regenerate_qpidd_queues(spinner)
+      feature(:service).handle_services(spinner, 'stop', :only => ['qpidd'])
+      execute!('rm -rf /var/lib/qpidd/.qpidd/qls')
+      spinner.update('Starting qpidd service')
+      feature(:service).handle_services(spinner, 'start', :only => ['qpidd'])
+      spinner.update('Service qpidd started, waiting 60 seconds to start it completely.')
+      sleep 60
+      spinner.update('Recreating qpidd queues')
+      run_qpid_command('add exchange topic event --durable')
+      run_qpid_command('add queue katello_event_queue --durable')
+      katello_events.each do |event|
+        run_qpid_command("bind event katello_event_queue #{event}")
+      end
+    end
+  end
+end

--- a/definitions/procedures/restore/regenerate_queues.rb
+++ b/definitions/procedures/restore/regenerate_queues.rb
@@ -8,16 +8,17 @@ module Procedures::Restore
       end
     end
 
-    def ssl_cert
-      "/etc/pki/katello/certs/#{hostname}-qpid-broker.crt"
+    def qpid_router_broker_port
+      @qpid_router_broker_port ||= feature(:installer).
+                                   answers['foreman_proxy_content']['qpid_router_broker_port']
     end
 
-    def ssl_key
-      "/etc/pki/katello/private/#{hostname}-qpid-broker.key"
-    end
-
-    def amqps_url
-      'amqps://localhost:5671'
+    def qpid_configs
+      @qpid_configs ||= {
+        'ssl_cert' => "/etc/pki/katello/certs/#{hostname}-qpid-broker.crt",
+        'ssl_key' => "/etc/pki/katello/private/#{hostname}-qpid-broker.key",
+        'amqps_url' => "amqps://localhost:#{qpid_router_broker_port}"
+      }
     end
 
     def katello_events
@@ -46,8 +47,8 @@ module Procedures::Restore
     end
 
     def run_qpid_command(opts)
-      execute!("qpid-config --ssl-certificate #{ssl_cert} \\
-                --ssl-key #{ssl_key} -b #{amqps_url} #{opts}")
+      execute!("qpid-config --ssl-certificate #{qpid_configs['ssl_cert']} \\
+                --ssl-key #{qpid_configs['ssl_key']} -b #{qpid_configs['amqps_url']} #{opts}")
     end
 
     def regenerate_qpidd_queues(spinner)

--- a/definitions/scenarios/backup.rb
+++ b/definitions/scenarios/backup.rb
@@ -210,6 +210,7 @@ module ForemanMaintain::Scenarios
         Procedures::Backup::Online::ForemanDB,
         Procedures::Backup::Online::PulpcoreDB
       )
+      add_step_with_context(Procedures::Backup::Metadata, :online_backup => true)
     end
 
     def strategy

--- a/definitions/scenarios/restore.rb
+++ b/definitions/scenarios/restore.rb
@@ -38,7 +38,7 @@ module ForemanMaintain::Scenarios
       add_steps_with_context(Procedures::Pulp::Migrate,
                              Procedures::Pulpcore::Migrate)
 
-      add_steps_with_context(Procedures::Restore::RegenerateQueues) if online_backup?
+      add_steps_with_context(Procedures::Restore::RegenerateQueues) if backup.online_backup?
       add_steps_with_context(Procedures::Service::Start,
                              Procedures::Service::DaemonReload)
     end
@@ -96,11 +96,6 @@ module ForemanMaintain::Scenarios
 
       context.map(:incremental_backup,
                   Procedures::Selinux::SetFileSecurity => :incremental_backup)
-    end
-
-    def online_backup?
-      metadata_file = YAML.load(File.read(context.get(:backup_dir) + 'metadata.yml'))
-      metadata_file['online'] || false
     end
   end
 end

--- a/definitions/scenarios/restore.rb
+++ b/definitions/scenarios/restore.rb
@@ -100,7 +100,7 @@ module ForemanMaintain::Scenarios
 
     def online_backup?
       metadata_file = YAML.load(File.read(context.get(:backup_dir) + 'metadata.yml'))
-      @online_flag = metadata_file['online']
+      metadata_file['online']
     end
   end
 end

--- a/definitions/scenarios/restore.rb
+++ b/definitions/scenarios/restore.rb
@@ -36,8 +36,10 @@ module ForemanMaintain::Scenarios
       end
       restore_mongo_dump(backup)
       add_steps_with_context(Procedures::Pulp::Migrate,
-                             Procedures::Pulpcore::Migrate,
-                             Procedures::Service::Start,
+                             Procedures::Pulpcore::Migrate)
+
+      add_steps_with_context(Procedures::Restore::RegenerateQueues) if online_backup?
+      add_steps_with_context(Procedures::Service::Start,
                              Procedures::Service::DaemonReload)
     end
     # rubocop:enable Metrics/MethodLength,Metrics/AbcSize
@@ -94,6 +96,11 @@ module ForemanMaintain::Scenarios
 
       context.map(:incremental_backup,
                   Procedures::Selinux::SetFileSecurity => :incremental_backup)
+    end
+
+    def online_backup?
+      metadata_file = YAML.load(File.read(context.get(:backup_dir) + 'metadata.yml'))
+      @online_flag = metadata_file['online']
     end
   end
 end

--- a/definitions/scenarios/restore.rb
+++ b/definitions/scenarios/restore.rb
@@ -100,7 +100,7 @@ module ForemanMaintain::Scenarios
 
     def online_backup?
       metadata_file = YAML.load(File.read(context.get(:backup_dir) + 'metadata.yml'))
-      metadata_file['online']
+      metadata_file['online'] || false
     end
   end
 end

--- a/lib/foreman_maintain/utils/backup.rb
+++ b/lib/foreman_maintain/utils/backup.rb
@@ -206,7 +206,7 @@ module ForemanMaintain
       end
 
       def online_backup?
-        !!metadata.fetch('online')
+        !!metadata.fetch('online', false)
       end
     end
   end

--- a/lib/foreman_maintain/utils/backup.rb
+++ b/lib/foreman_maintain/utils/backup.rb
@@ -204,6 +204,10 @@ module ForemanMaintain
       def incremental?
         !!metadata.fetch('incremental', false)
       end
+
+      def online_backup?
+        !!metadata.fetch('online')
+      end
     end
   end
 end


### PR DESCRIPTION
This adds the qpidd and activemq queue generation if restore is from online backup. To know if backup is online or offline new flag 'online' has introduced in backup metadata. This flag helps to decide if restore scenario should run procedure to create queues and bindings.