### PR TITLE
Fixes #29654 - hide disk performance check

### DIFF
--- a/definitions/checks/disk/performance.rb
+++ b/definitions/checks/disk/performance.rb
@@ -3,7 +3,6 @@ module Checks
     class Performance < ForemanMaintain::Check
       metadata do
         label :disk_performance
-        tags :pre_upgrade
         preparation_steps { Procedures::Packages::Install.new(:packages => %w[fio]) }
         confine do
           feature(:instance).pulp


### PR DESCRIPTION
With commit changes, foreman-maintain won't run disk performance check during upgrade as well as while running default checks. 
If user would like to run this check on demand then he/she will be able to run it with --label option in `health check` sub-command.

For example - `foreman-maintain health check --label disk-performance`

Note that - This check will be visible under output of command  `foreman-maintain health list`.

