### PR TITLE
Fixes #29645 - Make upgrade executable via REX

### DIFF
--- a/definitions/procedures/installer/run.rb
+++ b/definitions/procedures/installer/run.rb
@@ -7,7 +7,6 @@ module Procedures::Installer
 
     def run
       assumeyes_val = @assumeyes.nil? ? assumeyes? : @assumeyes
-      # If assumeyes selected we execute installer in non-interactive mode
       feature(:installer).run(@arguments, :interactive => !assumeyes_val)
     end
 

--- a/definitions/procedures/installer/run.rb
+++ b/definitions/procedures/installer/run.rb
@@ -2,10 +2,13 @@ module Procedures::Installer
   class Run < ForemanMaintain::Procedure
     metadata do
       param :arguments, 'Arguments passed to installer'
+      param :assumeyes, 'Do not ask for confirmation'
     end
 
     def run
-      feature(:installer).run(@arguments, :interactive => true)
+      assumeyes_val = @assumeyes.nil? ? assumeyes? : @assumeyes
+      # If assumeyes selected we execute installer in non-interactive mode
+      feature(:installer).run(@arguments, :interactive => !assumeyes_val)
     end
 
     def description

--- a/definitions/procedures/installer/upgrade.rb
+++ b/definitions/procedures/installer/upgrade.rb
@@ -1,7 +1,13 @@
 module Procedures::Installer
   class Upgrade < ForemanMaintain::Procedure
+    metadata do
+      param :assumeyes, 'Do not ask for confirmation'
+    end
+
     def run
-      feature(:installer).upgrade(:interactive => true)
+      assumeyes_val = @assumeyes.nil? ? assumeyes? : @assumeyes
+      # If assumeyes selected we execute installer in non-interactive mode
+      feature(:installer).run(@arguments, :interactive => !assumeyes_val)
     end
   end
 end

--- a/definitions/procedures/installer/upgrade.rb
+++ b/definitions/procedures/installer/upgrade.rb
@@ -6,7 +6,6 @@ module Procedures::Installer
 
     def run
       assumeyes_val = @assumeyes.nil? ? assumeyes? : @assumeyes
-      # If assumeyes selected we execute installer in non-interactive mode
       feature(:installer).run(@arguments, :interactive => !assumeyes_val)
     end
   end

--- a/definitions/procedures/packages/update.rb
+++ b/definitions/procedures/packages/update.rb
@@ -10,7 +10,7 @@ module Procedures::Packages
 
     def run
       assumeyes_val = @assumeyes.nil? ? assumeyes? : @assumeyes
-      package_manager.clean_cache
+      package_manager.clean_cache(:assumeyes => assumeyes_val)
       packages_action(:update, @packages, :assumeyes => assumeyes_val)
     rescue ForemanMaintain::Error::ExecutionError => e
       if @warn_on_errors

--- a/definitions/scenarios/upgrade_to_capsule_6_7.rb
+++ b/definitions/scenarios/upgrade_to_capsule_6_7.rb
@@ -49,11 +49,15 @@ module Scenarios::Capsule_6_7
       tags :migrations
     end
 
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.7'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
-      add_step(Procedures::Installer::Upgrade.new)
+      add_step_with_context(Procedures::Installer::Upgrade)
     end
   end
 

--- a/definitions/scenarios/upgrade_to_capsule_6_7_z.rb
+++ b/definitions/scenarios/upgrade_to_capsule_6_7_z.rb
@@ -49,11 +49,15 @@ module Scenarios::Capsule_6_7_z
       tags :migrations
     end
 
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.7'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
-      add_step(Procedures::Installer::Upgrade.new)
+      add_step_with_context(Procedures::Installer::Upgrade)
     end
   end
 

--- a/definitions/scenarios/upgrade_to_capsule_6_8.rb
+++ b/definitions/scenarios/upgrade_to_capsule_6_8.rb
@@ -49,11 +49,15 @@ module Scenarios::Capsule_6_8
       tags :migrations
     end
 
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.8'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
-      add_step(Procedures::Installer::Upgrade.new)
+      add_step_with_context(Procedures::Installer::Upgrade)
     end
   end
 

--- a/definitions/scenarios/upgrade_to_capsule_6_8_z.rb
+++ b/definitions/scenarios/upgrade_to_capsule_6_8_z.rb
@@ -49,11 +49,15 @@ module Scenarios::Capsule_6_8_z
       tags :migrations
     end
 
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.8'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
-      add_step(Procedures::Installer::Upgrade.new)
+      add_step_with_context(Procedures::Installer::Upgrade)
     end
   end
 

--- a/definitions/scenarios/upgrade_to_satellite_6_2.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_2.rb
@@ -49,11 +49,15 @@ module Scenarios::Satellite_6_2
       tags :migrations
     end
 
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.2'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
-      add_step(Procedures::Installer::Upgrade.new)
+      add_step_with_context(Procedures::Installer::Upgrade)
     end
   end
 

--- a/definitions/scenarios/upgrade_to_satellite_6_2_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_2_z.rb
@@ -49,11 +49,15 @@ module Scenarios::Satellite_6_2_z
       tags :migrations
     end
 
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.2'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
-      add_step(Procedures::Installer::Upgrade.new)
+      add_step_with_context(Procedures::Installer::Upgrade)
     end
   end
 

--- a/definitions/scenarios/upgrade_to_satellite_6_3.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_3.rb
@@ -50,11 +50,15 @@ module Scenarios::Satellite_6_3
       tags :migrations
     end
 
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.3'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
-      add_step(Procedures::Installer::Upgrade.new)
+      add_step_with_context(Procedures::Installer::Upgrade)
     end
   end
 

--- a/definitions/scenarios/upgrade_to_satellite_6_3_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_3_z.rb
@@ -49,11 +49,15 @@ module Scenarios::Satellite_6_3_z
       tags :migrations
     end
 
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.3'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
-      add_step(Procedures::Installer::Upgrade.new)
+      add_step_with_context(Procedures::Installer::Upgrade)
     end
   end
 

--- a/definitions/scenarios/upgrade_to_satellite_6_4.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_4.rb
@@ -50,11 +50,15 @@ module Scenarios::Satellite_6_4
       tags :migrations
     end
 
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.4'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
-      add_step(Procedures::Installer::Upgrade.new)
+      add_step_with_context(Procedures::Installer::Upgrade)
     end
   end
 

--- a/definitions/scenarios/upgrade_to_satellite_6_4_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_4_z.rb
@@ -49,11 +49,15 @@ module Scenarios::Satellite_6_4_z
       tags :migrations
     end
 
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.4'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
-      add_step(Procedures::Installer::Upgrade.new)
+      add_step_with_context(Procedures::Installer::Upgrade)
     end
   end
 

--- a/definitions/scenarios/upgrade_to_satellite_6_5.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_5.rb
@@ -49,11 +49,15 @@ module Scenarios::Satellite_6_5
       tags :migrations
     end
 
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.5'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
-      add_step(Procedures::Installer::Upgrade.new)
+      add_step_with_context(Procedures::Installer::Upgrade)
     end
   end
 

--- a/definitions/scenarios/upgrade_to_satellite_6_5_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_5_z.rb
@@ -49,11 +49,15 @@ module Scenarios::Satellite_6_5_z
       tags :migrations
     end
 
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.5'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
-      add_step(Procedures::Installer::Upgrade.new)
+      add_step_with_context(Procedures::Installer::Upgrade)
     end
   end
 

--- a/definitions/scenarios/upgrade_to_satellite_6_6.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_6.rb
@@ -49,11 +49,15 @@ module Scenarios::Satellite_6_6
       tags :migrations
     end
 
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.6'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
-      add_step(Procedures::Installer::Upgrade.new)
+      add_step_with_context(Procedures::Installer::Upgrade)
     end
   end
 

--- a/definitions/scenarios/upgrade_to_satellite_6_6_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_6_z.rb
@@ -49,11 +49,15 @@ module Scenarios::Satellite_6_6_z
       tags :migrations
     end
 
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.6'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
-      add_step(Procedures::Installer::Upgrade.new)
+      add_step_with_context(Procedures::Installer::Upgrade)
     end
   end
 

--- a/definitions/scenarios/upgrade_to_satellite_6_7.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_7.rb
@@ -49,11 +49,15 @@ module Scenarios::Satellite_6_7
       tags :migrations
     end
 
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.7'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
-      add_step(Procedures::Installer::Upgrade.new)
+      add_step_with_context(Procedures::Installer::Upgrade)
     end
   end
 

--- a/definitions/scenarios/upgrade_to_satellite_6_7_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_7_z.rb
@@ -49,11 +49,15 @@ module Scenarios::Satellite_6_7_z
       tags :migrations
     end
 
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.7'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
-      add_step(Procedures::Installer::Upgrade.new)
+      add_step_with_context(Procedures::Installer::Upgrade)
     end
   end
 

--- a/definitions/scenarios/upgrade_to_satellite_6_8.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_8.rb
@@ -49,11 +49,15 @@ module Scenarios::Satellite_6_8
       tags :migrations
     end
 
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.8'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
-      add_step(Procedures::Installer::Upgrade.new)
+      add_step_with_context(Procedures::Installer::Upgrade)
     end
   end
 

--- a/definitions/scenarios/upgrade_to_satellite_6_8_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_8_z.rb
@@ -49,11 +49,15 @@ module Scenarios::Satellite_6_8_z
       tags :migrations
     end
 
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => '6.8'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
-      add_step(Procedures::Installer::Upgrade.new)
+      add_step_with_context(Procedures::Installer::Upgrade)
     end
   end
 

--- a/lib/foreman_maintain/package_manager/dnf.rb
+++ b/lib/foreman_maintain/package_manager/dnf.rb
@@ -10,7 +10,6 @@ module ForemanMaintain::PackageManager
     def dnf_action(action, packages, with_status: false, assumeyes: false)
       yum_options = []
       yum_options << '-y' if assumeyes
-      # If assumeyes selected we execute commands in non-interactive mode
       if with_status
         sys.execute_with_status("dnf #{yum_options.join(' ')} #{action} #{packages.join(' ')}",
                                 :interactive => !assumeyes)

--- a/lib/foreman_maintain/package_manager/dnf.rb
+++ b/lib/foreman_maintain/package_manager/dnf.rb
@@ -1,17 +1,24 @@
 module ForemanMaintain::PackageManager
   class Dnf < Yum
-    def clean_cache
-      dnf_action('clean', 'all')
+    def clean_cache(assumeyes: false)
+      dnf_action('clean', 'all', :assumeyes => assumeyes)
       super
     end
 
     private
 
-    def dnf_action(action, packages, assumeyes: false)
+    def dnf_action(action, packages, with_status: false, assumeyes: false)
       yum_options = []
       yum_options << '-y' if assumeyes
-      sys.execute!("dnf #{yum_options.join(' ')} #{action} #{packages.join(' ')}",
-                   :interactive => true)
+      # If assumeyes selected we execute commands in non-interactive mode
+      if with_status
+        sys.execute_with_status("dnf #{yum_options.join(' ')} #{action} #{packages.join(' ')}",
+                                :interactive => !assumeyes)
+      else
+        sys.execute!("dnf #{yum_options.join(' ')} #{action} #{packages.join(' ')}",
+                     :interactive => !assumeyes)
+
+      end
     end
   end
 end

--- a/lib/foreman_maintain/package_manager/yum.rb
+++ b/lib/foreman_maintain/package_manager/yum.rb
@@ -107,7 +107,6 @@ module ForemanMaintain::PackageManager
       yum_options << '-y' if assumeyes
       yum_options_s = yum_options.empty? ? '' : ' ' + yum_options.join(' ')
       packages_s = packages.empty? ? '' : ' ' + packages.join(' ')
-      # If assumeyes selected we execute commands in non-interactive mode
       if with_status
         sys.execute_with_status("yum#{yum_options_s} #{action}#{packages_s}",
                                 :interactive => !assumeyes)

--- a/lib/foreman_maintain/package_manager/yum.rb
+++ b/lib/foreman_maintain/package_manager/yum.rb
@@ -57,8 +57,8 @@ module ForemanMaintain::PackageManager
       yum_action('update', packages, :assumeyes => assumeyes)
     end
 
-    def clean_cache
-      yum_action('clean', 'all')
+    def clean_cache(assumeyes: false)
+      yum_action('clean', 'all', :assumeyes => assumeyes)
     end
 
     def update_available?(package)
@@ -107,12 +107,13 @@ module ForemanMaintain::PackageManager
       yum_options << '-y' if assumeyes
       yum_options_s = yum_options.empty? ? '' : ' ' + yum_options.join(' ')
       packages_s = packages.empty? ? '' : ' ' + packages.join(' ')
+      # If assumeyes selected we execute commands in non-interactive mode
       if with_status
         sys.execute_with_status("yum#{yum_options_s} #{action}#{packages_s}",
-                                :interactive => true)
+                                :interactive => !assumeyes)
       else
         sys.execute!("yum#{yum_options_s} #{action}#{packages_s}",
-                     :interactive => true)
+                     :interactive => !assumeyes)
       end
     end
 

--- a/test/lib/package_manager/yum_test.rb
+++ b/test/lib/package_manager/yum_test.rb
@@ -91,11 +91,12 @@ module ForemanMaintain
 
       it 'invokes yum to install list of packages' do
         expect_sys_execute('yum install package1 package2', :via => :execute!)
-        subject.install(%w[package1 package2])
+        subject.install(%w[package1 package2], :assumeyes => false)
       end
 
       it 'invokes yum to install package with yes enforced' do
-        expect_sys_execute('yum -y install package', :via => :execute!)
+        expect_sys_execute('yum -y install package', :via => :execute!,
+                                                     :execute_options => { :interactive => false })
         subject.install('package', :assumeyes => true)
       end
     end
@@ -112,7 +113,8 @@ module ForemanMaintain
       end
 
       it 'invokes yum to update package with yes enforced' do
-        expect_sys_execute('yum -y update package', :via => :execute!)
+        expect_sys_execute('yum -y update package', :via => :execute!,
+                                                    :execute_options => { :interactive => false })
         subject.update('package', :assumeyes => true)
       end
 
@@ -124,8 +126,9 @@ module ForemanMaintain
 
     describe 'clean_cache' do
       it 'invokes yum to clean cache' do
-        expect_sys_execute('yum clean all', :via => :execute!)
-        subject.clean_cache
+        expect_sys_execute('yum -y clean all', :via => :execute!,
+                                               :execute_options => { :interactive => false })
+        subject.clean_cache(:assumeyes => true)
       end
     end
 


### PR DESCRIPTION
There are two different variables in play when considering the non-interactive mode. One is :assumeyes and another is :interactive. If I see the :assumeyes working then we expect that if this is passed then no questions should be asked and run should be in non-interactive mode. I have handled it using the :assumeyes value.