### PR TITLE
Fixes #29713 - Display names of corrupted roles

### DIFF
--- a/definitions/checks/foreman/check_corrupted_roles.rb
+++ b/definitions/checks/foreman/check_corrupted_roles.rb
@@ -14,14 +14,22 @@ module Checks
       def run
         items = find_filter_permissions
         assert(items.empty?,
-               'There are user roles with inconsistent filters',
+               error_message(items),
                :next_steps => Procedures::Foreman::FixCorruptedRoles.new)
+      end
+
+      def error_message(items)
+        roles = items.map { |item| item['role_name'] }.uniq
+        'Below are affected roles containing the filters with ' \
+        'permission for which resource type has been changed.' \
+        "\n#{roles.join("\n")}"
       end
 
       def find_filter_permissions
         feature(:foreman_database).query(self.class.inconsistent_filter_perms)
       end
 
+      # rubocop:disable Metrics/MethodLength
       def self.inconsistent_filter_perms
         subquery = <<-SQL
           SELECT filters.id AS filter_id,
@@ -32,14 +40,17 @@ module Checks
                  filterings.id AS filtering_id,
                  permissions.id AS permission_id,
                  permissions.name AS permission_name,
-                 permissions.resource_type
+                 permissions.resource_type,
+                 roles.name AS role_name
           FROM filters INNER JOIN filterings ON filters.id = filterings.filter_id
                        INNER JOIN permissions ON permissions.id = filterings.permission_id
+                       INNER JOIN roles ON filters.role_id = roles.id
         SQL
 
         <<-SQL
           SELECT DISTINCT first.filter_id,
                           first.role_id,
+                          first.role_name,
                           first.filtering_id,
                           first.permission_id,
                           first.permission_name,
@@ -54,6 +65,7 @@ module Checks
                 OR (first.resource_type != second.resource_type))
         SQL
       end
+      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/definitions/checks/foreman/check_corrupted_roles.rb
+++ b/definitions/checks/foreman/check_corrupted_roles.rb
@@ -20,8 +20,8 @@ module Checks
 
       def error_message(items)
         roles = items.map { |item| item['role_name'] }.uniq
-        'Below are affected roles containing the filters with ' \
-        'permission for which resource type has been changed.' \
+        'There are filters having permissions with multiple resource types. ' \
+        'Roles with such filters are:' \
         "\n#{roles.join("\n")}"
       end
 

--- a/test/definitions/checks/foreman/check_corrupted_roles_test.rb
+++ b/test/definitions/checks/foreman/check_corrupted_roles_test.rb
@@ -14,10 +14,16 @@ describe Checks::Foreman::CheckCorruptedRoles do
   end
 
   it 'fails when some roles with corrupted filters detected' do
-    assume_feature_present(:foreman_database, :query => [{ 'role_id' => 5 }])
+    assume_feature_present(:foreman_database, :present? => true)
+    dups = [{ 'role_id' => '31', 'role_name' => 'demoRole', 'permission_name' => 'edit_hosts', \
+              'resource_type' => 'Host' },
+            { 'role_id' => '31', 'role_name' => 'demoRole', 'permission_name' => 'view_hosts', \
+              'resource_type' => 'xyz' }]
+    subject.stubs(:find_filter_permissions).returns(dups)
     result = run_check(subject)
     assert result.fail?, 'Check expected to fail'
-    assert_match 'There are user roles with inconsistent filters', result.output
+    assert_match 'Below are affected roles containing the filters with permission for which ' \
+                  "resource type has been changed.\ndemoRole", result.output
     assert_equal [Procedures::Foreman::FixCorruptedRoles],
                  subject.next_steps.map(&:class)
   end

--- a/test/definitions/checks/foreman/check_corrupted_roles_test.rb
+++ b/test/definitions/checks/foreman/check_corrupted_roles_test.rb
@@ -22,8 +22,8 @@ describe Checks::Foreman::CheckCorruptedRoles do
     subject.stubs(:find_filter_permissions).returns(dups)
     result = run_check(subject)
     assert result.fail?, 'Check expected to fail'
-    assert_match 'Below are affected roles containing the filters with permission for which ' \
-                  "resource type has been changed.\ndemoRole", result.output
+    assert_match 'There are filters having permissions with multiple resource types. ' \
+                  "Roles with such filters are:\ndemoRole", result.output
     assert_equal [Procedures::Foreman::FixCorruptedRoles],
                  subject.next_steps.map(&:class)
   end

--- a/test/definitions/checks/foreman/check_corrupted_roles_test.rb
+++ b/test/definitions/checks/foreman/check_corrupted_roles_test.rb
@@ -14,7 +14,6 @@ describe Checks::Foreman::CheckCorruptedRoles do
   end
 
   it 'fails when some roles with corrupted filters detected' do
-    assume_feature_present(:foreman_database, :present? => true)
     dups = [{ 'role_id' => '31', 'role_name' => 'demoRole', 'permission_name' => 'edit_hosts', \
               'resource_type' => 'Host' },
             { 'role_id' => '31', 'role_name' => 'demoRole', 'permission_name' => 'view_hosts', \


### PR DESCRIPTION
Modified the output as below. 

```
[root@foreman]# foreman-maintain health check --label corrupted-roles
Running ForemanMaintain::Scenario::FilteredScenario
================================================================================
Check for roles that have filters with multiple resources attached:   [FAIL]
Below are affected roles containing the filters with permission for which resource type has been changed.
role007
role008
--------------------------------------------------------------------------------
Continue with step [Create additional filters so that each filter has only permissions of one resource]?, [y(yes), n(no), q(quit)]
```