### PR TITLE
Fixes #29815 - Fixed the runner to execute rescue scenario

### DIFF
--- a/lib/foreman_maintain/runner.rb
+++ b/lib/foreman_maintain/runner.rb
@@ -15,6 +15,7 @@ module ForemanMaintain
       @reporter = reporter
       @scenarios = Array(scenarios)
       @quit = false
+      @rescue = false
       @last_scenario = nil
       @last_scenario_continuation_confirmed = false
       @exit_code = 0
@@ -29,12 +30,17 @@ module ForemanMaintain
       @assumeyes
     end
 
+    def rescue?
+      @rescue
+    end
+
     def run
       @scenarios.each do |scenario|
         run_scenario(scenario)
         next unless @quit
 
         if @rescue_scenario
+          @rescue = true
           logger.debug('=== Rescue scenario found. Executing ===')
           execute_scenario_steps(@rescue_scenario, true)
         end
@@ -44,10 +50,10 @@ module ForemanMaintain
 
     def run_scenario(scenario)
       return if scenario.steps.empty?
-      raise 'The runner is already in quit state' if quit?
+      raise 'The runner is already in quit state' if quit? && !rescue?
 
       confirm_scenario(scenario)
-      return if quit?
+      return if quit? && !rescue?
 
       execute_scenario_steps(scenario)
     ensure


### PR DESCRIPTION
**Issue** - 
Rescue scenario never executed if the backup fails in the middle due to any reason. Not only for backup but in general rescue scenario is never triggered. (The main scenario fails with error - "The runner is already in quit state".)

**Root cause** - 
When the main scenario fails due to any reason, it triggers the rescue scenario. But in 'execute_scenario_steps' method 'run_scenario' is called for running the before_scenarios(if any). Then in run_scenario expectation is raised 'The runner is already in quit state' if quit? (quit? is set from main scenario as it failed), this quit? is stoping rescue scenario from running. 

**Reproducer steps** - 
1) Make sure backup will fail by editing /etc/foreman-proxy/settings.d/dhcp.yml. modify it as below.

`:use_provider: dhcp_infoblox`

Instead of dhcp_isc make it dhcp_infoblox 

2) run backup 

```
# mkdir /tmp/backup/
# foreman-maintain backup offline --assumeyes --skip-pulp-content /tmp/backup/
```

Backup should fail with 

```
Backup config files:                                                  [FAIL]
Couldn't find DHCP Configuration file
```

**Note** - Above reproducer steps will only work till the merge of this [PR](https://github.com/theforeman/foreman_maintain/pull/337)
