### PR TITLE
Fixes #25943 - Added --disable-spinner flag

### DIFF
--- a/lib/foreman_maintain/cli/base.rb
+++ b/lib/foreman_maintain/cli/base.rb
@@ -138,6 +138,7 @@ module ForemanMaintain
                'Run only a specific check with a label. ' \
                  '(Use "list" command to see available labels)' do |label|
           raise ArgumentError, 'value not specified' if label.nil? || label.empty?
+
           underscorize(label).to_sym
         end
       end
@@ -148,6 +149,7 @@ module ForemanMaintain
                  '(Use list-tags command to see available tags)',
                :multivalued => true) do |tags|
           raise ArgumentError, 'value not specified' if tags.nil? || tags.empty?
+
           tags.map { |tag| underscorize(tag).to_sym }
         end
       end
@@ -163,11 +165,16 @@ module ForemanMaintain
         option(['-w', '--whitelist'], 'whitelist',
                'Comma-separated list of labels of steps to be skipped') do |whitelist|
           raise ArgumentError, 'value not specified' if whitelist.nil? || whitelist.empty?
+
           whitelist.split(',').map(&:strip)
         end
 
         option ['-f', '--force'], :flag,
                'Force steps that would be skipped as they were already run'
+
+        option '--disable-spinner', :flag, 'Disable the spinner' do |disable_spinner|
+          ForemanMaintain.reporter.disable_spinner = disable_spinner
+        end
       end
 
       def self.service_options

--- a/lib/foreman_maintain/reporter.rb
+++ b/lib/foreman_maintain/reporter.rb
@@ -46,6 +46,10 @@ module ForemanMaintain
       @assumeyes
     end
 
+    def disable_spinner?
+      @disable_spinner
+    end
+
     # simple yes/no question, returns :yes, :no or :quit
     # rubocop:disable Metrics/LineLength
     def ask_decision(message, actions_msg: 'y(yes), n(no), q(quit)', assumeyes: assumeyes?, run_strategy: :fail_fast)
@@ -63,6 +67,10 @@ module ForemanMaintain
 
     def assumeyes=(assume)
       @assumeyes = !!assume
+    end
+
+    def disable_spinner=(disable_spinner)
+      @disable_spinner = !!disable_spinner
     end
 
     private

--- a/lib/foreman_maintain/reporter/cli_reporter.rb
+++ b/lib/foreman_maintain/reporter/cli_reporter.rb
@@ -30,12 +30,13 @@ module ForemanMaintain
         end
 
         def activate
-          @mutex.synchronize { @active = true }
+          @mutex.synchronize { @active = true } unless @reporter.disable_spinner?
           spin
         end
 
         def deactivate
           return unless active?
+
           @mutex.synchronize do
             @active = false
           end
@@ -55,6 +56,7 @@ module ForemanMaintain
         def spin
           @mutex.synchronize do
             return unless @active
+
             print_current_line
             @spinner_index = (@spinner_index + 1) % @spinner_chars.size
           end
@@ -75,6 +77,7 @@ module ForemanMaintain
         @stdin = stdin
         options.validate_options!(:assumeyes)
         @assumeyes = options.fetch(:assumeyes, false)
+        @disable_spinner = options.fetch(:disable_spinner, false)
         @hl = HighLine.new(@stdin, @stdout)
         @max_length = 80
         @line_char = '-'
@@ -162,7 +165,11 @@ module ForemanMaintain
       end
 
       def clear_line
-        print "\r" + ' ' * @max_length + "\r"
+        if disable_spinner?
+          print "\n"
+        else
+          print "\r" + ' ' * @max_length + "\r"
+        end
       end
 
       def assumeyes?


### PR DESCRIPTION
Added new flag in interactive_option. "**--disable-spinner**" will stop spinner from activating and will also not print the carriage return char "^M" if the output is redirected to the file. 


`# foreman-maintain backup offline  -y --skip-pulp-content --disable-spinner /tmp/backup/ > ~/after_spinner_fix/logs_without_spinner.txt`

Below is output of logs_without_spinner.txt

https://gist.github.com/patilsuraj767/0b31584c032b1eb7277b091aac07d869
