### PR TITLE
Fixes #30120 - Added check-update option in foreman-maintain

### DIFF
--- a/definitions/procedures/packages/check_update.rb
+++ b/definitions/procedures/packages/check_update.rb
@@ -1,0 +1,11 @@
+module Procedures::Packages
+  class CheckUpdate < ForemanMaintain::Procedure
+    metadata do
+      description 'Check for available package updates'
+    end
+
+    def run
+      puts package_manager.check_update
+    end
+  end
+end

--- a/definitions/scenarios/packages.rb
+++ b/definitions/scenarios/packages.rb
@@ -50,6 +50,18 @@ module ForemanMaintain::Scenarios
       end
     end
 
+    class CheckUpdate < ForemanMaintain::Scenario
+      metadata do
+        label :packages_check_update
+        description 'Check for available package updates'
+        manual_detection
+      end
+
+      def compose
+        add_step(Procedures::Packages::CheckUpdate)
+      end
+    end
+
     class Install < ForemanMaintain::Scenario
       metadata do
         description 'install packages in unlocked session'

--- a/lib/foreman_maintain/cli/packages_command.rb
+++ b/lib/foreman_maintain/cli/packages_command.rb
@@ -22,6 +22,13 @@ module ForemanMaintain
         end
       end
 
+      subcommand 'check-update', 'Check for available package updates' do
+        interactive_option
+        def execute
+          run_scenarios_and_exit(Scenarios::Packages::CheckUpdate.new)
+        end
+      end
+
       subcommand 'install', 'Install packages in an unlocked session' do
         interactive_option
         parameter 'PACKAGES ...', 'packages to install', :attribute_name => :packages

--- a/test/lib/cli/packages_command_test.rb
+++ b/test/lib/cli/packages_command_test.rb
@@ -23,6 +23,7 @@ module ForemanMaintain
             lock                          Prevent packages from automatic update
             unlock                        Enable packages for automatic update
             status                        Check if packages are protected against update
+            check-update                  Check for available package updates
             install                       Install packages in an unlocked session
             update                        Update packages in an unlocked session
             is-locked                     Check if update of packages is allowed

--- a/test/lib/package_manager/yum_test.rb
+++ b/test/lib/package_manager/yum_test.rb
@@ -5,7 +5,8 @@ require 'foreman_maintain/package_manager'
 module ForemanMaintain
   describe PackageManager::Yum do
     def expect_sys_execute(command, via: :execute,
-                           execute_options: { :interactive => true }, response: 'OK')
+                           execute_options: { :interactive => true, :valid_exit_statuses => [0] },
+                           response: 'OK')
       ForemanMaintain::Utils::SystemHelpers.expects(via).
         with(command, execute_options).returns(response)
     end
@@ -85,49 +86,57 @@ module ForemanMaintain
 
     describe 'install' do
       it 'invokes yum to install single package' do
-        expect_sys_execute('yum install package', :via => :execute!)
+        expect_sys_execute('yum --disableplugin=foreman-protector install package',
+                           :via => :execute!)
         subject.install('package')
       end
 
       it 'invokes yum to install list of packages' do
-        expect_sys_execute('yum install package1 package2', :via => :execute!)
+        expect_sys_execute('yum --disableplugin=foreman-protector install package1 package2',
+                           :via => :execute!)
         subject.install(%w[package1 package2], :assumeyes => false)
       end
 
       it 'invokes yum to install package with yes enforced' do
-        expect_sys_execute('yum -y install package', :via => :execute!,
-                                                     :execute_options => { :interactive => false })
+        expect_sys_execute('yum -y --disableplugin=foreman-protector install package',
+                           :via => :execute!, :execute_options => { :interactive => false,
+                                                                    :valid_exit_statuses => [0] })
         subject.install('package', :assumeyes => true)
       end
     end
 
     describe 'update' do
       it 'invokes yum to update single package' do
-        expect_sys_execute('yum update package', :via => :execute!)
+        expect_sys_execute('yum --disableplugin=foreman-protector update package',
+                           :via => :execute!)
         subject.update('package')
       end
 
       it 'invokes yum to update list of packages' do
-        expect_sys_execute('yum update package1 package2', :via => :execute!)
+        expect_sys_execute('yum --disableplugin=foreman-protector update package1 package2',
+                           :via => :execute!)
         subject.update(%w[package1 package2])
       end
 
       it 'invokes yum to update package with yes enforced' do
-        expect_sys_execute('yum -y update package', :via => :execute!,
-                                                    :execute_options => { :interactive => false })
+        expect_sys_execute('yum -y --disableplugin=foreman-protector update package',
+                           :via => :execute!, :execute_options => { :interactive => false,
+                                                                    :valid_exit_statuses => [0] })
         subject.update('package', :assumeyes => true)
       end
 
       it 'invokes yum to update all packages' do
-        expect_sys_execute('yum update', :via => :execute!)
+        expect_sys_execute('yum --disableplugin=foreman-protector update', :via => :execute!)
         subject.update
       end
     end
 
     describe 'clean_cache' do
       it 'invokes yum to clean cache' do
-        expect_sys_execute('yum -y clean all', :via => :execute!,
-                                               :execute_options => { :interactive => false })
+        expect_sys_execute('yum -y --disableplugin=foreman-protector clean all',
+                           :via => :execute!,
+                           :execute_options => { :interactive => false,
+                                                 :valid_exit_statuses => [0] })
         subject.clean_cache(:assumeyes => true)
       end
     end


### PR DESCRIPTION

```
$ yum check-update
Loaded plugins: foreman-protector, product-id, search-disabled-repos, subscription-manager

WARNING: Excluding 12529 packages due to foreman-protector. 
Use foreman-maintain packages install/update <package> 
to safely install packages without restrictions.
Use foreman-maintain upgrade run for full upgrade.
```


```
$ ./bin/foreman-maintain packages check-update
Running Check for available package updates
================================================================================
Check for available package updates: 
Loaded plugins: product-id, search-disabled-repos, subscription-manager

microcode_ctl.x86_64                 2:2.1-61.6.el7_8         rhel-7-server-rpms
tomcat.noarch                        7.0.76-12.el7_8          rhel-7-server-rpms
tomcat-el-2.2-api.noarch             7.0.76-12.el7_8          rhel-7-server-rpms
tomcat-jsp-2.2-api.noarch            7.0.76-12.el7_8          rhel-7-server-rpms
tomcat-lib.noarch                    7.0.76-12.el7_8          rhel-7-server-rpms
tomcat-servlet-3.0-api.noarch        7.0.76-12.el7_8          rhel-7-server-rpms
                                                                      [OK]
--------------------------------------------------------------------------------

```