### PR TITLE
Fixes #30164 - Manage cron service in foreman-maintain restore

### DIFF
--- a/definitions/scenarios/restore.rb
+++ b/definitions/scenarios/restore.rb
@@ -20,6 +20,7 @@ module ForemanMaintain::Scenarios
                              Checks::Restore::ValidateHostname,
                              Procedures::Selinux::SetFileSecurity,
                              Procedures::Restore::Configs)
+      add_step_with_context(Procedures::Crond::Stop) if feature(:cron)
       unless backup.incremental?
         add_steps_with_context(Procedures::Restore::EnsureMongoEngineMatches,
                                Procedures::Restore::InstallerReset)
@@ -41,6 +42,7 @@ module ForemanMaintain::Scenarios
       add_steps_with_context(Procedures::Restore::RegenerateQueues) if backup.online_backup?
       add_steps_with_context(Procedures::Service::Start,
                              Procedures::Service::DaemonReload)
+      add_step_with_context(Procedures::Crond::Start) if feature(:cron)
     end
     # rubocop:enable Metrics/MethodLength,Metrics/AbcSize
 
@@ -96,6 +98,17 @@ module ForemanMaintain::Scenarios
 
       context.map(:incremental_backup,
                   Procedures::Selinux::SetFileSecurity => :incremental_backup)
+    end
+  end
+
+  class RestoreRescue < ForemanMaintain::Scenario
+    metadata do
+      description 'Resuce Restore backup'
+      manual_detection
+    end
+
+    def compose
+      add_step_with_context(Procedures::Crond::Stop) if feature(:cron)
     end
   end
 end

--- a/lib/foreman_maintain/cli/restore_command.rb
+++ b/lib/foreman_maintain/cli/restore_command.rb
@@ -13,7 +13,8 @@ module ForemanMaintain
           :backup_dir => @backup_dir,
           :incremental_backup => @incremental || incremental_backup?
         )
-        run_scenario(scenario)
+        rescue_scenario = Scenarios::RestoreRescue.new
+        run_scenario(scenario, rescue_scenario)
         exit runner.exit_code
       end
 


### PR DESCRIPTION
With this PR, cron will be only managed in the foreman-maintain restore scenario if `:manage_crond: true` in `/etc/foreman-maintain/foreman_maintain.yml`