### PR TITLE
Fixes #30458 - don't run steps inside content subcommands

### DIFF
--- a/definitions/procedures/content/prepare.rb
+++ b/definitions/procedures/content/prepare.rb
@@ -3,6 +3,11 @@ module Procedures::Content
     metadata do
       description 'Prepare content for Pulp 3'
       for_feature :pulpcore
+
+      confine do
+        # FIXME: remove this condition on next downstream upgrade scenario
+        !feature(:instance).downstream
+      end
     end
 
     def run

--- a/definitions/procedures/content/switchover.rb
+++ b/definitions/procedures/content/switchover.rb
@@ -3,6 +3,11 @@ module Procedures::Content
     metadata do
       description 'Switch support for certain content from Pulp 2 to Pulp 3'
       for_feature :pulpcore
+
+      confine do
+        # FIXME: remove this condition on next downstream upgrade scenario
+        !feature(:instance).downstream
+      end
     end
 
     def run

--- a/definitions/scenarios/content.rb
+++ b/definitions/scenarios/content.rb
@@ -8,7 +8,10 @@ module ForemanMaintain::Scenarios
       end
 
       def compose
-        add_step(Procedures::Content::Prepare)
+        # FIXME: remove this condition on next downstream upgrade scenario
+        if Procedures::Content::Prepare.present?
+          add_step(Procedures::Content::Prepare)
+        end
       end
     end
 
@@ -20,7 +23,10 @@ module ForemanMaintain::Scenarios
       end
 
       def compose
-        add_step(Procedures::Content::Switchover)
+        # FIXME: remove this condition on next downstream upgrade scenario
+        if Procedures::Content::Switchover.present?
+          add_step(Procedures::Content::Switchover)
+        end
       end
     end
   end


### PR DESCRIPTION
@jameerpathan111, 
With this commit, it won't hide `content` command and its sub-commands but foreman-maintain will not run any step or procedure during their invocation.

In my opinion as this is a temporary change, we shouldn't change code base much just to hide these commands. If I get any alternative with minimal code changes which hide this content command then I will post updates.