### PR TITLE
Fixes #30469 - Use data_dir with tar transform option

### DIFF
--- a/lib/foreman_maintain/concerns/base_database.rb
+++ b/lib/foreman_maintain/concerns/base_database.rb
@@ -82,7 +82,7 @@ module ForemanMaintain
           tar_options = {
             :archive => backup_file,
             :command => 'create',
-            :transform => 's,^,var/lib/pgsql/data/,S',
+            :transform => "s,^,#{data_dir[1..-1]},S",
             :files => '*'
           }.merge(extra_tar_options)
           feature(:tar).run(tar_options)


### PR DESCRIPTION
While introducing pgsql 12 we missed to handle tar transform option conditionally to select pgsql 12 data directory. Because of this backup is collected with transform `var/lib/pgsql/data/`. When this backup gets restored it extracts the tar file in `/var/lib/pgsql/data` instead of `/var/opt/rh/rh-postgresql12/lib/pgsql/data/` ; hence on restore the db is empty and does not match with backup.