### PR TITLE
Fixes #30471 - Return status code 75 on successful self upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,39 +116,39 @@ the *pre-upgrade check* phase. In case the upgrade failed before **migrations**
 phase made some modifying changes, the tool tries to rollback to the previous
 state of the system.
 
-The `foreman-maintain upgrade check` and `foreman-maintain upgrade run` commands execute
-the self update procedure. This tries to update `rubygem-foreman_maintain` package
-from repositories configured on system. If updade is available and successfully completed
-user is asked to re-run the upgrade to use new sources from updated package. With this
-successful upgrade also return status code as 75 which therotically means temporary
-failure and manual user intervetion is required. Below is example of self update,
+#### Self-upgrade for rubygem-foreman_maintain package
 
-```
-# foreman-maintain upgrade check --target-version TARGET_VERSION
-Checking for new version of foreman-maintain...
+**Note:** This feature is available from `rubygem-foreman_maintain` version 0.6.4 and newer.
 
-rubygem-foreman_maintain.noarch   repository
+When a user runs any `foreman-maintain upgrade` sub commands (e.g. `foreman-maintain upgrade check` or `foreman-maintain upgrade run`) then,
 
-Updating foreman-maintain package.
+  * If update available for `rubygem-foreman_maintain` package, the sub command tries to update this package. After successful package update, it returns the exit code 75 and requests user to re-run with the updated source code.
 
-The foreman-maintain package successfully updated.
-Re-run foreman-maintain with required options!
+    Here, exit code (value 75) is to indicate that it can not continue with further execution & needs re-run. e.g.,
 
-# echo $?
-75
-```
+    ~~~
+    # foreman-maintain upgrade check --target-version TARGET_VERSION
+    Checking for new version of foreman-maintain...
+    rubygem-foreman_maintain.noarch   repository
 
-If user wants to skip self update mechanism `--disable-self-upgrade` can be used with
-`upgrade check` and `upgrade run` commands, as example,
+    Updating foreman-maintain package.
 
-```
-# foreman-maintain upgrade check --target-version TARGET_VERSION --disable-self-upgrade
+    The foreman-maintain package successfully updated.
 
-# foreman-maintain upgrade run --target-version TARGET_VERSION --disable-self-upgrade
-```
+    Re-run foreman-maintain with required options!
 
-If there isn't any new version available for `rubygem-foreman_maintain` package the upgrade
-continues without halt.
+    # echo $?
+    75
+    ~~~
+
+  * If update is not available for `rubygem-foreman_maintain` package, then sub command simply executes the further steps without halt.
+
+  * If user wants to skip self-update mechanism then `--disable-self-upgrade` flag can be used with upgrade sub commands. e.g.,
+
+  ~~~
+  # foreman-maintain upgrade check --target-version TARGET_VERSION --disable-self-upgrade
+  # foreman-maintain upgrade run --target-version TARGET_VERSION --disable-self-upgrade
+  ~~~
 
 #### Satellite notes
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Foreman Maintenance [![Build Status](https://travis-ci.org/theforeman/foreman_maintain.svg?branch=master)](https://travis-ci.org/theforeman/foreman_maintain) <a href="https://codeclimate.com/github/theforeman/foreman_maintain"><img src="https://codeclimate.com/github/theforeman/foreman_maintain/badges/gpa.svg" /></a>
 
-`foreman_maintain` aims to provide various features that helps keep the
+The `foreman_maintain` aims to provide various features that helps keep the
 Foreman/Satellite up and running. It supports multiple versions and subparts
 of the Foreman infrastructure, including server or smart proxy and is smart
 enough to provide the right tools for the specific version.
@@ -19,8 +19,10 @@ Subcommands:
     upgrade                       Upgrade related commands
       list-versions                 List versions this system is upgradable to
       check --target-version TARGET_VERSION   Run pre-upgrade checks for upgrading to specified version
+            --disable-self-upgrade            Disable automatic self upgrade (default: false)
       run --target-version TARGET_VERSION     Run the full upgrade
           [--phase=phase TARGET_VERSION]      Run just a specific phase of the upgrade
+          --disable-self-upgrade              Disable automatic self upgrade (default: false)
 
     advanced                      Advanced tools for server maintenance
       procedure                     Run maintain procedures manually
@@ -59,8 +61,8 @@ Subcommands:
 Foreman-maintain implements upgrade tooling that helps the administrator to go
 through the upgrade process.
 
-Foreman-maintain scans the system to know, what version are available
-to upgrade to for the particular system. To see what versions are available
+Foreman-maintain scans the system to know, what versions are available
+for upgrade on the particular system. To see what versions are available
 for upgrade, run:
 
 ```
@@ -88,13 +90,13 @@ of the system:
 
   * **pre-migrations** - these steps perform changes on the system before
     the actual upgrade starts. An example is disabling access to the system from
-    external sources, a.k.a. maintenance mode or disabling sync plans during the run.
+    external sources, a.k.a. maintenance mode or disabling Katello sync plans during the run.
 
     After this phase ends, the system is still running the old version, and it's possible
     to revert the changes by running the post-migrations steps.
 
   * **migrations** - this phase performs the actual migrations, starting with
-    configuring new repositories, updated the packages and running the installer.
+    configuring new repositories, updating the packages and running the installer.
 
     At the end of this phase, the system should be fully migrated to the new version.
     However, the system is not fully operational yet, as the post-migrations steps
@@ -103,7 +105,7 @@ of the system:
   * **post-migrations** - these steps revert the changes made in pre-migrations phase,
     turning the system into fully-operational again.
 
-  * **post-upgrade checks** - this steps should perform sanity check of the system
+  * **post-upgrade checks** - these steps should perform sanity check of the system
     to ensure the system is valid and ready to be used again.
 
 
@@ -113,6 +115,40 @@ in case the upgrade is already in *migrations* phase, there is no point in runni
 the *pre-upgrade check* phase. In case the upgrade failed before **migrations**
 phase made some modifying changes, the tool tries to rollback to the previous
 state of the system.
+
+The `foreman-maintain upgrade check` and `foreman-maintain upgrade run` commands execute
+the self update procedure. This tries to update `rubygem-foreman_maintain` package
+from repositories configured on system. If updade is available and successfully completed
+user is asked to re-run the upgrade to use new sources from updated package. With this
+successful upgrade also return status code as 75 which therotically means temporary
+failure and manual user intervetion is required. Below is example of self update,
+
+```
+# foreman-maintain upgrade check --target-version TARGET_VERSION
+Checking for new version of foreman-maintain...
+
+rubygem-foreman_maintain.noarch   repository
+
+Updating foreman-maintain package.
+
+The foreman-maintain package successfully updated.
+Re-run foreman-maintain with required options!
+
+# echo $?
+75
+```
+
+If user wants to skip self update mechanism `--disable-self-upgrade` can be used with
+`upgrade check` and `upgrade run` commands, as example,
+
+```
+# foreman-maintain upgrade check --target-version TARGET_VERSION --disable-self-upgrade
+
+# foreman-maintain upgrade run --target-version TARGET_VERSION --disable-self-upgrade
+```
+
+If there isn't any new version available for `rubygem-foreman_maintain` package the upgrade
+continues without halt.
 
 #### Satellite notes
 
@@ -132,7 +168,7 @@ export FOREMAN_MAINTAIN_USE_BETA='1'
 
 ## Implementation
 
-`foreman_maintain` maps the CLI commands into definitions. This allows to keep the set
+The `foreman_maintain` maps the CLI commands into definitions. This allows to keep the set
 of the commands the user needs to know immutable from version-specific changes. The mapping
 between the CLI commands and definitions is made by defining various metadata.
 
@@ -329,8 +365,8 @@ end
 ```
 
 Before executing the command the feature checks if it has valid hammer configuration to run the command.
-Foreman maintain always use the 'admin' account to run the commands. The password is taken either form
-the Hammer config or installer answer files or asked from the user interactively (in this order).
+Foreman maintain always use the 'admin' account to run the commands. The password is taken from
+the hammer config or installer answer files or asked from the user interactively (in this order).
 The valid credentials are stored and reused next time if still valid.
 
 Usually we want to do the user interaction at the beginning of our scenario.
@@ -449,7 +485,7 @@ Possible options for the `:completion` attribute are:
 * `maintenance-mode is-enabled` returns `0 or 1` output depending upon the maintenance-mode status.
 Here, 0=ON & 1=OFF.
 
-If User would like to check whether maintenance-mode is ON/OFF on system in their external script then
+If users would like to check whether maintenance-mode is ON/OFF on system in their external script then
 they can use subcommand `foreman-maintain maintenance-mode is-enabled`.
 
 ## How to contribute?

--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -168,7 +168,7 @@ module ForemanMaintain
         ForemanMaintain.package_manager.update(main_package_name, :assumeyes => true)
         puts "\nThe #{package_name} package successfully updated."\
              "\nRe-run #{command} with required options!"
-        exit 0
+        exit 75
       end
       puts "Nothing to update, can't find new version of #{package_name}."
     end


### PR DESCRIPTION
The self upgrade mechanism use to return status code 0 on successful package upgrade, however this does not help to know if fm run was actually completed or not as 0 status code is for successful command execution. To handle this scenario now self upgrade will return status code 75 which means 'Temporary failure and user intervention is required'