### PR TITLE
Fixes #30527 - Add check for duplicate permissions

### DIFF
--- a/definitions/checks/foreman/check_duplicate_permission.rb
+++ b/definitions/checks/foreman/check_duplicate_permission.rb
@@ -4,7 +4,7 @@ module Checks
       metadata do
         label :duplicate_permission
         for_feature :foreman_database
-        description 'Check for duplicate permission from DB'
+        description 'Check for duplicate permission from database'
         tags :default
       end
 
@@ -25,7 +25,7 @@ module Checks
 
       def self.query_to_get_duplicate_permission
         <<-SQL
-          SELECT count(*), name, resource_type  FROM permissions GROUP BY name, resource_type HAVING count(*) > 1
+          SELECT id,name FROM permissions p WHERE (SELECT count(name) FROM permissions pr WHERE p.name =pr.name) > 1
         SQL
       end
     end

--- a/definitions/checks/foreman/check_duplicate_permission.rb
+++ b/definitions/checks/foreman/check_duplicate_permission.rb
@@ -1,0 +1,33 @@
+module Checks
+  module Foreman
+    class CheckDuplicatePermission < ForemanMaintain::Check
+      metadata do
+        label :duplicate_permission
+        for_feature :foreman_database
+        description 'Check for duplicate permission from DB'
+        tags :default
+      end
+
+      def run
+        duplicate_permissions = find_duplicate_permission
+        assert(
+          duplicate_permissions.empty?,
+          'Duplicate permissions in your DB',
+          :next_steps => [
+            Procedures::Foreman::RemoveDuplicatePermissions.new
+          ]
+        )
+      end
+
+      def find_duplicate_permission
+        feature(:foreman_database).query(self.class.query_to_get_duplicate_permission)
+      end
+
+      def self.query_to_get_duplicate_permission
+        <<-SQL
+          SELECT count(*), name, resource_type  FROM permissions GROUP BY name, resource_type HAVING count(*) > 1
+        SQL
+      end
+    end
+  end
+end

--- a/definitions/checks/foreman/check_duplicate_permission.rb
+++ b/definitions/checks/foreman/check_duplicate_permission.rb
@@ -5,7 +5,7 @@ module Checks
         label :duplicate_permissions
         for_feature :foreman_database
         description 'Check for duplicate permissions from database'
-        tags :default
+        tags :pre_upgrade
       end
 
       def run

--- a/definitions/checks/foreman/check_duplicate_permission.rb
+++ b/definitions/checks/foreman/check_duplicate_permission.rb
@@ -1,25 +1,25 @@
 module Checks
   module Foreman
-    class CheckDuplicatePermission < ForemanMaintain::Check
+    class CheckDuplicatePermissions < ForemanMaintain::Check
       metadata do
-        label :duplicate_permission
+        label :duplicate_permissions
         for_feature :foreman_database
-        description 'Check for duplicate permission from database'
+        description 'Check for duplicate permissions from database'
         tags :default
       end
 
       def run
-        duplicate_permissions = find_duplicate_permission
+        duplicate_permissions = find_duplicate_permissions
         assert(
           duplicate_permissions.empty?,
-          'Duplicate permissions in your DB',
+          'Duplicate permissions in your database',
           :next_steps => [
             Procedures::Foreman::RemoveDuplicatePermissions.new
           ]
         )
       end
 
-      def find_duplicate_permission
+      def find_duplicate_permissions
         feature(:foreman_database).query(self.class.query_to_get_duplicate_permission)
       end
 

--- a/definitions/procedures/foreman/remove_duplicate_permissions.rb
+++ b/definitions/procedures/foreman/remove_duplicate_permissions.rb
@@ -1,0 +1,80 @@
+module Procedures::Foreman
+  class RemoveDuplicatePermissions < ForemanMaintain::Procedure
+    metadata do
+      for_feature :foreman_database
+      description 'Remove duplicate permissions from DB'
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    def run
+      duplicate_permissions = feature(:foreman_database).query(
+        Checks::Foreman::CheckDuplicatePermission.query_to_get_duplicate_permission
+      )
+      duplicate_permissions.each do |permission|
+        assigned_permissions = []
+        ids = feature(:foreman_database).query(query_to_get_permission_ids(permission)).
+              flat_map(&:values)
+        ids.each do |permission_id|
+          filterings = feature(:foreman_database).
+                       query(query_to_check_permission_assign_to_filter(permission_id))
+          if filterings.empty?
+            delete_permission(permission_id)
+          else
+            assigned_permissions << permission_id
+          end
+        end
+        if assigned_permissions.length > 1
+          fix_permissions(assigned_permissions)
+        end
+      end
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    private
+
+    def fix_permissions(assigned_permissions)
+      persist_permission = assigned_permissions.shift
+      assigned_permissions.each do |permission|
+        update_filtering(permission, persist_permission)
+        delete_permission(permission)
+      end
+    end
+
+    def update_filtering(old_id, new_id)
+      sql = <<-SQL
+      WITH rows AS (
+        UPDATE filterings SET permission_id = '#{new_id}' WHERE permission_id = '#{old_id}'
+        RETURNING id
+      )
+      SELECT id
+      FROM rows
+      SQL
+
+      feature(:foreman_database).query(sql)
+    end
+
+    def delete_permission(permission_id)
+      sql = <<-SQL
+      WITH rows AS (
+        DELETE FROM permissions where id = '#{permission_id}' RETURNING id
+      )
+      SELECT id
+      FROM rows
+      SQL
+
+      feature(:foreman_database).query(sql)
+    end
+
+    def query_to_get_permission_ids(permission)
+      <<-SQL
+        SELECT id FROM permissions where name = '#{permission['name']}' and resource_type = '#{permission['resource_type']}'
+      SQL
+    end
+
+    def query_to_check_permission_assign_to_filter(permission_id)
+      <<-SQL
+        SELECT id, filter_id FROM filterings WHERE permission_id = '#{permission_id}'
+      SQL
+    end
+  end
+end

--- a/definitions/procedures/foreman/remove_duplicate_permissions.rb
+++ b/definitions/procedures/foreman/remove_duplicate_permissions.rb
@@ -59,11 +59,5 @@ module Procedures::Foreman
 
       feature(:foreman_database).query(sql)
     end
-
-    def query_to_check_permission_assign_to_filter(permission_ids)
-      <<-SQL
-        SELECT id, filter_id, permission_id FROM filterings WHERE permission_id IN (#{permission_ids.join(',')})
-      SQL
-    end
   end
 end

--- a/definitions/procedures/foreman/remove_duplicate_permissions.rb
+++ b/definitions/procedures/foreman/remove_duplicate_permissions.rb
@@ -31,7 +31,7 @@ module Procedures::Foreman
 
     def fix_permissions(assigned_permissions)
       persist_permission = assigned_permissions.shift
-      filter_ids = filters_for_permission(persist_permission).map { |filter| filter['filter_id'] }
+      filter_ids = filters_for_permission(persist_permission)
       update_filtering(assigned_permissions, persist_permission, filter_ids)
       delete_filtering(assigned_permissions)
       delete_permission(assigned_permissions)
@@ -40,7 +40,7 @@ module Procedures::Foreman
     def filters_for_permission(permission)
       feature(:foreman_database).query(
         "SELECT filter_id FROM filterings WHERE permission_id = #{permission.to_i}"
-      )
+      ).map { |filter| filter['filter_id'] }
     end
 
     def update_filtering(old_ids, new_id, filter_ids)


### PR DESCRIPTION
How to reproduce the issue- 

1) Create the duplicate filter. 
`INSERT INTO permissions (name, resource_type) VALUES ('edit_ansible_variables', 'AnsibleVariable');`

2) From foreman UI create two filters in a single role and add both the duplicate permission "edit_ansible_variables" in the filter. You might need to verify the filterings table to make sure both permissions are present in the filter. 
`select * from filterings where filter_id = <FILTER_ID> or filter_id = <FILTER_ID>;`

Run `foreman-maintain health check --label duplicate_permission` to fix the permissions. 