### PR TITLE
Fixes #30589 - make packages update & install commands consistent

### DIFF
--- a/lib/foreman_maintain/cli/packages_command.rb
+++ b/lib/foreman_maintain/cli/packages_command.rb
@@ -38,7 +38,7 @@ module ForemanMaintain
 
       subcommand 'update', 'Update packages in an unlocked session' do
         interactive_option
-        parameter '[PACKAGES ...]', 'packages to update', :attribute_name => :packages
+        parameter '[PACKAGES] ...', 'packages to update', :attribute_name => :packages
 
         def execute
           run_scenarios_and_exit(


### PR DESCRIPTION
Foreman Maintain is based on clamp framework. If user declares multivalued (aka "greedy") parameter then it will consume all remaining command-line arguments. That's why, it is expected to pass other options before parameter value.

Refer readme section from clamp framework - https://github.com/mdub/clamp#multivalued-aka-greedy-parameters

