### PR TITLE
Fixes #30640 - Fix tftp storage check

### DIFF
--- a/definitions/checks/foreman_proxy/check_tftp_storage.rb
+++ b/definitions/checks/foreman_proxy/check_tftp_storage.rb
@@ -22,10 +22,11 @@ module Checks::ForemanProxy
     end
 
     def old_files_from_tftp_boot
-      Dir.entries(tftp_boot_directory).map do |file|
+      initrd = File.join(tftp_boot_directory, '/*-initrd.img')
+      vmlinuz = File.join(tftp_boot_directory, '/*-vmlinuz')
+      Dir.glob([initrd, vmlinuz]).map do |file|
         unless File.directory?(file)
-          file_path =  tftp_boot_directory + file
-          file_path if File.mtime(file_path) + (token_duration * 60) < Time.now
+          file if File.mtime(file) + (token_duration * 60) < Time.now
         end
       end.compact
     end

--- a/definitions/checks/foreman_proxy/check_tftp_storage.rb
+++ b/definitions/checks/foreman_proxy/check_tftp_storage.rb
@@ -22,9 +22,7 @@ module Checks::ForemanProxy
     end
 
     def old_files_from_tftp_boot
-      initrd = File.join(tftp_boot_directory, '/*-initrd.img')
-      vmlinuz = File.join(tftp_boot_directory, '/*-vmlinuz')
-      Dir.glob([initrd, vmlinuz]).map do |file|
+      Dir.glob("#{tftp_boot_directory}*-{vmlinuz,initrd.img}").map do |file|
         unless File.directory?(file)
           file if File.mtime(file) + (token_duration * 60) < Time.now
         end


### PR DESCRIPTION
```
root@satellite ~/foreman_maintain (fix-check-tftp-storage) $ ls /var/lib/tftpboot/boot/
fdi-image  red-hat-enterprise-linux-7-server-kickstart-x86_64-7-7-6-initrd.img  red-hat-enterprise-linux-7-server-kickstart-x86_64-7-7-6-vmlinuz  test.yml
root@satellite ~/foreman_maintain (fix-check-tftp-storage) $ 
root@satellite ~/foreman_maintain (fix-check-tftp-storage) $ ./bin/foreman-maintain health check --label check-tftp-storage
Running ForemanMaintain::Scenario::FilteredScenario
================================================================================
Clean old Kernel and initramfs files from tftp-boot:                  [FAIL]
There are old initrd and vmlinuz files present in tftp
--------------------------------------------------------------------------------
Continue with step [Remove the files]?, [y(yes), n(no), q(quit)] y
Remove the files:                                                     [OK]      
--------------------------------------------------------------------------------
Rerunning the check after fix procedure
Clean old Kernel and initramfs files from tftp-boot:                  [OK]
--------------------------------------------------------------------------------

root@satellite ~/foreman_maintain (fix-check-tftp-storage) $ ls /var/lib/tftpboot/boot/
fdi-image  test.yml
root@satellite ~/foreman_maintain (fix-check-tftp-storage) $ 
```