### PR TITLE
Fixes #30649 - self-update for list-versions

### DIFF
--- a/lib/foreman_maintain/cli/upgrade_command.rb
+++ b/lib/foreman_maintain/cli/upgrade_command.rb
@@ -53,7 +53,10 @@ module ForemanMaintain
       end
 
       subcommand 'list-versions', 'List versions this system is upgradable to' do
+        disable_self_upgrade_option
+
         def execute
+          ForemanMaintain.perform_self_upgrade unless disable_self_upgrade?
           print_versions(UpgradeRunner.available_targets)
         end
       end

--- a/test/lib/cli/upgrade_command_test.rb
+++ b/test/lib/cli/upgrade_command_test.rb
@@ -35,7 +35,7 @@ module ForemanMaintain
 
     describe 'list-versions' do
       let :command do
-        %w[upgrade list-versions]
+        %w[upgrade list-versions --disable-self-upgrade]
       end
       it 'lists the available versions' do
         assert_cmd <<-OUTPUT.strip_heredoc


### PR DESCRIPTION
Fixes #30649

Description:
This PR adds support for `foreman-maintain upgrade list-versions` to check if update for foreman-maintain package is available.

```
[root@dell-per620-2 foreman_maintain]# ./bin/foreman-maintain upgrade list-versions --help
Usage:
    foreman-maintain upgrade list-versions [OPTIONS]

Options:
    --disable-self-upgrade        Disable automatic self upgrade (default: false)
    -h, --help                    print help

[root@dell-per620-2 foreman_maintain]# ./bin/foreman-maintain upgrade list-versions
Checking for new version of satellite-maintain...

rubygem-foreman_maintain.noarch                                               1:0.6.8-1.el7sat                                                foreman-maintain
Security: kernel-3.10.0-1127.18.2.el7.x86_64 is an installed security update
Security: kernel-3.10.0-1127.el7.x86_64 is the currently running version

Updating satellite-maintain package.

The satellite-maintain package successfully updated.
Re-run satellite-maintain with required options!

[root@dell-per620-2 foreman_maintain]# ./bin/foreman-maintain upgrade list-versions --disable-self-upgrade
6.6.z
6.7


```