### PR TITLE
Fixes #30810 - Print error to stderr

### DIFF
--- a/lib/foreman_maintain/cli.rb
+++ b/lib/foreman_maintain/cli.rb
@@ -57,7 +57,7 @@ module ForemanMaintain
           raise error
         end
 
-        puts error.message
+        $stderr.puts error.message
         logger.error(error)
 
         @exit_code = 1
@@ -65,7 +65,7 @@ module ForemanMaintain
 
       def process_usage_error(error)
         log_exit_code_info(1)
-        puts error.message
+        $stderr.puts error.message
         exit!
       end
     end


### PR DESCRIPTION
With this fix, foreman-maintain will write the error to stderr and not to stdout. 

This can be verified by running 

`# foreman-maintain upgrade run --assumeyes --target-version=6.7  2> /tmp/stderr.txt`

If the target version is the same as the installed version of the satellite then it throws the error to stderr. 

Below is output of remote capsule upgrade job from the satellite.

`19:
TASK [Print satellite-maintain output] *****************************************
  20:
ok: [vm249-193.gsslab.pnq2.redhat.com] => {
  21:
    "result": {
  22:
        "changed": true, 
  23:
        "cmd": "satellite-maintain upgrade run --assumeyes --target-version=6.7 --whitelist=\"disk-io\"", 
  24:
        "delta": "0:00:17.574305", 
  25:
        "end": "2020-09-10 10:50:47.030845", 
  26:
        "failed": true, 
  27:
        "msg": "non-zero return code", 
  28:
        "rc": 1, 
  29:
        "start": "2020-09-10 10:50:29.456540", 
  30:
        "stderr": "Can't upgrade to 6.7\nPossible target versions are:\n6.8", 
  31:
        "stderr_lines": [
  32:
            "Can't upgrade to 6.7", 
  33:
            "Possible target versions are:", 
  34:
            "6.8"
  35:
        ], 
  36:
        "stdout": "Checking for new version of satellite-maintain...\nNothing to update, can't find new version of satellite-maintain.", 
  37:
        "stdout_lines": [
  38:
            "Checking for new version of satellite-maintain...", 
  39:
            "Nothing to update, can't find new version of satellite-maintain."
  40:
        ]
  41:
    }
  42:
}`
