### PR TITLE
Fixes #31124 - Don't start pulp 3 if it's not enabled

### DIFF
--- a/definitions/features/pulpcore.rb
+++ b/definitions/features/pulpcore.rb
@@ -5,7 +5,8 @@ class Features::Pulpcore < ForemanMaintain::Feature
     label :pulpcore
 
     confine do
-      ForemanMaintain::Utils::Service::Systemd.new('pulpcore-api', 0).exist?
+      ForemanMaintain::Utils::Service::Systemd.new('pulpcore-api', 0).exist? &&
+        ForemanMaintain::Utils::Service::Systemd.new('pulpcore-api', 0).enabled?
     end
   end
 

--- a/lib/foreman_maintain/utils/service/systemd.rb
+++ b/lib/foreman_maintain/utils/service/systemd.rb
@@ -50,10 +50,16 @@ module ForemanMaintain::Utils
 
       def exist?
         if @sys.systemd_installed?
-          systemd = @sys.execute("systemctl is-enabled #{@name} 2>&1 | tail -1").strip
+          systemd = service_enabled_status
           systemd == 'enabled' || systemd == 'disabled'
         else
           File.exist?("/etc/init.d/#{@name}")
+        end
+      end
+
+      def enabled?
+        if @sys.systemd_installed?
+          service_enabled_status == 'enabled'
         end
       end
 
@@ -61,6 +67,10 @@ module ForemanMaintain::Utils
 
       def execute(action, options = {})
         @sys.execute_with_status(command(action, options))
+      end
+
+      def service_enabled_status
+        @sys.execute("systemctl is-enabled #{@name} 2>&1 | tail -1").strip
       end
 
       def skip_enablement_message(action, name)


### PR DESCRIPTION
Pulp 3 services should not be touched if they are not enabled.  This helps ensure that Pulp 3 is not running if the environment is not yet using it.