### PR TITLE
Fixes #31172 - content prepare on sat 6.9 must handle pulpcore services

### DIFF
--- a/definitions/features/pulpcore.rb
+++ b/definitions/features/pulpcore.rb
@@ -10,19 +10,35 @@ class Features::Pulpcore < ForemanMaintain::Feature
   end
 
   def services
-    [
-      system_service('rh-redis5-redis', 5),
-      system_service('pulpcore-api', 10),
-      system_service('pulpcore-content', 10),
-      system_service('pulpcore-resource-manager', 10),
+    pulpcore_common_services + [
       system_service('pulpcore-worker@*', 20, :all => true, :skip_enablement => true),
       system_service('httpd', 30)
+    ]
+  end
+
+  def pulpcore_migration_services
+    pulpcore_common_services + [
+      system_service('pulpcore-worker@1', 20),
+      system_service('pulpcore-worker@2', 20),
+      system_service('pulpcore-worker@3', 20),
+      system_service('pulpcore-worker@4', 20)
     ]
   end
 
   def config_files
     [
       '/etc/pulp/settings.py'
+    ]
+  end
+
+  private
+
+  def pulpcore_common_services
+    [
+      system_service('rh-redis5-redis', 5),
+      system_service('pulpcore-api', 10),
+      system_service('pulpcore-content', 10),
+      system_service('pulpcore-resource-manager', 10)
     ]
   end
 end

--- a/definitions/procedures/content/prepare.rb
+++ b/definitions/procedures/content/prepare.rb
@@ -6,7 +6,7 @@ module Procedures::Content
 
       confine do
         # FIXME: remove this condition on next downstream upgrade scenario
-        !feature(:instance).downstream
+        !feature(:satellite) || feature(:satellite).at_least_version?('6.9')
       end
     end
 

--- a/definitions/scenarios/content.rb
+++ b/definitions/scenarios/content.rb
@@ -10,7 +10,30 @@ module ForemanMaintain::Scenarios
       def compose
         # FIXME: remove this condition on next downstream upgrade scenario
         if Procedures::Content::Prepare.present?
+          enable_and_start_services
           add_step(Procedures::Content::Prepare)
+          disable_and_stop_services
+        end
+      end
+
+      private
+
+      def enable_and_start_services
+        add_step(Procedures::Service::Start)
+        if feature(:satellite) && feature(:satellite).at_least_version?('6.9')
+          add_step(Procedures::Service::Enable.
+                   new(:only => feature(:pulpcore).pulpcore_migration_services))
+          add_step(Procedures::Service::Start.
+                   new(:only => feature(:pulpcore).pulpcore_migration_services))
+        end
+      end
+
+      def disable_and_stop_services
+        if feature(:satellite) && feature(:satellite).current_minor_version == '6.9'
+          add_step(Procedures::Service::Stop.
+                   new(:only => feature(:pulpcore).pulpcore_migration_services))
+          add_step(Procedures::Service::Disable.
+                   new(:only => feature(:pulpcore).pulpcore_migration_services))
         end
       end
     end


### PR DESCRIPTION
For Satellite 6.9, content prepare needs to ensure that Pulpcore services are only enabled and running when the Pulp 3 migration is running.

To get around the issue of determining how many Pulpcore workers to start, we are going to simply stick to starting 4 workers.  Not all workers should be on anyway since Pulpcore will be running alongside Pulp 2.  Having too many workers could degrade system performance.

To test:

1) Hack foreman-maintain so it thinks you have satellite installed and returns only `6.9` as the installed version
-> `version_from_source` in `definitions/features/satellite.rb`
-> The `confine` block in `definitions/features/satellite.rb`
-> `current_minor_version` in `lib/foreman_maintain/concerns/downstream.rb`
2) Edit `run` in `definitions/procedures/content/prepare.rb` in case foreman-rake is not on your system
3) Run your "stubbed" `bin/foreman-maintain content prepare` and see that the steps: enable->start->migration->stop->disable