### PR TITLE
Fixes #31210 - add check for diskusage in cp-dir

### DIFF
--- a/definitions/checks/disk/available_space_candlepin.rb
+++ b/definitions/checks/disk/available_space_candlepin.rb
@@ -1,0 +1,27 @@
+module Checks
+  module Disk
+    class AvailableSpaceCandlepin < ForemanMaintain::Check
+      metadata do
+        label :available_space_cp
+        description 'Check to make sure /var/lib/candlepin has enough space'
+        tags :pre_upgrade
+        confine do
+          feature(:candlepin) && check_min_version('candlepin', '3.1')
+        end
+      end
+
+      MAX_USAGE_IN_PERCENT = 90
+
+      def run
+        assert(enough_space?, "System has more than #{MAX_USAGE_IN_PERCENT}% space used"\
+               " on #{feature(:candlepin).work_dir}.\n"\
+               'See https://bugzilla.redhat.com/show_bug.cgi?id=1898605')
+      end
+
+      def enough_space?
+        io_obj = ForemanMaintain::Utils::Disk::IODevice.new(feature(:candlepin).work_dir)
+        io_obj.space_used_in_percent < MAX_USAGE_IN_PERCENT
+      end
+    end
+  end
+end

--- a/definitions/features/candlepin.rb
+++ b/definitions/features/candlepin.rb
@@ -7,6 +7,10 @@ class Features::Candlepin < ForemanMaintain::Feature
     end
   end
 
+  def work_dir
+    '/var/lib/candlepin'
+  end
+
   def services
     [
       system_service('tomcat', 20),

--- a/lib/foreman_maintain/utils/disk/io_device.rb
+++ b/lib/foreman_maintain/utils/disk/io_device.rb
@@ -22,6 +22,10 @@ module ForemanMaintain
           convert_kb_to_mb(execute!("df #{dir}|awk {'print $4'}|tail -1").to_i)
         end
 
+        def space_used_in_percent
+          execute!("df #{dir}|awk {'print $5'}|tail -1").to_i
+        end
+
         private
 
         # In fio command, --direct option bypass the cache page


### PR DESCRIPTION
Make sure /var/lib/candlepin has enough free space.