### PR TITLE
Fixes #31196 - add foreman-maintain content migration-stats

### DIFF
--- a/definitions/procedures/content/migration_stats.rb
+++ b/definitions/procedures/content/migration_stats.rb
@@ -1,0 +1,12 @@
+module Procedures::Content
+  class MigrationStats < ForemanMaintain::Procedure
+    metadata do
+      description 'Retrieve Pulp 2 to Pulp 3 migration statistics'
+      for_feature :pulpcore
+    end
+
+    def run
+      puts execute!('foreman-rake katello:pulp3_migration_stats')
+    end
+  end
+end

--- a/definitions/scenarios/content.rb
+++ b/definitions/scenarios/content.rb
@@ -52,5 +52,20 @@ module ForemanMaintain::Scenarios
         end
       end
     end
+
+    class MigrationStats < ForemanMaintain::Scenario
+      metadata do
+        label :content_migration_stats
+        description 'Retrieve Pulp 2 to Pulp 3 migration statistics'
+        manual_detection
+      end
+
+      def compose
+        # FIXME: remove this condition on next downstream upgrade scenario
+        if Procedures::Content::MigrationStats.present?
+          add_step(Procedures::Content::MigrationStats)
+        end
+      end
+    end
   end
 end

--- a/lib/foreman_maintain/cli/content_command.rb
+++ b/lib/foreman_maintain/cli/content_command.rb
@@ -12,6 +12,12 @@ module ForemanMaintain
           run_scenarios_and_exit(Scenarios::Content::Switchover.new)
         end
       end
+
+      subcommand 'migration-stats', 'Retrieve Pulp 2 to Pulp 3 migration statistics' do
+        def execute
+          run_scenarios_and_exit(Scenarios::Content::MigrationStats.new)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Same test steps as https://github.com/Katello/katello/pull/8995, but use `foreman-maintain content migration-stats` instead.  Testing should be done on a production install due to the use of foreman-rake.