### PR TITLE
Fixes #31253 - Validate if custom-hiera is yaml

### DIFF
--- a/definitions/checks/foreman/check_checkpoint_segments.rb
+++ b/definitions/checks/foreman/check_checkpoint_segments.rb
@@ -18,31 +18,36 @@ module Checks
       # rubocop:disable Metrics/MethodLength
       def check_custom_hiera
         hiera_file = feature(:installer).custom_hiera_file
-        if (config = YAML.load_file(hiera_file)) &&
-           config.key?('postgresql::server::config_entries')
-          if config['postgresql::server::config_entries'].nil?
-            return <<-MESSAGE.strip_heredoc
-            ERROR: 'postgresql::server::config_entries' cannot be null.
-            Please remove it from following file and re-run the command.
-            - #{hiera_file}
-            MESSAGE
-          elsif config['postgresql::server::config_entries'].key?('checkpoint_segments')
-            message = <<-MESSAGE.strip_heredoc
-            ERROR: Tuning option 'checkpoint_segments' found.
-            This option is no longer valid for PostgreSQL 9.5 or newer.
-            Please remove it from following file and re-run the command.
-            - #{hiera_file}
-            MESSAGE
-            if feature(:katello)
-              message += <<-MESSAGE.strip_heredoc
-              The presence of checkpoint_segments in #{hiera_file} indicates manual tuning.
-              Manual tuning can override values provided by the --tuning parameter.
-              Review #{hiera_file} for values that are already provided by the built in tuning profiles.
-              Built in tuning profiles also provide a supported upgrade path.
+        begin
+          if (config = YAML.load_file(hiera_file)) && config.is_a?(Hash) &&
+             config.key?('postgresql::server::config_entries')
+            if config['postgresql::server::config_entries'].nil?
+              return <<-MESSAGE.strip_heredoc
+              ERROR: 'postgresql::server::config_entries' cannot be null.
+              Please remove it from following file and re-run the command.
+              - #{hiera_file}
               MESSAGE
+            elsif config['postgresql::server::config_entries'].key?('checkpoint_segments')
+              message = <<-MESSAGE.strip_heredoc
+              ERROR: Tuning option 'checkpoint_segments' found.
+              This option is no longer valid for PostgreSQL 9.5 or newer.
+              Please remove it from following file and re-run the command.
+              - #{hiera_file}
+              MESSAGE
+              if feature(:katello)
+                message += <<-MESSAGE.strip_heredoc
+                The presence of checkpoint_segments in #{hiera_file} indicates manual tuning.
+                Manual tuning can override values provided by the --tuning parameter.
+                Review #{hiera_file} for values that are already provided by the built in tuning profiles.
+                Built in tuning profiles also provide a supported upgrade path.
+                MESSAGE
+              end
+              return message
             end
-            return message
           end
+        rescue Psych::SyntaxError
+          fail! "Found syntax error in file: #{hiera_file}"
+          exit 1
         end
       end
       # rubocop:enable Metrics/MethodLength

--- a/definitions/checks/foreman/check_checkpoint_segments.rb
+++ b/definitions/checks/foreman/check_checkpoint_segments.rb
@@ -19,8 +19,8 @@ module Checks
       def check_custom_hiera
         hiera_file = feature(:installer).custom_hiera_file
         begin
-          if (config = YAML.load_file(hiera_file)) && config.is_a?(Hash) &&
-             config.key?('postgresql::server::config_entries')
+          config = YAML.load_file(hiera_file)
+          if config.is_a?(Hash) && config.key?('postgresql::server::config_entries')
             if config['postgresql::server::config_entries'].nil?
               return <<-MESSAGE.strip_heredoc
               ERROR: 'postgresql::server::config_entries' cannot be null.
@@ -44,6 +44,9 @@ module Checks
               end
               return message
             end
+          elsif config.is_a?(String)
+            fail! "Error: File #{hiera_file} is not a yaml file."
+            exit 1
           end
         rescue Psych::SyntaxError
           fail! "Found syntax error in file: #{hiera_file}"


### PR DESCRIPTION
Foreman-maintain will not fail with below `NoMethodError` exception if `/etc/foreman-installer/custom-hiera.yaml` has a string. 

```
================================================================================
Check if checkpoint_segments configuration exists on the system:      [FAIL]
undefined method `key?' for "s asdfasdf":String
--------------------------------------------------------------------------------
```

A syntax error will be only reported if `/etc/foreman-installer/custom-hiera.yaml` has a yaml content with syntax issue. 
