### PR TITLE
Fixes #31194 - Add content prepare-abort command

### DIFF
--- a/definitions/procedures/content/migration_stats.rb
+++ b/definitions/procedures/content/migration_stats.rb
@@ -3,6 +3,11 @@ module Procedures::Content
     metadata do
       description 'Retrieve Pulp 2 to Pulp 3 migration statistics'
       for_feature :pulpcore
+
+      confine do
+        # FIXME: remove this condition on next downstream upgrade scenario
+        !feature(:satellite) || feature(:satellite).at_least_version?('6.9')
+      end
     end
 
     def run

--- a/definitions/procedures/content/prepare_abort.rb
+++ b/definitions/procedures/content/prepare_abort.rb
@@ -3,6 +3,11 @@ module Procedures::Content
     metadata do
       description 'Abort all running Pulp 2 to Pulp 3 migration tasks'
       for_feature :pulpcore
+
+      confine do
+        # FIXME: remove this condition on next downstream upgrade scenario
+        !feature(:satellite) || feature(:satellite).at_least_version?('6.9')
+      end
     end
 
     def run

--- a/definitions/procedures/content/prepare_abort.rb
+++ b/definitions/procedures/content/prepare_abort.rb
@@ -1,0 +1,12 @@
+module Procedures::Content
+  class PrepareAbort < ForemanMaintain::Procedure
+    metadata do
+      description 'Abort all running Pulp 2 to Pulp 3 migration tasks'
+      for_feature :pulpcore
+    end
+
+    def run
+      puts execute!('foreman-rake katello:pulp3_migration_abort')
+    end
+  end
+end

--- a/definitions/scenarios/content.rb
+++ b/definitions/scenarios/content.rb
@@ -52,5 +52,20 @@ module ForemanMaintain::Scenarios
         end
       end
     end
+
+    class PrepareAbort < ForemanMaintain::Scenario
+      metadata do
+        label :content_prepare_abort
+        description 'Abort all running Pulp 2 to Pulp 3 migration tasks'
+        manual_detection
+      end
+
+      def compose
+        # FIXME: remove this condition on next downstream upgrade scenario
+        if Procedures::Content::PrepareAbort.present?
+          add_step(Procedures::Content::PrepareAbort)
+        end
+      end
+    end
   end
 end

--- a/lib/foreman_maintain/cli/content_command.rb
+++ b/lib/foreman_maintain/cli/content_command.rb
@@ -12,6 +12,12 @@ module ForemanMaintain
           run_scenarios_and_exit(Scenarios::Content::Switchover.new)
         end
       end
+
+      subcommand 'prepare-abort', 'Abort all running Pulp 2 to Pulp 3 migration tasks' do
+        def execute
+          run_scenarios_and_exit(Scenarios::Content::PrepareAbort.new)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This command runs a new rake task that kills all running Pulp 2 -> Pulp 3 migration tasks.