### PR TITLE
Fixes #31283 - add foreman-maintain prep-6.10-upgrade command

### DIFF
--- a/definitions/procedures/prep_6_10_upgrade.rb
+++ b/definitions/procedures/prep_6_10_upgrade.rb
@@ -1,0 +1,31 @@
+class Procedures::Prep610Upgrade < ForemanMaintain::Procedure
+  metadata do
+    description 'Preparations for the Satellite 6.10 upgrade'
+
+    confine do
+      ::Scenarios.const_defined?('Satellite_6_10') &&
+        feature(:satellite) &&
+        feature(:satellite).current_minor_version == '6.9'
+    end
+  end
+
+  def run
+    puts time_warning
+    with_spinner('Updating filesystem permissions for Pulp 3') do |spinner|
+      spinner.update('$ chmod -R g+rwX /var/lib/pulp/content')
+      FileUtils.chmod_R 'g=rwX', '/var/lib/pulp/content'
+      spinner.update("$ find /var/lib/pulp/content -type d -perm -g-s -exec chmod g+s {} \;")
+      execute!('find /var/lib/pulp/content -type d -perm -g-s -exec chmod g+s {} \;')
+      spinner.update('$ chown -R :pulp /var/lib/pulp/content')
+      FileUtils.chown_R nil, 'pulp', '/var/lib/pulp/content'
+      # TODO: Install Pulp 3 without starting services?
+    end
+  end
+
+  private
+
+  def time_warning
+    "\e[33mprep-6.10-upgrade may take a while depending on the "\
+    "size of /var/lib/pulp/content\e[0m"
+  end
+end

--- a/definitions/scenarios/prep_6_10_upgrade.rb
+++ b/definitions/scenarios/prep_6_10_upgrade.rb
@@ -1,0 +1,13 @@
+module ForemanMaintain::Scenarios
+  class Prep610Upgrade < ForemanMaintain::Scenario
+    metadata do
+      label :prep_6_10_upgrade
+      description 'Preparations for the Satellite 6.10 upgrade'
+      manual_detection
+    end
+
+    def compose
+      add_step(Procedures::Prep610Upgrade)
+    end
+  end
+end

--- a/lib/foreman_maintain/cli.rb
+++ b/lib/foreman_maintain/cli.rb
@@ -27,6 +27,15 @@ module ForemanMaintain
       subcommand 'content', 'Content related commands', ContentCommand
       subcommand 'maintenance-mode', 'Control maintenance-mode for application',
                  MaintenanceModeCommand
+      if ::Scenarios.const_defined?('Satellite_6_10') &&
+         ForemanMaintain.detector.feature('satellite') &&
+         ForemanMaintain.detector.feature('satellite').current_minor_version == '6.9'
+        subcommand 'prep-6.10-upgrade', 'Preparations for the Satellite 6.10 upgrade' do
+          def execute
+            run_scenarios_and_exit(Scenarios::Prep610Upgrade.new)
+          end
+        end
+      end
 
       def run(*arguments)
         logger.info("Running foreman-maintain command with arguments #{arguments.inspect}")


### PR DESCRIPTION
`foreman-maintain prep-6.10-upgrade` will run only on Satellite 6.9.  It fixes permissions for Pulp 3 to run on its own.

To test, just remove the `confine` requirement for Satellite 6.9 and run `foreman-maintain prep-6.10-upgrade`.  Double check what your permissions were before running so your environment does break.

I used `FileUtils` where I could.  Original commands:

```
chmod -R g+rwX /var/lib/pulp/content
find /var/lib/pulp/content -type d -perm -g-s -exec sudo chmod g+s {} \;
chgrp -R pulp /var/lib/pulp/content
```