### PR TITLE
Fixes #31289 - Regenerate apipie cache after pulp3 content switchover

### DIFF
--- a/definitions/scenarios/content.rb
+++ b/definitions/scenarios/content.rb
@@ -49,6 +49,7 @@ module ForemanMaintain::Scenarios
         # FIXME: remove this condition on next downstream upgrade scenario
         if Procedures::Content::Switchover.present?
           add_step(Procedures::Content::Switchover)
+          add_step(Procedures::Foreman::ApipieCache)
         end
       end
     end


### PR DESCRIPTION
There are some aspects of our API that change after migrating to pulp3. So in prod environments we need to update the apipie cache to make sure hammer understands that