### PR TITLE
Fixes #31305 - Block content switchover for downstream servers

### DIFF
--- a/definitions/procedures/content/switchover.rb
+++ b/definitions/procedures/content/switchover.rb
@@ -5,7 +5,7 @@ module Procedures::Content
       for_feature :pulpcore
 
       confine do
-        # FIXME: remove this condition on next downstream upgrade scenario
+        # FIXME: remove this condition for the 6.10 upgrade scenario
         !feature(:instance).downstream
       end
     end

--- a/definitions/scenarios/content.rb
+++ b/definitions/scenarios/content.rb
@@ -46,7 +46,7 @@ module ForemanMaintain::Scenarios
       end
 
       def compose
-        # FIXME: remove this condition on next downstream upgrade scenario
+        # FIXME: remove this condition for the 6.10 upgrade scenario
         if Procedures::Content::Switchover.present?
           add_step(Procedures::Content::Switchover)
         end

--- a/lib/foreman_maintain/cli/content_command.rb
+++ b/lib/foreman_maintain/cli/content_command.rb
@@ -7,9 +7,12 @@ module ForemanMaintain
         end
       end
 
-      subcommand 'switchover', 'Switch support for certain content from Pulp 2 to Pulp 3' do
-        def execute
-          run_scenarios_and_exit(Scenarios::Content::Switchover.new)
+      unless ForemanMaintain.detector.feature(:satellite) ||
+             ForemanMaintain.detector.feature(:capsule)
+        subcommand 'switchover', 'Switch support for certain content from Pulp 2 to Pulp 3' do
+          def execute
+            run_scenarios_and_exit(Scenarios::Content::Switchover.new)
+          end
         end
       end
 


### PR DESCRIPTION
Satellite users should never run `content switchover` themselves.