### PR TITLE
Fixes #31520 - handle listing of systemd instantiated service

### DIFF
--- a/definitions/features/dynflow_sidekiq.rb
+++ b/definitions/features/dynflow_sidekiq.rb
@@ -20,9 +20,12 @@ class Features::DynflowSidekiq < ForemanMaintain::Feature
 
   def services
     [
-      system_service('dynflow-sidekiq@orchestrator', 30, :parent_unit => 'dynflow-sidekiq@'),
-      system_service('dynflow-sidekiq@worker-hosts-queue', 31, :parent_unit => 'dynflow-sidekiq@'),
-      system_service('dynflow-sidekiq@worker', 31, :parent_unit => 'dynflow-sidekiq@')
+      system_service('dynflow-sidekiq@orchestrator', 30,
+                     :instance_parent_unit => 'dynflow-sidekiq@'),
+      system_service('dynflow-sidekiq@worker-hosts-queue', 31,
+                     :instance_parent_unit => 'dynflow-sidekiq@'),
+      system_service('dynflow-sidekiq@worker', 31,
+                     :instance_parent_unit => 'dynflow-sidekiq@')
     ]
   end
 end

--- a/definitions/procedures/service/list.rb
+++ b/definitions/procedures/service/list.rb
@@ -26,7 +26,7 @@ module Procedures::Service
 
     def build_regex_for_services(services)
       services.map do |service|
-        if service.instance?
+        if service.respond_to?(:instance_parent_unit) && service.instance_parent_unit
           "^#{service.instance_parent_unit}.service"
         else
           "^#{service.name}.service"

--- a/definitions/procedures/service/list.rb
+++ b/definitions/procedures/service/list.rb
@@ -16,12 +16,22 @@ module Procedures::Service
 
     def unit_files_list(services)
       if systemd_installed?
-        regex = services.map { |service| "^#{service.name}.service" }.join('\|')
-        execute("systemctl list-unit-files | grep '#{regex}'")
+        execute("systemctl list-unit-files --type=service | \
+                 grep '#{systemd_service_names_regex(services)}'")
       else
         regex = services.map { |service| "^#{service.name} " }.join('\|')
         execute("chkconfig --list 2>&1 | grep '#{regex}'")
       end
+    end
+
+    def systemd_service_names_regex(services)
+      services.map do |service|
+        if service.instance?
+          "^#{service.instance_parent_unit}.service"
+        else
+          "^#{service.name}.service"
+        end
+      end.join('\|')
     end
   end
 end

--- a/definitions/procedures/service/list.rb
+++ b/definitions/procedures/service/list.rb
@@ -17,14 +17,14 @@ module Procedures::Service
     def unit_files_list(services)
       if systemd_installed?
         execute("systemctl list-unit-files --type=service | \
-                 grep '#{systemd_service_names_regex(services)}'")
+                 grep '#{build_regex_for_services(services)}'")
       else
         regex = services.map { |service| "^#{service.name} " }.join('\|')
         execute("chkconfig --list 2>&1 | grep '#{regex}'")
       end
     end
 
-    def systemd_service_names_regex(services)
+    def build_regex_for_services(services)
       services.map do |service|
         if service.instance?
           "^#{service.instance_parent_unit}.service"

--- a/lib/foreman_maintain/utils/service/abstract.rb
+++ b/lib/foreman_maintain/utils/service/abstract.rb
@@ -66,14 +66,6 @@ module ForemanMaintain::Utils
       def running?
         raise NotImplementedError
       end
-
-      def instance_parent_unit
-        raise NotImplementedError
-      end
-
-      def instance?
-        raise NotImplementedError
-      end
     end
   end
 end

--- a/lib/foreman_maintain/utils/service/abstract.rb
+++ b/lib/foreman_maintain/utils/service/abstract.rb
@@ -66,6 +66,14 @@ module ForemanMaintain::Utils
       def running?
         raise NotImplementedError
       end
+
+      def instance_parent_unit
+        raise NotImplementedError
+      end
+
+      def instance?
+        raise NotImplementedError
+      end
     end
   end
 end

--- a/lib/foreman_maintain/utils/service/systemd.rb
+++ b/lib/foreman_maintain/utils/service/systemd.rb
@@ -1,9 +1,11 @@
 module ForemanMaintain::Utils
   module Service
     class Systemd < Abstract
+      attr_reader :instance_parent_unit
       def initialize(name, priority, options = {})
         super
         @sys = SystemHelpers.new
+        @instance_parent_unit = options.fetch(:instance_parent_unit, nil)
       end
 
       def command(action, options = {})
@@ -64,10 +66,6 @@ module ForemanMaintain::Utils
 
       def instance?
         instance_parent_unit ? true : false
-      end
-
-      def instance_parent_unit
-        @options.fetch(:parent_unit, nil)
       end
 
       private

--- a/lib/foreman_maintain/utils/service/systemd.rb
+++ b/lib/foreman_maintain/utils/service/systemd.rb
@@ -10,7 +10,6 @@ module ForemanMaintain::Utils
         do_wait = options.fetch(:wait, true) # wait for service to start
         all = @options.fetch(:all, false)
         skip_enablement = @options.fetch(:skip_enablement, false)
-
         if skip_enablement && %w[enable disable].include?(action)
           return skip_enablement_message(action, @name)
         end
@@ -61,6 +60,14 @@ module ForemanMaintain::Utils
         if @sys.systemd_installed?
           service_enabled_status == 'enabled'
         end
+      end
+
+      def instance?
+        instance_parent_unit ? true : false
+      end
+
+      def instance_parent_unit
+        @options.fetch(:parent_unit, nil)
       end
 
       private

--- a/lib/foreman_maintain/utils/service/systemd.rb
+++ b/lib/foreman_maintain/utils/service/systemd.rb
@@ -64,10 +64,6 @@ module ForemanMaintain::Utils
         end
       end
 
-      def instance?
-        instance_parent_unit ? true : false
-      end
-
       private
 
       def execute(action, options = {})


### PR DESCRIPTION
The dynflow-sidekiq is instantiated type service. This means that it start three services as per priority. The foreman-maintain's service list command is based on 'systemctl list-unit-files --type=service' only difference is, it limits the service list to features which are available on the system, i.e dynflow, cockpit. The implementation takes introduces new attribute which helps to set parent_unit_file and detect if service is instance.