### PR TITLE
Fixes #31575 - Online and offline backup with --include-db-dumps fails

### DIFF
--- a/definitions/procedures/backup/online/safety_confirmation.rb
+++ b/definitions/procedures/backup/online/safety_confirmation.rb
@@ -8,7 +8,7 @@ module Procedures::Backup
       end
 
       def run
-        answer = ask_decision(warning_message(@include_db_dumps), 'y(yes), q(quit)')
+        answer = ask_decision(warning_message(@include_db_dumps), actions_msg: 'y(yes), q(quit)')
         abort! unless answer == :yes
       end
 


### PR DESCRIPTION
This fixes a syntax error that was failing online and offline backups.