### PR TITLE
Fixes #31592 - various pulp migration fixes

### DIFF
--- a/definitions/features/pulpcore.rb
+++ b/definitions/features/pulpcore.rb
@@ -11,18 +11,19 @@ class Features::Pulpcore < ForemanMaintain::Feature
   end
 
   def services
-    pulpcore_common_services + [
+    self.class.pulpcore_common_services + [
+      system_service('rh-redis5-redis', 5),
       system_service('pulpcore-worker@*', 20, :all => true, :skip_enablement => true),
       system_service('httpd', 30)
     ]
   end
 
-  def pulpcore_migration_services
+  def self.pulpcore_migration_services
     pulpcore_common_services + [
-      system_service('pulpcore-worker@1', 20),
-      system_service('pulpcore-worker@2', 20),
-      system_service('pulpcore-worker@3', 20),
-      system_service('pulpcore-worker@4', 20)
+      ForemanMaintain::Utils.system_service('pulpcore-worker@1', 20),
+      ForemanMaintain::Utils.system_service('pulpcore-worker@2', 20),
+      ForemanMaintain::Utils.system_service('pulpcore-worker@3', 20),
+      ForemanMaintain::Utils.system_service('pulpcore-worker@4', 20)
     ]
   end
 
@@ -32,14 +33,11 @@ class Features::Pulpcore < ForemanMaintain::Feature
     ]
   end
 
-  private
-
-  def pulpcore_common_services
+  def self.pulpcore_common_services
     [
-      system_service('rh-redis5-redis', 5),
-      system_service('pulpcore-api', 10, :socket => 'pulpcore-api'),
-      system_service('pulpcore-content', 10, :socket => 'pulpcore-content'),
-      system_service('pulpcore-resource-manager', 10)
+      ForemanMaintain::Utils.system_service('pulpcore-api', 10, :socket => 'pulpcore-api'),
+      ForemanMaintain::Utils.system_service('pulpcore-content', 10, :socket => 'pulpcore-content'),
+      ForemanMaintain::Utils.system_service('pulpcore-resource-manager', 10)
     ]
   end
 end

--- a/definitions/procedures/prep_6_10_upgrade.rb
+++ b/definitions/procedures/prep_6_10_upgrade.rb
@@ -3,8 +3,7 @@ class Procedures::Prep610Upgrade < ForemanMaintain::Procedure
     description 'Preparations for the Satellite 6.10 upgrade'
 
     confine do
-      ::Scenarios.const_defined?('Satellite_6_10') &&
-        feature(:satellite) &&
+      feature(:satellite) &&
         feature(:satellite).current_minor_version == '6.9'
     end
   end
@@ -18,7 +17,6 @@ class Procedures::Prep610Upgrade < ForemanMaintain::Procedure
       execute!('find /var/lib/pulp/content -type d -perm -g-s -exec chmod g+s {} \;')
       spinner.update('$ chown -R :pulp /var/lib/pulp/content')
       FileUtils.chown_R nil, 'pulp', '/var/lib/pulp/content'
-      # TODO: Install Pulp 3 without starting services?
     end
   end
 

--- a/definitions/scenarios/content.rb
+++ b/definitions/scenarios/content.rb
@@ -20,16 +20,16 @@ module ForemanMaintain::Scenarios
       def enable_and_start_services
         add_step(Procedures::Service::Start)
         add_step(Procedures::Service::Enable.
-                 new(:only => feature(:pulpcore).pulpcore_migration_services))
+                 new(:only => Features::Pulpcore.pulpcore_migration_services))
         add_step(Procedures::Service::Start.
-                 new(:only => feature(:pulpcore).pulpcore_migration_services))
+                 new(:only => Features::Pulpcore.pulpcore_migration_services))
       end
 
       def disable_and_stop_services
         add_step(Procedures::Service::Stop.
-                 new(:only => feature(:pulpcore).pulpcore_migration_services))
+                 new(:only => Features::Pulpcore.pulpcore_migration_services))
         add_step(Procedures::Service::Disable.
-                 new(:only => feature(:pulpcore).pulpcore_migration_services))
+                 new(:only => Features::Pulpcore.pulpcore_migration_services))
       end
     end
 

--- a/lib/foreman_maintain/cli.rb
+++ b/lib/foreman_maintain/cli.rb
@@ -27,9 +27,8 @@ module ForemanMaintain
       subcommand 'content', 'Content related commands', ContentCommand
       subcommand 'maintenance-mode', 'Control maintenance-mode for application',
                  MaintenanceModeCommand
-      if ::Scenarios.const_defined?('Satellite_6_10') &&
-         ForemanMaintain.detector.feature('satellite') &&
-         ForemanMaintain.detector.feature('satellite').current_minor_version == '6.9'
+      if ForemanMaintain.detector.feature(:satellite) &&
+         ForemanMaintain.detector.feature(:satellite).current_minor_version == '6.9'
         subcommand 'prep-6.10-upgrade', 'Preparations for the Satellite 6.10 upgrade' do
           def execute
             run_scenarios_and_exit(Scenarios::Prep610Upgrade.new)


### PR DESCRIPTION
* Move pulpcore services into class methods
  This allows referencing them even if the services
  are disabled.
* Also moves redis out of the 'migration' services,
  since its running regardless
* Do not look for a 6.10 scenario for prep_6_10_upgrade
