### PR TITLE
Fixes #31617 - pulp remove procedure

### DIFF
--- a/definitions/procedures/pulp/remove.rb
+++ b/definitions/procedures/pulp/remove.rb
@@ -1,0 +1,51 @@
+module Procedures::Pulp
+  class Remove < ForemanMaintain::Procedure
+
+    metadata do
+      description 'Remove pulp2'
+      for_feature :pulp2
+    end
+
+    def pulp_packages
+      [
+       'pulp-server', 'python-pulp-streamer', 'pulp-puppet-plugins',
+       'python-pulp-rpm-common', 'python-pulp-common',
+       'pulp-selinux', 'python-pulp-oid_validation',
+       'python-pulp-puppet-common', 'python-pulp-repoauth',
+       'pulp-rpm-plugins'
+      ]
+
+    end
+
+    def run
+      question = "\nWARNING: All pulp2 packages will be removed.\n" \
+          "All pulp2 data will be removed.\n" \
+          "Do you want to proceed automatically?\n"
+      answer = ask_decision(question, actions_msg: 'y(yes), n(no), q(quit)')
+      abort! if answer == :quit
+
+      with_spinner('Removing pulp') do |spinner|
+        spinner.update('Stopping pulp2 services')
+        pulp_services = %w[pulp_celerybeat pulp_workers pulp_resource_manager]
+        feature(:service).handle_services(spinner, 'stop', :only => pulp_services)
+
+        spinner.update('Removing pulp2 packages')
+        packages_action(:remove, pulp_packages, :assumeyes => true)
+
+      end
+
+      pulp_data_dir_path = feature(:pulp2).data_dir
+      if File.directory?(pulp_data_dir_path)
+        question = '\nProceed with removal of pulp2 data directory?\n'
+        rm_answer = ask_decision(question, actions_msg: 'y(yes), n(no), q(quit)')
+        abort! if answer == :quit
+        if rm_answer == :yes
+          with_spinner('Deleting pulp2 data directory') do |spinner|
+            execute!("rm -rf #{pulp_data_dir_path}")
+            spinner.update 'Done deleting pulp2 data directory'
+          end
+        end
+      end
+    end
+  end
+end

--- a/definitions/procedures/pulp/remove.rb
+++ b/definitions/procedures/pulp/remove.rb
@@ -1,6 +1,5 @@
 module Procedures::Pulp
   class Remove < ForemanMaintain::Procedure
-
     metadata do
       description 'Remove pulp2'
       for_feature :pulp2
@@ -8,35 +7,32 @@ module Procedures::Pulp
 
     def pulp_packages
       [
-       'pulp-server', 'python-pulp-streamer', 'pulp-puppet-plugins',
-       'python-pulp-rpm-common', 'python-pulp-common',
-       'pulp-selinux', 'python-pulp-oid_validation',
-       'python-pulp-puppet-common', 'python-pulp-repoauth',
-       'pulp-rpm-plugins'
+        'pulp-server', 'python-pulp-streamer', 'pulp-puppet-plugins',
+        'python-pulp-rpm-common', 'python-pulp-common',
+        'pulp-selinux', 'python-pulp-oid_validation',
+        'python-pulp-puppet-common', 'python-pulp-repoauth',
+        'pulp-rpm-plugins'
       ]
-
     end
 
     def run
       question = "\nWARNING: All pulp2 packages will be removed.\n" \
-          "All pulp2 data will be removed.\n" \
-          "Do you want to proceed automatically? "
+          "All pulp2 data will be removed.\n' " \
+          'Do you want to proceed automatically? '
       answer_automatic = ask_decision(question, actions_msg: 'y(yes), n(no), q(quit)')
       abort! if answer_automatic == :quit
 
-      assumeyes = true
-      if answer_automatic == :no
-        assumeyes = false
-      end
-
-      with_spinner('Removing pulp') do |spinner|
-        spinner.update('Stopping pulp2 services')
+      with_spinner('Stopping pulp2 services') do |spinner|
         pulp_services = %w[pulp_celerybeat pulp_workers pulp_resource_manager]
         feature(:service).handle_services(spinner, 'stop', :only => pulp_services)
-
-        spinner.update('Removing pulp2 packages')
       end
 
+      with_spinner('Removing pulp2 packages') do |spinner|
+        remove_packages(pulp_packages, answer_automatic, spinner)
+      end
+    end
+
+    def remove_packages(pulp_packages, answer_automatic, spinner)
       pulp_packages.each do |package|
         remove_answer = :yes
         if answer_automatic == :no
@@ -44,7 +40,11 @@ module Procedures::Pulp
           remove_answer = ask_decision(remove_question, actions_msg: 'y(yes), n(no), q(quit)')
           abort! if remove_answer == :quit
         end
-        packages_action(:remove, [package], :assumeyes => true) if remove_answer
+
+        if remove_answer
+          spinner.update("Removing #{package}")
+          packages_action(:remove, [package], :assumeyes => true) if remove_answer
+        end
       end
     end
   end


### PR DESCRIPTION
This change adds a procedure to remove pulp2 packages and data directories. An option is presented to execute automatically, and if declined, prompts the user for each step.