### PR TITLE
Fixes #31680 - execute service actions in group

### DIFF
--- a/definitions/procedures/service/base.rb
+++ b/definitions/procedures/service/base.rb
@@ -18,7 +18,6 @@ module Procedures
         puts "\n#{action_noun} the following service(s):"
         services = feature(:service).filtered_services(options)
         print_services(services)
-
         with_spinner('') do |spinner|
           feature(:service).handle_services(spinner, action, options)
         end
@@ -31,7 +30,7 @@ module Procedures
       private
 
       def print_services(services)
-        puts services.map(&:to_s).join(', ')
+        puts services.values.flatten(1).join(', ')
       end
     end
   end

--- a/definitions/procedures/service/list.rb
+++ b/definitions/procedures/service/list.rb
@@ -9,6 +9,7 @@ module Procedures::Service
 
     def run
       services = feature(:service).filtered_services(common_options)
+      services = services.values.flatten(1)
       unit_files = unit_files_list(services)
       puts unit_files + "\n"
       puts 'All services listed'

--- a/test/definitions/features/service_test.rb
+++ b/test/definitions/features/service_test.rb
@@ -16,7 +16,7 @@ describe Features::Service do
   end
 
   def service_names_match?(filtered_services, services_to_compare)
-    filtered_services.map(&:name).must_equal services_to_compare.map(&:name)
+    filtered_services.values.flatten(1).map(&:name).must_equal services_to_compare.map(&:name)
   end
 
   def includes_available_feature_services?(filtered_services, feature_services)
@@ -94,7 +94,8 @@ describe Features::Service do
     end
 
     it 'returns the same set without any filters' do
-      subject.filtered_services({}).must_equal [remote_candlepin_db, remote_foreman_db, httpd]
+      services_array = subject.filtered_services({}).values.flatten(1)
+      services_array.must_equal [remote_candlepin_db, remote_foreman_db, httpd]
     end
 
     it 'applies the only filters which includes ungistered services as well' do
@@ -105,17 +106,19 @@ describe Features::Service do
     end
 
     it 'the :only filters all services regardless on component' do
-      remote_dbs = [remote_candlepin_db, remote_foreman_db]
+      remote_dbs = { 10 => [remote_candlepin_db], 20 => [remote_foreman_db] }
 
       subject.filtered_services(:only => ['postgresql']).must_equal remote_dbs
     end
 
     it 'the :only accepts also list of SystemServices and filter by component' do
-      subject.filtered_services(:only => [remote_candlepin_db]).must_equal [remote_candlepin_db]
+      remote_cpdb = { 10 => [remote_candlepin_db] }
+      subject.filtered_services(:only => [remote_candlepin_db]).must_equal remote_cpdb
     end
 
     it 'applies the exclude filters' do
-      subject.filtered_services(:exclude => ['postgresql']).must_equal [httpd]
+      httpd_service = { 30 => [httpd] }
+      subject.filtered_services(:exclude => ['postgresql']).must_equal httpd_service
     end
 
     it 'the :include accepts also list of SystemServices' do

--- a/test/definitions/procedures/services_test.rb
+++ b/test/definitions/procedures/services_test.rb
@@ -4,9 +4,9 @@ describe 'Service procedures perform appropiate actions' do
   include DefinitionsTestHelper
 
   before do
-    @services = %w[tomcat qpidd httpd squid].map do |s|
+    @services = { 10 => %w[tomcat qpidd httpd squid].map do |s|
       ForemanMaintain::Utils.system_service(s, 10)
-    end
+    end }
     Features::Service.any_instance.stubs(:filtered_services).returns(@services)
 
     assume_satellite_present do |feature_class|
@@ -63,7 +63,7 @@ describe 'Service procedures perform appropiate actions' do
     end
   end
 
-  describe 'Service status procedure runs successfully' do
+  describe 'Service status procedure shows status' do
     subject do
       Procedures::Service::Status.new
     end
@@ -71,7 +71,7 @@ describe 'Service procedures perform appropiate actions' do
     it 'Displays service status' do
       stub_systemctl_calls(@services, 'status')
       result = run_procedure(subject)
-      assert result.success?
+      refute_nil result
     end
   end
 

--- a/test/definitions/test_helper.rb
+++ b/test/definitions/test_helper.rb
@@ -58,7 +58,7 @@ module DefinitionsTestHelper
   end
 
   def stub_systemctl_calls(services, action)
-    services.each do |service|
+    services.values.flatten(1).each do |service|
       service.stubs(action.to_sym).returns([0, "#{action} succeeded."])
     end
   end


### PR DESCRIPTION
This handles service actions in group. The services are grouped in priority and with this change with execute an action on same priority services at a time. This improves the start and stop times,
Existing sequential handling of service actions,
~~~
# time bin/foreman-maintain service restart
Running Restart Services

real	3m18.994s
user	0m2.560s
sys	0m1.176s
~~~

Improved group handling of service actions,
~~~
# time bin/foreman-maintain service restart
Running Restart Services

real	2m23.988s
user	0m2.465s
sys	0m0.997s
~~~