### PR TITLE
Fixes #31886 - error out if psql and mongo packages missing

### DIFF
--- a/definitions/checks/candlepin/db_up.rb
+++ b/definitions/checks/candlepin/db_up.rb
@@ -9,15 +9,19 @@ module Checks
 
       def run
         status = false
-        with_spinner('Checking connection to the Candlepin DB') do
-          status = feature(:candlepin_database).ping
+        if feature(:candlepin_database).psql_cmd_available?
+          with_spinner('Checking connection to the Candlepin DB') do
+            status = feature(:candlepin_database).ping
+          end
+          assert(status, 'Candlepin DB is not responding. ' \
+            'It needs to be up and running to perform the following steps',
+                 :next_steps => start_pgsql)
+        else
+          feature(:candlepin_database).raise_psql_missing_error
         end
-        assert(status, 'Candlepin DB is not responding. ' \
-          'It needs to be up and running to perform the following steps',
-               :next_steps => next_steps)
       end
 
-      def next_steps
+      def start_pgsql
         if feature(:candlepin_database).local?
           [Procedures::Service::Start.new(:only => 'postgresql')]
         else

--- a/definitions/checks/foreman/db_up.rb
+++ b/definitions/checks/foreman/db_up.rb
@@ -9,15 +9,19 @@ module Checks
 
       def run
         status = false
-        with_spinner('Checking connection to the Foreman DB') do
-          status = feature(:foreman_database).ping
+        if feature(:foreman_database).psql_cmd_available?
+          with_spinner('Checking connection to the Foreman DB') do
+            status = feature(:foreman_database).ping
+          end
+          assert(status, 'Foreman DB is not responding. ' \
+            'It needs to be up and running to perform the following steps',
+                 :next_steps => start_pgsql)
+        else
+          feature(:foreman_database).raise_psql_missing_error
         end
-        assert(status, 'Foreman DB is not responding. ' \
-          'It needs to be up and running to perform the following steps',
-               :next_steps => next_steps)
       end
 
-      def next_steps
+      def start_pgsql
         if feature(:foreman_database).local?
           [Procedures::Service::Start.new(:only => 'postgresql')]
         else

--- a/definitions/checks/mongo/db_up.rb
+++ b/definitions/checks/mongo/db_up.rb
@@ -9,15 +9,19 @@ module Checks
 
       def run
         status = false
-        with_spinner('Checking connection to the Mongo DB') do
-          status = feature(:mongo).ping
+        if feature(:mongo).mongo_cmd_available?
+          with_spinner('Checking connection to the Mongo DB') do
+            status = feature(:mongo).ping
+          end
+          assert(status, 'Mongo DB is not responding. ' \
+            'It needs to be up and running to perform the following steps.',
+                 :next_steps => start_mongodb)
+        else
+          feature(:mongo).raise_mongo_client_missing_error
         end
-        assert(status, 'Mongo DB is not responding. ' \
-          'It needs to be up and running to perform the following steps.',
-               :next_steps => next_steps)
       end
 
-      def next_steps
+      def start_mongodb
         if feature(:mongo).local?
           [Procedures::Service::Start.new(:only => feature(:mongo).services)]
         else

--- a/definitions/features/mongo.rb
+++ b/definitions/features/mongo.rb
@@ -140,6 +140,16 @@ class Features::Mongo < ForemanMaintain::Feature
     end
   end
 
+  def mongo_cmd_available?
+    exit_status, _output = execute_with_status("which #{core.client_command}")
+    exit_status == 0
+  end
+
+  def raise_mongo_client_missing_error
+    raise ForemanMaintain::Error::Fail, "The #{core.client_command} command not found."\
+                                  " Make sure system has #{core.client_command} utility installed."
+  end
+
   private
 
   def load_mongo_core_default(version)

--- a/lib/foreman_maintain/concerns/base_database.rb
+++ b/lib/foreman_maintain/concerns/base_database.rb
@@ -119,6 +119,7 @@ module ForemanMaintain
         SQL
         result = query(sql)
         return false if result.nil? || (result && result.empty?)
+
         result.first['exists'].eql?('t')
       end
 
@@ -159,6 +160,16 @@ module ForemanMaintain
         else
           raise_service_error
         end
+      end
+
+      def psql_cmd_available?
+        exit_status, _output = execute_with_status('which psql')
+        exit_status == 0
+      end
+
+      def raise_psql_missing_error
+        raise Error::Fail, 'The psql command not found.'\
+                ' Make sure system has psql utility installed.'
       end
 
       private


### PR DESCRIPTION
When checking external db connections foreman-maintain fails to do so if psql and mongo commands are not available. This change does not try to install packages on external system as it will require auth and root access which will over complicate the restore process. Its expected to have those packages on target system. If not then we explicitly fail the checks instead of giving false warning of db connection failure. 