### PR TITLE
Fixes #31906 - Add content migration reset command

### DIFF
--- a/definitions/procedures/content/migration_reset.rb
+++ b/definitions/procedures/content/migration_reset.rb
@@ -1,0 +1,12 @@
+module Procedures::Content
+  class MigrationReset < ForemanMaintain::Procedure
+    metadata do
+      description 'Reset the Pulp 2 to Pulp 3 migration data (pre-switchover)'
+      for_feature :pulpcore
+    end
+
+    def run
+      puts execute!('foreman-rake katello:pulp3_migration_reset')
+    end
+  end
+end

--- a/definitions/scenarios/content.rb
+++ b/definitions/scenarios/content.rb
@@ -79,6 +79,24 @@ module ForemanMaintain::Scenarios
       end
     end
 
+    class MigrationReset < ForemanMaintain::Scenario
+      metadata do
+        label :content_migration_reset
+        description 'Reset the Pulp 2 to Pulp 3 migration data (pre-switchover)'
+        manual_detection
+      end
+
+      def compose
+        if feature(:satellite) && feature(:satellite).at_least_version?('6.9')
+          enable_and_start_services
+          add_step(Procedures::Content::MigrationReset)
+          disable_and_stop_services
+        elsif !feature(:satellite)
+          add_step(Procedures::Content::MigrationReset)
+        end
+      end
+    end
+
     class RemovePulp2 < ForemanMaintain::Scenario
       metadata do
         label :content_remove_pulp2
@@ -87,7 +105,7 @@ module ForemanMaintain::Scenarios
       end
 
       def compose
-        add_step(Procedures::Pulp::Remove)
+        add_step_with_context(Procedures::Pulp::Remove)
       end
     end
   end

--- a/lib/foreman_maintain/cli/content_command.rb
+++ b/lib/foreman_maintain/cli/content_command.rb
@@ -28,6 +28,12 @@ module ForemanMaintain
         end
       end
 
+      subcommand 'migration-reset', 'Reset the Pulp 2 to Pulp 3 migration data (pre-switchover)' do
+        def execute
+          run_scenarios_and_exit(Scenarios::Content::MigrationReset.new)
+        end
+      end
+
       subcommand 'remove-pulp2', 'Remove pulp2 and mongodb packages and data' do
         def execute
           run_scenarios_and_exit(Scenarios::Content::RemovePulp2.new)


### PR DESCRIPTION
Adds the `content migration-reset` command.

Needs https://github.com/Katello/katello/pull/9142 in Katello.

Questions:

Do we need any Satellite guards?

Do you agree with the naming and printed information?