### PR TITLE
Fixes #32198 - Switchover needs to proxy yum and deb too

### DIFF
--- a/definitions/procedures/content/switchover.rb
+++ b/definitions/procedures/content/switchover.rb
@@ -19,8 +19,11 @@ module Procedures::Content
       puts execute!('foreman-rake katello:pulp3_content_switchover')
       puts 'Re-running the installer to switch specified content over to pulp3'
       args = ['--foreman-proxy-content-proxy-pulp-isos-to-pulpcore=true',
+              '--foreman-proxy-content-proxy-pulp-yum-to-pulpcore=true',
+              '--foreman-proxy-content-proxy-pulp-deb-to-pulpcore=true',
               '--katello-use-pulp-2-for-file=false',
               '--katello-use-pulp-2-for-docker=false',
+              '--katello-use-pulp-2-for-deb=false',
               '--katello-use-pulp-2-for-yum=false']
       feature(:installer).run(args.join(' '))
     end


### PR DESCRIPTION
Foreman maintain was never told to proxy Pulp 3 content for content types other than file. This fixes that.