### PR TITLE
Fixes #32211 - Add qdpidd and qdrouterd to Katello services

### DIFF
--- a/definitions/features/katello.rb
+++ b/definitions/features/katello.rb
@@ -16,9 +16,14 @@ class Features::Katello < ForemanMaintain::Feature
   end
 
   def services
-    [
-      system_service('elasticsearch', 30)
-    ]
+    if feature(:pulp2)
+      []
+    else
+      [
+        system_service('qpidd', 10),
+        system_service('qdrouterd', 10)
+      ]
+    end
   end
 
   # rubocop:disable  Metrics/MethodLength


### PR DESCRIPTION
Katello 4.0 inherited the pulp2 functionality of the katello-agent so it now requires qpidd+qdrouterd totally independent of pulp2!

I found this on 0.7.x and would like this backported to that line (Foreman 2.4)
