### PR TITLE
Fixes #32292 - only collect .yml dynflow configs for services

### DIFF
--- a/definitions/features/dynflow_sidekiq.rb
+++ b/definitions/features/dynflow_sidekiq.rb
@@ -37,6 +37,6 @@ class Features::DynflowSidekiq < ForemanMaintain::Feature
   end
 
   def configured_instances
-    Dir['/etc/foreman/dynflow/*'].map { |config| File.basename(config, '.yml') }
+    Dir['/etc/foreman/dynflow/*.yml'].map { |config| File.basename(config, '.yml') }
   end
 end


### PR DESCRIPTION
otherwise this will pick up backup files, which don't exist as services