### PR TITLE
Fixes #32633 - handle scl and nonscl package names dynamically

### DIFF
--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -8,6 +8,9 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
+      - name: Install facter package
+        run: |
+          sudo apt-get install facter
       - name: Install RVM
         run: |
           gpg --keyserver hkps://keys.openpgp.org --recv-keys 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
@@ -33,6 +36,9 @@ jobs:
         ruby-version: [2.3.3, 2.4.5, 2.5.3, 2.6.5]
     steps:
       - uses: actions/checkout@v2
+      - name: Install facter package
+        run: |
+          sudo apt-get install facter
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -26,19 +26,19 @@ jobs:
           rvm use 2.0.0
           bundle exec rake
   Test_ruby:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.3.3, 2.4.5, 2.5.3, 2.6.5]
+        ruby-version: [22, 24, 25, 26]
+        centos: ["7"]
+    container:
+      image: centos/ruby-${{ matrix.ruby-version }}-centos${{matrix.centos}}
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby-version }}
       - name: Setup
         run: |
+          sudo yum install rubygems ruby-devel -y
           gem install bundler
           bundle install --jobs=3 --retry=3
       - name: Run tests

--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -26,19 +26,19 @@ jobs:
           rvm use 2.0.0
           bundle exec rake
   Test_ruby:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [22, 24, 25, 26]
-        centos: ["7"]
-    container:
-      image: centos/ruby-${{ matrix.ruby-version }}-centos${{matrix.centos}}
+        ruby-version: [2.3.3, 2.4.5, 2.5.3, 2.6.5]
     steps:
       - uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
       - name: Setup
         run: |
-          sudo yum install rubygems ruby-devel -y
           gem install bundler
           bundle install --jobs=3 --retry=3
       - name: Run tests

--- a/definitions/checks/remote_execution/verify_settings_file_already_exists.rb
+++ b/definitions/checks/remote_execution/verify_settings_file_already_exists.rb
@@ -6,7 +6,7 @@ module Checks::RemoteExecution
       confine do
         feature(:instance).downstream &&
           feature(:instance).downstream.current_minor_version == '6.2' &&
-          find_scl_or_nonscl_package('rubygem-smart_proxy_dynflow_core') &&
+          plugin_package(:smart_proxy_dynflow_core) &&
           file_exists?('/etc/smart_proxy_dynflow_core')
       end
     end

--- a/definitions/checks/remote_execution/verify_settings_file_already_exists.rb
+++ b/definitions/checks/remote_execution/verify_settings_file_already_exists.rb
@@ -6,7 +6,7 @@ module Checks::RemoteExecution
       confine do
         feature(:instance).downstream &&
           feature(:instance).downstream.current_minor_version == '6.2' &&
-          plugin_package_name('dynflow_core', 'smart_proxy') &&
+          find_package(proxy_plugin_name('dynflow_core')) &&
           file_exists?('/etc/smart_proxy_dynflow_core')
       end
     end

--- a/definitions/checks/remote_execution/verify_settings_file_already_exists.rb
+++ b/definitions/checks/remote_execution/verify_settings_file_already_exists.rb
@@ -6,7 +6,7 @@ module Checks::RemoteExecution
       confine do
         feature(:instance).downstream &&
           feature(:instance).downstream.current_minor_version == '6.2' &&
-          plugin_package(:smart_proxy_dynflow_core) &&
+          plugin_package_name('dynflow_core', 'smart_proxy') &&
           file_exists?('/etc/smart_proxy_dynflow_core')
       end
     end

--- a/definitions/checks/remote_execution/verify_settings_file_already_exists.rb
+++ b/definitions/checks/remote_execution/verify_settings_file_already_exists.rb
@@ -6,7 +6,7 @@ module Checks::RemoteExecution
       confine do
         feature(:instance).downstream &&
           feature(:instance).downstream.current_minor_version == '6.2' &&
-          find_package('tfm-rubygem-smart_proxy_dynflow_core') &&
+          find_scl_or_nonscl_package('rubygem-smart_proxy_dynflow_core') &&
           file_exists?('/etc/smart_proxy_dynflow_core')
       end
     end

--- a/definitions/features/foreman_cockpit.rb
+++ b/definitions/features/foreman_cockpit.rb
@@ -3,7 +3,7 @@ class Features::ForemanCockpit < ForemanMaintain::Feature
     label :foreman_cockpit
 
     confine do
-      server? && find_package('tfm-rubygem-foreman_remote_execution-cockpit')
+      server? && find_scl_or_nonscl_package('rubygem-foreman_remote_execution-cockpit')
     end
   end
 

--- a/definitions/features/foreman_cockpit.rb
+++ b/definitions/features/foreman_cockpit.rb
@@ -3,7 +3,7 @@ class Features::ForemanCockpit < ForemanMaintain::Feature
     label :foreman_cockpit
 
     confine do
-      server? && plugin_package_name('remote_execution-cockpit', 'foreman')
+      server? && find_package(foreman_plugin_name('foreman_remote_execution-cockpit'))
     end
   end
 

--- a/definitions/features/foreman_cockpit.rb
+++ b/definitions/features/foreman_cockpit.rb
@@ -3,7 +3,7 @@ class Features::ForemanCockpit < ForemanMaintain::Feature
     label :foreman_cockpit
 
     confine do
-      server? && plugin_package(:cockpit)
+      server? && plugin_package_name('remote_execution-cockpit', 'foreman')
     end
   end
 

--- a/definitions/features/foreman_cockpit.rb
+++ b/definitions/features/foreman_cockpit.rb
@@ -3,7 +3,7 @@ class Features::ForemanCockpit < ForemanMaintain::Feature
     label :foreman_cockpit
 
     confine do
-      server? && find_scl_or_nonscl_package('rubygem-foreman_remote_execution-cockpit')
+      server? && plugin_package(:cockpit)
     end
   end
 

--- a/definitions/features/foreman_openscap.rb
+++ b/definitions/features/foreman_openscap.rb
@@ -3,7 +3,8 @@ class Features::ForemanOpenscap < ForemanMaintain::Feature
     label :foreman_openscap
 
     confine do
-      check_min_version('tfm-rubygem-foreman_openscap', '0.5.3')
+      package_name = scl_or_nonscl_package('rubygem-foreman_openscap')
+      check_min_version(package_name, '0.5.3')
     end
   end
 

--- a/definitions/features/foreman_openscap.rb
+++ b/definitions/features/foreman_openscap.rb
@@ -3,8 +3,7 @@ class Features::ForemanOpenscap < ForemanMaintain::Feature
     label :foreman_openscap
 
     confine do
-      package_name = scl_or_nonscl_package('rubygem-foreman_openscap')
-      check_min_version(package_name, '0.5.3')
+      check_min_version(plugin_package(:openscap), '0.5.3')
     end
   end
 

--- a/definitions/features/foreman_openscap.rb
+++ b/definitions/features/foreman_openscap.rb
@@ -3,7 +3,7 @@ class Features::ForemanOpenscap < ForemanMaintain::Feature
     label :foreman_openscap
 
     confine do
-      check_min_version(plugin_package(:openscap), '0.5.3')
+      plugin_package_name('openscap', 'foreman')
     end
   end
 

--- a/definitions/features/foreman_openscap.rb
+++ b/definitions/features/foreman_openscap.rb
@@ -3,7 +3,7 @@ class Features::ForemanOpenscap < ForemanMaintain::Feature
     label :foreman_openscap
 
     confine do
-      plugin_package_name('openscap', 'foreman')
+      find_package(foreman_plugin_name('foreman_openscap'))
     end
   end
 

--- a/definitions/features/foreman_tasks.rb
+++ b/definitions/features/foreman_tasks.rb
@@ -23,7 +23,7 @@ class Features::ForemanTasks < ForemanMaintain::Feature
     label :foreman_tasks
 
     confine do
-      plugin_package_name('tasks', 'foreman')
+      find_package(foreman_plugin_name('foreman-tasks'))
     end
   end
 

--- a/definitions/features/foreman_tasks.rb
+++ b/definitions/features/foreman_tasks.rb
@@ -23,8 +23,9 @@ class Features::ForemanTasks < ForemanMaintain::Feature
     label :foreman_tasks
 
     confine do
+      package_name = scl_or_nonscl_package('rubygem-foreman-tasks')
       check_min_version('ruby193-rubygem-foreman-tasks', '0.6') ||
-        check_min_version('tfm-rubygem-foreman-tasks', '0.7')
+        check_min_version(package_name, '0.7')
     end
   end
 

--- a/definitions/features/foreman_tasks.rb
+++ b/definitions/features/foreman_tasks.rb
@@ -23,8 +23,7 @@ class Features::ForemanTasks < ForemanMaintain::Feature
     label :foreman_tasks
 
     confine do
-      check_min_version('ruby193-rubygem-foreman-tasks', '0.6') ||
-        check_min_version(plugin_package(:tasks), '0.7')
+      plugin_package_name('tasks', 'foreman')
     end
   end
 

--- a/definitions/features/foreman_tasks.rb
+++ b/definitions/features/foreman_tasks.rb
@@ -23,9 +23,8 @@ class Features::ForemanTasks < ForemanMaintain::Feature
     label :foreman_tasks
 
     confine do
-      package_name = scl_or_nonscl_package('rubygem-foreman-tasks')
       check_min_version('ruby193-rubygem-foreman-tasks', '0.6') ||
-        check_min_version(package_name, '0.7')
+        check_min_version(plugin_package(:tasks), '0.7')
     end
   end
 

--- a/definitions/features/hammer.rb
+++ b/definitions/features/hammer.rb
@@ -7,7 +7,7 @@ class Features::Hammer < ForemanMaintain::Feature
     label :hammer
     confine do
       # FIXME: How does this run on proxy?
-      find_scl_or_nonscl_package('rubygem-hammer_cli')
+      hammer_package
     end
   end
 

--- a/definitions/features/hammer.rb
+++ b/definitions/features/hammer.rb
@@ -6,7 +6,6 @@ class Features::Hammer < ForemanMaintain::Feature
   metadata do
     label :hammer
     confine do
-      # FIXME: How does this run on proxy?
       find_package(hammer_package)
     end
   end

--- a/definitions/features/hammer.rb
+++ b/definitions/features/hammer.rb
@@ -7,7 +7,7 @@ class Features::Hammer < ForemanMaintain::Feature
     label :hammer
     confine do
       # FIXME: How does this run on proxy?
-      find_package('rubygem-hammer_cli') || find_package('tfm-rubygem-hammer_cli')
+      find_scl_or_nonscl_package('rubygem-hammer_cli')
     end
   end
 

--- a/definitions/features/hammer.rb
+++ b/definitions/features/hammer.rb
@@ -7,7 +7,7 @@ class Features::Hammer < ForemanMaintain::Feature
     label :hammer
     confine do
       # FIXME: How does this run on proxy?
-      hammer_package
+      find_package(hammer_package)
     end
   end
 

--- a/definitions/procedures/foreman_docker/remove_foreman_docker.rb
+++ b/definitions/procedures/foreman_docker/remove_foreman_docker.rb
@@ -3,17 +3,14 @@ module Procedures::ForemanDocker
     metadata do
       advanced_run false
       description 'Drop foreman_docker plugin'
-    end
-
-    def docker_package
-      find_package(foreman_plugin_name('foreman_docker'))
+      confine do
+        find_package(foreman_plugin_name('foreman_docker'))
+      end
     end
 
     def run
-      return unless execute?("rpm -q #{docker_package}")
-
       execute!('foreman-rake foreman_docker:cleanup')
-      packages_action(:remove, [docker_package], :assumeyes => true)
+      packages_action(:remove, foreman_plugin_name('foreman_docker'), :assumeyes => true)
     end
   end
 end

--- a/definitions/procedures/foreman_docker/remove_foreman_docker.rb
+++ b/definitions/procedures/foreman_docker/remove_foreman_docker.rb
@@ -6,7 +6,7 @@ module Procedures::ForemanDocker
     end
 
     def docker_package
-      scl_or_nonscl_package('rubygem-foreman_docker')
+      plugin_package_name('docker', 'foreman')
     end
 
     def run

--- a/definitions/procedures/foreman_docker/remove_foreman_docker.rb
+++ b/definitions/procedures/foreman_docker/remove_foreman_docker.rb
@@ -6,11 +6,12 @@ module Procedures::ForemanDocker
     end
 
     def docker_package
-      'tfm-rubygem-foreman_docker'
+      scl_or_nonscl_package('rubygem-foreman_docker')
     end
 
     def run
       return unless execute?("rpm -q #{docker_package}")
+
       execute!('foreman-rake foreman_docker:cleanup')
       packages_action(:remove, [docker_package], :assumeyes => true)
     end

--- a/definitions/procedures/foreman_docker/remove_foreman_docker.rb
+++ b/definitions/procedures/foreman_docker/remove_foreman_docker.rb
@@ -6,7 +6,7 @@ module Procedures::ForemanDocker
     end
 
     def docker_package
-      plugin_package_name('docker', 'foreman')
+      find_package(foreman_plugin_name('foreman_docker'))
     end
 
     def run

--- a/lib/foreman_maintain/concerns/system_helpers.rb
+++ b/lib/foreman_maintain/concerns/system_helpers.rb
@@ -184,27 +184,6 @@ module ForemanMaintain
         ForemanMaintain.package_manager
       end
 
-      def find_scl_or_nonscl_package(name)
-        find_package(scl_or_nonscl_package(name))
-      end
-
-      def scl_or_nonscl_package(name)
-        if ForemanMaintain::Utils::Facter.os_major_release == '7'
-          return "tfm-#{name}"
-        end
-
-        name
-      end
-
-      private
-
-      def check_version(name)
-        current_version = package_version(name)
-        if current_version
-          yield current_version
-        end
-      end
-
       def os_facts
         facter = ForemanMaintain::Utils::Facter.path
         @os_facts ||= JSON.parse(execute("#{facter} -j os"))
@@ -228,6 +207,37 @@ module ForemanMaintain
 
       def el_major_version
         return os_facts['os']['release']['major'] if el?
+      end
+
+      def plugin_package(name)
+        package_names = \
+          { cockpit: 'rubygem-foreman_remote_execution-cockpit',
+            docker: 'rubygem-foreman_docker',
+            smart_proxy_dynflow_core: 'rubygem-smart_proxy_dynflow_core',
+            openscap: 'rubygem-foreman_openscap',
+            tasks: 'rubygem-foreman-tasks' }
+        if el7?
+          "tfm-#{package_names.fetch(name)}"
+        elsif el8? || debian?
+          package_names.fetch(name)
+        end
+      end
+
+      def hammer_package
+        if el7?
+          'tfm-rubygem-hammer_cli'
+        elsif el8? || debian?
+          'rubygem-hammer_cli'
+        end
+      end
+
+      private
+
+      def check_version(name)
+        current_version = package_version(name)
+        if current_version
+          yield current_version
+        end
       end
     end
   end

--- a/lib/foreman_maintain/concerns/system_helpers.rb
+++ b/lib/foreman_maintain/concerns/system_helpers.rb
@@ -238,13 +238,12 @@ module ForemanMaintain
       end
 
       def hammer_package
-        if el7?
-          'tfm-rubygem-hammer_cli'
-        elsif el8?
-          'rubygem-hammer_cli'
-        elsif debian?
-          'rubygem-hammer-cli'
-        end
+        hammer_prefix = if debian?
+                          'hammer-cli'
+                        else
+                          'hammer_cli'
+                        end
+        ruby_prefix + hammer_prefix
       end
 
       private

--- a/lib/foreman_maintain/concerns/system_helpers.rb
+++ b/lib/foreman_maintain/concerns/system_helpers.rb
@@ -209,39 +209,32 @@ module ForemanMaintain
         return os_facts['os']['release']['major'] if el?
       end
 
-      def foreman_plugin_prefix
-        if el7?
-          'tfm-rubygem-foreman_'
-        elsif el8?
-          'rubygem-foreman_'
+      def ruby_prefix(scl = true)
+        if el7? && scl
+          'tfm-rubygem-'
+        elsif el7? || el8?
+          'rubygem-'
         elsif debian?
-          'ruby-foreman-'
+          'ruby-'
         end
       end
 
-      def smart_proxy_plugin_prefix
-        if el7?
-          'tfm-rubygem-smart_proxy_'
+      def foreman_plugin_name(plugin)
+        if debian?
+          plugin.tr!('_', '-')
+        end
+        ruby_prefix + plugin
+      end
+
+      def proxy_plugin_name(plugin)
+        if debian?
+          plugin.tr!('_', '-')
+          proxy_plugin_prefix = 'smart-proxy-'
         else
-          'rubygem-smart_proxy_'
+          proxy_plugin_prefix = 'smart_proxy_'
         end
-      end
-
-      def plugin_package_name(name, plugin_of)
-        case plugin_of
-        when 'foreman'
-          if el?
-            foreman_plugin_prefix + name
-          elsif debian?
-            foreman_plugin_prefix + name.tr('_', '-')
-          end
-        when 'smart_proxy'
-          if el?
-            smart_proxy_plugin_prefix + name
-          elsif debian?
-            (smart_proxy_plugin_prefix + name).tr('_', '-')
-          end
-        end
+        scl = check_min_version('foreman', '2.0')
+        ruby_prefix(scl) + proxy_plugin_prefix + plugin
       end
 
       def hammer_package

--- a/lib/foreman_maintain/concerns/system_helpers.rb
+++ b/lib/foreman_maintain/concerns/system_helpers.rb
@@ -209,25 +209,48 @@ module ForemanMaintain
         return os_facts['os']['release']['major'] if el?
       end
 
-      def plugin_package(name)
-        package_names = \
-          { cockpit: 'rubygem-foreman_remote_execution-cockpit',
-            docker: 'rubygem-foreman_docker',
-            smart_proxy_dynflow_core: 'rubygem-smart_proxy_dynflow_core',
-            openscap: 'rubygem-foreman_openscap',
-            tasks: 'rubygem-foreman-tasks' }
+      def foreman_plugin_prefix
         if el7?
-          "tfm-#{package_names.fetch(name)}"
-        elsif el8? || debian?
-          package_names.fetch(name)
+          'tfm-rubygem-foreman_'
+        elsif el8?
+          'rubygem-foreman_'
+        elsif debian?
+          'ruby-foreman-'
+        end
+      end
+
+      def smart_proxy_plugin_prefix
+        if el7?
+          'tfm-rubygem-smart_proxy_'
+        else
+          'rubygem-smart_proxy_'
+        end
+      end
+
+      def plugin_package_name(name, plugin_of)
+        case plugin_of
+        when 'foreman'
+          if el?
+            foreman_plugin_prefix + name
+          elsif debian?
+            foreman_plugin_prefix + name.tr('_', '-')
+          end
+        when 'smart_proxy'
+          if el?
+            smart_proxy_plugin_prefix + name
+          elsif debian?
+            (smart_proxy_plugin_prefix + name).tr('_', '-')
+          end
         end
       end
 
       def hammer_package
         if el7?
           'tfm-rubygem-hammer_cli'
-        elsif el8? || debian?
+        elsif el8?
           'rubygem-hammer_cli'
+        elsif debian?
+          'rubygem-hammer-cli'
         end
       end
 

--- a/lib/foreman_maintain/concerns/system_helpers.rb
+++ b/lib/foreman_maintain/concerns/system_helpers.rb
@@ -184,6 +184,18 @@ module ForemanMaintain
         ForemanMaintain.package_manager
       end
 
+      def find_scl_or_nonscl_package(name)
+        find_package(scl_or_nonscl_package(name))
+      end
+
+      def scl_or_nonscl_package(name)
+        if ForemanMaintain::Utils::Facter.os_major_release == '7'
+          return "tfm-#{name}"
+        end
+
+        name
+      end
+
       private
 
       def check_version(name)


### PR DESCRIPTION
To restrict the number of executions, different portions of the code employ package installed conditions.
This update eliminates the requirement for explicit package names for plugins by introducing helper methods to generate package names depending on OS versions EL7(scl or non scl), EL8, and Debian.