### PR TITLE
Fixes #32777 - remove pulp 2to3 migration plugin and tables

### DIFF
--- a/definitions/procedures/pulp/remove.rb
+++ b/definitions/procedures/pulp/remove.rb
@@ -2,6 +2,7 @@ module Procedures::Pulp
   class Remove < ForemanMaintain::Procedure
     metadata do
       description 'Remove pulp2'
+      param :assumeyes, 'Do not ask for confirmation', :default => false
 
       confine do
         check_min_version('katello-common', '4.0')
@@ -43,7 +44,8 @@ module Procedures::Pulp
                     python-pulp-python-common python-pulp-repoauth python-pulp-rpm-common
                     python-pulp-streamer python-pymongo python-pymongo-gridfs python2-amqp
                     python2-billiard python2-celery python2-debpkgr python2-django python2-kombu
-                    python2-solv python2-vine pulp-katello pulp-maintenance]
+                    python2-solv python2-vine pulp-katello pulp-maintenance
+                    python3-pulp-2to3-migration]
 
       @installed_pulp_packages ||= possible.select { |pkg| find_package(pkg) }
       @installed_pulp_packages
@@ -54,9 +56,9 @@ module Procedures::Pulp
     end
 
     def ask_to_proceed(rm_cmds)
-      question = "\nWARNING: All pulp2 packages will be removed with the following commands:\n" \
-        "\n# rpm -e #{pulp_packages.join('  ')}" \
-        "\n# yum remove rh-mongodb34-*" \
+      question = "\nWARNING: All pulp2 packages will be removed with the following commands:\n"
+      question += "\n# rpm -e #{pulp_packages.join('  ')}" if pulp_packages.any?
+      question += "\n# yum remove rh-mongodb34-*" \
         "\n\nAll pulp2 data will be removed.\n"
       question += rm_cmds.collect { |cmd| "\n# #{cmd}" }.join
       question += "\n\nDo you want to proceed?"
@@ -66,11 +68,18 @@ module Procedures::Pulp
 
     def run
       rm_cmds = data_dir_removal_cmds
-      ask_to_proceed(rm_cmds) if rm_cmds.any? && !@assume_yes
 
-      remove_pulp
+      assumeyes_val = @assumeyes.nil? ? assumeyes? : @assumeyes
+
+      ask_to_proceed(rm_cmds) unless assumeyes_val
+
+      remove_pulp if pulp_packages.any?
 
       remove_mongo
+
+      drop_migration_tables
+
+      drop_migrations
 
       delete_pulp_data(rm_cmds) if rm_cmds.any?
     end
@@ -86,6 +95,60 @@ module Procedures::Pulp
         packages_action(:remove, ['rh-mongodb34-*'], :assumeyes => true)
       end
     end
+
+    def drop_migration_tables
+      with_spinner('Dropping migration tables') do
+        feature(:pulpcore_database).psql(<<-SQL)
+          BEGIN;
+          DROP TABLE IF EXISTS pulp_2to3_migration_migrationplan,
+            pulp_2to3_migration_pulp2blob,
+            pulp_2to3_migration_pulp2content,
+            pulp_2to3_migration_pulp2debcomponent,
+            pulp_2to3_migration_pulp2debcomponentpackage,
+            pulp_2to3_migration_pulp2debpackage,
+            pulp_2to3_migration_pulp2debrelease,
+            pulp_2to3_migration_pulp2debreleasearchitecture,
+            pulp_2to3_migration_pulp2distribution,
+            pulp_2to3_migration_pulp2distributor,
+            pulp_2to3_migration_pulp2distributor_pulp2_repos,
+            pulp_2to3_migration_pulp2erratum,
+            pulp_2to3_migration_pulp2importer,
+            pulp_2to3_migration_pulp2iso,
+            pulp_2to3_migration_pulp2lazycatalog,
+            pulp_2to3_migration_pulp2manifest,
+            pulp_2to3_migration_pulp2manifestlist,
+            pulp_2to3_migration_pulp2modulemd,
+            pulp_2to3_migration_pulp2modulemddefaults,
+            pulp_2to3_migration_pulp2packagecategory,
+            pulp_2to3_migration_pulp2packageenvironment,
+            pulp_2to3_migration_pulp2packagegroup,
+            pulp_2to3_migration_pulp2packagelangpacks,
+            pulp_2to3_migration_pulp2repocontent,
+            pulp_2to3_migration_pulp2repository,
+            pulp_2to3_migration_pulp2rpm,
+            pulp_2to3_migration_pulp2srpm,
+            pulp_2to3_migration_pulp2tag,
+            pulp_2to3_migration_pulp2yumrepometadatafile,
+            pulp_2to3_migration_reposetup CASCADE;
+          DROP SEQUENCE IF EXISTS pulp_2to3_migration_pulp2distributor_pulp2_repos_id_seq;
+          END;
+        SQL
+      end
+    end
+
+    def drop_migrations
+      with_spinner('Dropping migrations') do
+        feature(:pulpcore_database).psql(<<-SQL)
+          BEGIN;
+          DELETE FROM django_migrations WHERE app = 'pulp_2to3_migration';
+          DELETE FROM auth_permission WHERE content_type_id in (SELECT id FROM django_content_type WHERE app_label = 'pulp_2to3_migration');
+          DELETE FROM django_admin_log WHERE content_type_id in (SELECT id FROM django_content_type WHERE app_label = 'pulp_2to3_migration');
+          DELETE FROM django_content_type WHERE app_label = 'pulp_2to3_migration';
+          END;
+        SQL
+      end
+    end
+    # rubocop:enable Metrics/BlockLength
 
     def delete_pulp_data(rm_cmds)
       with_spinner('Deleting pulp2 data directories') do |spinner|

--- a/definitions/scenarios/content.rb
+++ b/definitions/scenarios/content.rb
@@ -101,7 +101,12 @@ module ForemanMaintain::Scenarios
       metadata do
         label :content_remove_pulp2
         description 'Remove Pulp2 and mongodb packages and data'
+        param :assumeyes, 'Do not ask for confirmation'
         manual_detection
+      end
+
+      def set_context_mapping
+        context.map(:assumeyes, Procedures::Pulp::Remove => :assumeyes)
       end
 
       def compose

--- a/lib/foreman_maintain/cli/content_command.rb
+++ b/lib/foreman_maintain/cli/content_command.rb
@@ -35,8 +35,11 @@ module ForemanMaintain
       end
 
       subcommand 'remove-pulp2', 'Remove pulp2 and mongodb packages and data' do
+        interactive_option(%w[assumeyes plaintext])
         def execute
-          run_scenarios_and_exit(Scenarios::Content::RemovePulp2.new)
+          run_scenarios_and_exit(
+            Scenarios::Content::RemovePulp2.new(:assumeyes => assumeyes?)
+          )
         end
       end
     end


### PR DESCRIPTION
This PR changes the pulp2 remove command so that tables and migrations are removed. It is a known issue with django2 (and dbshell included in django-admin) that problem with SQL are not reflected in the error status of the pulpcore-manager dbshell command. (This is fixed in django3.)