### PR TITLE
Refs #32909 - don't install default ruby with rvm

### DIFF
--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install RVM
         run: |
           gpg --keyserver hkps://keys.openpgp.org --recv-keys 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-          \curl -sSL https://get.rvm.io | bash -s stable --ruby
+          \curl -sSL https://get.rvm.io | bash -s stable
           source $HOME/.rvm/scripts/rvm
           rvm install 2.0.0
       - name: Setup


### PR DESCRIPTION
when you call rvms installer with `--ruby`, it installs the default ruby
(3.0 at the time of writing), but we don't need that as we will
explicitly install 2.0 two lines later

saves some setup time :)