### PR TITLE
Fixes #30094 - drop unwanted interactive options from packages cmd

### DIFF
--- a/lib/foreman_maintain/cli/packages_command.rb
+++ b/lib/foreman_maintain/cli/packages_command.rb
@@ -2,28 +2,28 @@ module ForemanMaintain
   module Cli
     class PackagesCommand < Base
       subcommand 'lock', 'Prevent packages from automatic update' do
-        interactive_option
+        interactive_option(['assumeyes'])
         def execute
           run_scenarios_and_exit(Scenarios::Packages::Lock.new)
         end
       end
 
       subcommand 'unlock', 'Enable packages for automatic update' do
-        interactive_option
+        interactive_option(['assumeyes'])
         def execute
           run_scenarios_and_exit(Scenarios::Packages::Unlock.new)
         end
       end
 
       subcommand 'status', 'Check if packages are protected against update' do
-        interactive_option
+        interactive_option(['assumeyes'])
         def execute
           run_scenarios_and_exit(Scenarios::Packages::Status.new)
         end
       end
 
       subcommand 'install', 'Install packages in an unlocked session' do
-        interactive_option
+        interactive_option(['assumeyes'])
         parameter 'PACKAGES ...', 'packages to install', :attribute_name => :packages
 
         def execute
@@ -37,7 +37,7 @@ module ForemanMaintain
       end
 
       subcommand 'update', 'Update packages in an unlocked session' do
-        interactive_option
+        interactive_option(['assumeyes'])
         parameter '[PACKAGES] ...', 'packages to update', :attribute_name => :packages
 
         def execute
@@ -51,7 +51,7 @@ module ForemanMaintain
       end
 
       subcommand 'is-locked', 'Check if update of packages is allowed' do
-        interactive_option
+        interactive_option([])
         def execute
           locked = ForemanMaintain.package_manager.versions_locked?
           puts "Packages are#{locked ? '' : ' not'} locked"


### PR DESCRIPTION
The package sub-commands by default use to have 'assumeyes' and
'whitelist' options. These options are not required for all
sub-commands.