### PR TITLE
Fixes #25943 - Add support in spinner for plaintext output

### DIFF
--- a/lib/foreman_maintain/cli/base.rb
+++ b/lib/foreman_maintain/cli/base.rb
@@ -153,7 +153,7 @@ module ForemanMaintain
       end
 
       # rubocop:disable  Metrics/MethodLength
-      def self.interactive_option(opts = %w[assumeyes whitelist force])
+      def self.interactive_option(opts = %w[assumeyes whitelist force plaintext])
         delete_duplicate_assumeyes_if_any
 
         if opts.include?('assumeyes')
@@ -174,6 +174,13 @@ module ForemanMaintain
         if opts.include?('force')
           option ['-f', '--force'], :flag,
                  'Force steps that would be skipped as they were already run'
+        end
+
+        if opts.include?('plaintext')
+          option(['--plaintext'], :flag,
+                 'Print the output in plaintext and disable the spinner') do |plaintext|
+            ForemanMaintain.reporter.plaintext = plaintext
+          end
         end
       end
       # rubocop:enable  Metrics/MethodLength

--- a/lib/foreman_maintain/reporter.rb
+++ b/lib/foreman_maintain/reporter.rb
@@ -46,6 +46,10 @@ module ForemanMaintain
       @assumeyes
     end
 
+    def plaintext?
+      @plaintext
+    end
+
     # simple yes/no question, returns :yes, :no or :quit
     # rubocop:disable Metrics/LineLength
     def ask_decision(message, actions_msg: 'y(yes), n(no), q(quit)', assumeyes: assumeyes?, run_strategy: :fail_fast)
@@ -63,6 +67,10 @@ module ForemanMaintain
 
     def assumeyes=(assume)
       @assumeyes = !!assume
+    end
+
+    def plaintext=(plaintext)
+      @plaintext = !!plaintext
     end
 
     private


### PR DESCRIPTION
This PR adds an option to foreman-maintain backup to output in plaintext.  Simply add --plaintext as an argument to try it out.

Based on this original PR: https://github.com/theforeman/foreman_maintain/pull/346