### PR TITLE
Fixes #32319 - skip external databases while filtering services

### DIFF
--- a/definitions/features/service.rb
+++ b/definitions/features/service.rb
@@ -45,7 +45,7 @@ class Features::Service < ForemanMaintain::Feature
 
   def filter_disabled_services!(action, service_list)
     if %w[start stop restart status].include?(action)
-      service_list.select!(&:enabled?)
+      service_list.select! { |service| !service.respond_to?(:enabled?) || service.enabled? }
     end
     service_list
   end


### PR DESCRIPTION
The external databases can't be enabled or disabled hence
not considering pgsql databases while filtering disabled
services