### PR TITLE
Fixes #33053 - don't guard disable-system-checks by old katello

### DIFF
--- a/definitions/procedures/restore/installer_reset.rb
+++ b/definitions/procedures/restore/installer_reset.rb
@@ -21,8 +21,7 @@ module Procedures::Restore
       # already ran since this is to be run on an existing system, which means installer checks
       # has already been skipped
       if feature(:foreman_proxy) &&
-         feature(:foreman_proxy).with_content? &&
-         check_min_version('katello-installer-base', '3.2.0')
+         feature(:foreman_proxy).with_content?
         installer << '--disable-system-checks '
       end
       installer


### PR DESCRIPTION
katello-installer is not a thing anymore, and 3.2.0 is super old too,
so let's just drop this part of the guard instead of making it "correct"
by using foreman-installer-katello.