### PR TITLE
Fixes #33183 - adjusts the interactive command runner for nohup

### DIFF
--- a/lib/foreman_maintain/utils/command_runner.rb
+++ b/lib/foreman_maintain/utils/command_runner.rb
@@ -59,12 +59,15 @@ module ForemanMaintain
 
       private
 
+      # rubocop:disable Metrics/MethodLength
       def run_interactively
         # use tmp files to capture output and exit status of the command when
         # running interactively
         log_file = Tempfile.open('captured-output')
         exit_file = Tempfile.open('captured-exit-code')
-        Kernel.system("script -qc '#{full_command}; echo $? > #{exit_file.path}' #{log_file.path}")
+        Kernel.system(
+          "bash -c '#{full_command}; echo $? > #{exit_file.path}' | tee -i #{log_file.path}"
+        )
         File.open(log_file.path) { |f| @output = f.read }
         File.open(exit_file.path) do |f|
           exit_status = f.read.strip
@@ -78,6 +81,7 @@ module ForemanMaintain
         log_file.close
         exit_file.close
       end
+      # rubocop:enable Metrics/MethodLength
 
       def run_non_interactively
         IO.popen(full_command, 'r+') do |f|


### PR DESCRIPTION
Example of problem before, running a migration command in the background:
```
Running Prepare content for Pulp 3
================================================================================
Prepare content for Pulp 3: 
                                                                      [FAIL]
Failed executing foreman-rake katello:pulp3_migration, exit status 256
--------------------------------------------------------------------------------
Scenario [Prepare content for Pulp 3] failed.

The following steps ended up in failing state:

  [content-prepare]

Resolve the failed steps and rerun
the command. In case the failures are false positives,
use --whitelist="content-prepare"
```

And after:
```
Running Prepare content for Pulp 3
================================================================================
Prepare content for Pulp 3: 
Checking for valid Katello configuraton.
Starting task.

2021-07-29 15:59:30 +0000: Content migration starting. 
Content Migration completed successfully

Checking for valid Katello configuraton.
Starting task.

2021-07-29 15:59:30 +0000: Content migration starting. 
Content Migration completed successfully
                             [OK]
--------------------------------------------------------------------------------
```
