### PR TITLE
Fixes #33202 - add append-output mode to content prepare

### DIFF
--- a/definitions/procedures/content/prepare.rb
+++ b/definitions/procedures/content/prepare.rb
@@ -3,12 +3,14 @@ module Procedures::Content
     metadata do
       description 'Prepare content for Pulp 3'
       for_feature :pulpcore
+      param :quiet, 'Keep the output on a single line', :flag => true, :default => false
     end
 
     def run
       sleep(20) # in satellite 6.9 the services are still coming up
       # use interactive to get realtime output
-      puts execute!('foreman-rake katello:pulp3_migration', :interactive => true)
+      env_vars = @quiet ? '' : 'preserve_output=true '
+      puts execute!("#{env_vars}foreman-rake katello:pulp3_migration", :interactive => true)
     end
   end
 end

--- a/definitions/scenarios/content.rb
+++ b/definitions/scenarios/content.rb
@@ -2,11 +2,10 @@ module ForemanMaintain::Scenarios
   module Content
     class ContentBase < ForemanMaintain::Scenario
       def enable_and_start_services
-        add_step(Procedures::Service::Start)
         add_step(Procedures::Service::Enable.
                  new(:only => Features::Pulpcore.pulpcore_migration_services))
         add_step(Procedures::Service::Start.
-                 new(:only => Features::Pulpcore.pulpcore_migration_services))
+                 new(:include => Features::Pulpcore.pulpcore_migration_services))
       end
 
       def disable_and_stop_services
@@ -27,11 +26,17 @@ module ForemanMaintain::Scenarios
       def compose
         if feature(:satellite) && feature(:satellite).at_least_version?('6.9')
           enable_and_start_services
-          add_step(Procedures::Content::Prepare)
+          add_step(Procedures::Content::Prepare.new(quiet: quiet?))
           disable_and_stop_services
         elsif !feature(:satellite)
-          add_step(Procedures::Content::Prepare)
+          add_step(Procedures::Content::Prepare.new(quiet: quiet?))
         end
+      end
+
+      private
+
+      def quiet?
+        !!context.get(:quiet)
       end
     end
 
@@ -60,6 +65,7 @@ module ForemanMaintain::Scenarios
 
       def compose
         if !feature(:satellite) || feature(:satellite).at_least_version?('6.9')
+          enable_and_start_services if feature(:satellite)
           add_step(Procedures::Content::PrepareAbort)
           disable_and_stop_services if feature(:satellite)
         end

--- a/lib/foreman_maintain/cli/content_command.rb
+++ b/lib/foreman_maintain/cli/content_command.rb
@@ -2,8 +2,9 @@ module ForemanMaintain
   module Cli
     class ContentCommand < Base
       subcommand 'prepare', 'Prepare content for Pulp 3' do
+        option ['-q', '--quiet'], :flag, 'Keep the output on a single line'
         def execute
-          run_scenarios_and_exit(Scenarios::Content::Prepare.new)
+          run_scenarios_and_exit(Scenarios::Content::Prepare.new(:quiet => quiet?))
         end
       end
 


### PR DESCRIPTION
With `--append-output` or `-a`, `foreman-maintain content prepare` will now show all output instead of overwriting the last line.