### PR TITLE
Fixes #33406 - add latest z-stream check

### DIFF
--- a/definitions/checks/check_for_newer_packages.rb
+++ b/definitions/checks/check_for_newer_packages.rb
@@ -1,0 +1,26 @@
+class Checks::CheckForNewerPackages < ForemanMaintain::Check
+  metadata do
+    label :check_for_newer_packages
+    description 'Check for newer packages and optionally ask for confirmation if not found.'
+
+    param :packages,
+          'package names to validate',
+          :required => true
+    param :manual_confirmation_version,
+          'Version of satellite (6.9) to ask the user if they are on the latest minor release of.',
+          :required => false
+  end
+
+  def run
+    exit_status, = ForemanMaintain.package_manager.check_update(packages: @packages,
+                                                                with_status: true)
+    assert(exit_status == 0, 'An update is available for one of these packages: '\
+                "#{@packages.join(',')}. Please update before proceeding.")
+    if @manual_confirmation_version
+      question = 'Confirm that you are running the latest minor release of Satellite '\
+                "#{@manual_confirmation_version}"
+      answer = ask_decision(question, actions_msg: 'y(yes), q(quit)')
+      abort! if answer != :yes
+    end
+  end
+end

--- a/definitions/scenarios/upgrade_to_satellite_6_10.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_10.rb
@@ -26,8 +26,12 @@ module Scenarios::Satellite_6_10
 
     def compose
       add_step(Checks::Puppet::WarnAboutPuppetRemoval)
+      add_step(Checks::CheckForNewerPackages.new(:packages => [foreman_plugin_name('katello'),
+                                                               'python3-pulp-2to3-migration'],
+                                                 :manual_confirmation_version => '6.9'))
       add_steps(find_checks(:default))
       add_steps(find_checks(:pre_upgrade))
+
       add_step(Checks::Foreman::CheckpointSegments)
       add_step(Checks::Repositories::Validate.new(:version => '6.10'))
     end

--- a/lib/foreman_maintain/package_manager/yum.rb
+++ b/lib/foreman_maintain/package_manager/yum.rb
@@ -61,8 +61,9 @@ module ForemanMaintain::PackageManager
       yum_action('clean', 'all', :assumeyes => assumeyes)
     end
 
-    def check_update
-      yum_action('check-update', nil, :assumeyes => true, :valid_exit_statuses => [100])
+    def check_update(packages: nil, with_status: false)
+      yum_action('check-update', packages, :assumeyes => true, :valid_exit_statuses => [100],
+                                           :with_status => with_status)
     end
 
     def update_available?(package)


### PR DESCRIPTION
this will check that the katello and pulp migration plugin
packages are updated and if not will fail the upgrade.

Even if they are upgraded, we pause and ask the user to
confirm that they are on the latest z-stream, as requested
by CEE