### PR TITLE
Fixes #33411 - disable and stop pulp3 services

### DIFF
--- a/definitions/scenarios/upgrade_to_satellite_6_10.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_10.rb
@@ -63,15 +63,22 @@ module Scenarios::Satellite_6_10
       end
     end
 
-    def compose
-      check_var_lib_pulp
-
+    def pulp3_switchover_steps
       add_step(Procedures::Service::Start)
       add_step(Procedures::Service::Enable.
           new(:only => Features::Pulpcore.pulpcore_migration_services))
       add_step(Procedures::Service::Start.
           new(:only => Features::Pulpcore.pulpcore_migration_services))
       add_step(Procedures::Content::Switchover.new(:skip_deb => true))
+      add_step(Procedures::Service::Stop.
+                 new(:only => Features::Pulpcore.pulpcore_migration_services))
+      add_step(Procedures::Service::Disable.
+                 new(:only => Features::Pulpcore.pulpcore_migration_services))
+    end
+
+    def compose
+      check_var_lib_pulp
+      pulp3_switchover_steps
       add_step(Procedures::Repositories::Setup.new(:version => '6.10'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))


### PR DESCRIPTION
The pulp3 workers should be stopped and disabled after migration
to pulp3