### PR TITLE
Fixes #33437 - skip installer run after switchover 

### DIFF
--- a/definitions/procedures/content/switchover.rb
+++ b/definitions/procedures/content/switchover.rb
@@ -11,7 +11,6 @@ module Procedures::Content
       param :skip_deb, 'Do not run debian options in installer.'
     end
 
-    # rubocop:disable Metrics/MethodLength
     def run
       puts 'Performing final content migration before switching content'
       puts execute!('foreman-rake katello:pulp3_migration')
@@ -19,6 +18,10 @@ module Procedures::Content
       puts execute!('foreman-rake katello:pulp3_post_migration_check')
       puts 'Switching specified content over to pulp 3'
       puts execute!('foreman-rake katello:pulp3_content_switchover')
+      run_installer if feature(:upstream)
+    end
+
+    def run_installer
       puts 'Re-running the installer to switch specified content over to pulp3'
       args = ['--foreman-proxy-content-proxy-pulp-isos-to-pulpcore=true',
               '--foreman-proxy-content-proxy-pulp-yum-to-pulpcore=true',

--- a/definitions/scenarios/upgrade_to_satellite_6_10.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_10.rb
@@ -64,15 +64,11 @@ module Scenarios::Satellite_6_10
     end
 
     def pulp3_switchover_steps
-      add_step(Procedures::Service::Start)
       add_step(Procedures::Service::Enable.
           new(:only => Features::Pulpcore.pulpcore_migration_services))
-      add_step(Procedures::Service::Start.
-          new(:only => Features::Pulpcore.pulpcore_migration_services))
-      add_step(Procedures::Content::Switchover.new(:skip_deb => true))
+      add_step(Procedures::Service::Start)
+      add_step(Procedures::Content::Switchover.new)
       add_step(Procedures::Service::Stop.
-                 new(:only => Features::Pulpcore.pulpcore_migration_services))
-      add_step(Procedures::Service::Disable.
                  new(:only => Features::Pulpcore.pulpcore_migration_services))
     end
 


### PR DESCRIPTION
The installer run stops and disables pulpcore-workers*
We need to stop the services but not disable those