### PR TITLE
Fixes #33528 - default to 'rubygem-' prefix for Ruby packages

### DIFF
--- a/lib/foreman_maintain/concerns/system_helpers.rb
+++ b/lib/foreman_maintain/concerns/system_helpers.rb
@@ -210,12 +210,12 @@ module ForemanMaintain
       end
 
       def ruby_prefix(scl = true)
-        if el7? && scl
-          'tfm-rubygem-'
-        elsif el7? || el8?
-          'rubygem-'
-        elsif debian?
+        if debian?
           'ruby-'
+        elsif el7? && scl
+          'tfm-rubygem-'
+        else
+          'rubygem-'
         end
       end
 


### PR DESCRIPTION
this is true for EL8, EL9 and Fedora, so lets make this the default