### PR TITLE
update ruby versions to match destination OSes

### DIFF
--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.3.3, 2.4.5, 2.5.3, 2.6.5]
+        ruby-version: ['2.5.3', '2.7.4', '3.0.2']
     steps:
       - uses: actions/checkout@v2
       - name: Install facter package

--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,7 @@ if File.exist? "#{__FILE__}.local"
   eval(File.read("#{__FILE__}.local"), nil, "#{__FILE__}.local")
 end
 # rubocop:enable  Security/Eval
+
+if RUBY_VERSION >= '3.0'
+  gem 'rexml' # rexml was a default gem in ruby < 3.0, and is a bundled gem in >= 3.0
+end


### PR DESCRIPTION
EL7 uses 2.0.0
EL8 uses 2.7.4 (and used 2.5.9 for a while)
EL9 uses 3.0.2 (at least today)
Debian/Ubuntu have 2.5/2.7