### PR TITLE
Fixes #33686 - 6.10 upgrade check & warn if user has HTTPS proxy

### DIFF
--- a/definitions/checks/foreman/check_https_proxies.rb
+++ b/definitions/checks/foreman/check_https_proxies.rb
@@ -1,0 +1,34 @@
+module Checks
+  class CheckHttpsProxies < ForemanMaintain::Check
+    metadata do
+      label :https_proxies
+      for_feature :foreman_database
+      description 'Check for HTTPS proxies from the database'
+      manual_detection
+    end
+
+    def run
+      https_proxies = find_https_proxies
+      unless https_proxies.empty?
+        https_proxy_names = https_proxies.map { |proxy| proxy['name'] }
+        question = "Syncing repositories through an 'HTTP Proxy' that uses the HTTPS\n"\
+                    "protocol is not supported directly with Satellite 6.10.\n"\
+                    "The following proxies use HTTPS: #{https_proxy_names.join(', ')}.\n"\
+                    "For a suggested solution see https://access.redhat.com/solutions/6414991\n"\
+                    'Continue upgrade?'
+        answer = ask_decision(question, actions_msg: 'y(yes), q(quit)')
+        abort! if answer != :yes
+      end
+    end
+
+    def find_https_proxies
+      feature(:foreman_database).query(self.class.query_to_get_https_proxies)
+    end
+
+    def self.query_to_get_https_proxies
+      <<-SQL
+        SELECT \"http_proxies\".* FROM \"http_proxies\" WHERE (http_proxies.url ilike 'https://%')
+      SQL
+    end
+  end
+end

--- a/definitions/scenarios/upgrade_to_satellite_6_10.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_10.rb
@@ -29,6 +29,7 @@ module Scenarios::Satellite_6_10
       add_step(Checks::CheckForNewerPackages.new(:packages => [foreman_plugin_name('katello'),
                                                                'python3-pulp-2to3-migration'],
                                                  :manual_confirmation_version => '6.9'))
+      add_step(Checks::CheckHttpsProxies)
       add_steps(find_checks(:default))
       add_steps(find_checks(:pre_upgrade))
 


### PR DESCRIPTION
This PR adds a check to see if users have any HTTPS proxies before continuing with the 6.10 upgrade. They are given an option about whether or not to continue the upgrade.

Example output:

```
--------------------------------------------------------------------------------
Check for HTTPS proxies from DB: 
Warning: Syncing repositories via HTTPS proxies is temporarily unsupported.
The following proxies use HTTPS: https proxy.
Continue upgrade?, [y(yes), q(quit)] q
                                                                      [ABORTED] 
--------------------------------------------------------------------------------
```