### PR TITLE
Refs #33271 - Use Dir.entries instead of Dir.children

### DIFF
--- a/lib/foreman_maintain/utils/backup.rb
+++ b/lib/foreman_maintain/utils/backup.rb
@@ -291,7 +291,7 @@ module ForemanMaintain
         # I wanted to do `Socket.getifaddrs.map(&:name).uniq`,
         # but this has to work with Ruby 2.0, and Socket.getifaddrs is 2.1+
         errors = {}
-        system_interfaces = Dir.children('/sys/class/net')
+        system_interfaces = Dir.entries('/sys/class/net') - ['.', '..']
 
         proxy_config = metadata.fetch('proxy_config', {})
 

--- a/test/lib/utils/backup_test.rb
+++ b/test/lib/utils/backup_test.rb
@@ -339,13 +339,13 @@ module ForemanMaintain
 
     it 'accepts backup without proxy config in the metadata' do
       backup = subject.new(katello_standard_pulp2)
-      Dir.stubs(:children).returns(%w[lo eth0])
+      Dir.stubs(:entries).returns(%w[. .. lo eth0])
       assert backup.validate_interfaces.empty?
     end
 
     it 'accepts backup with proxy config and disabled DHCP/DNS in the metadata' do
       backup = subject.new(katello_standard_pulp2)
-      Dir.stubs(:children).returns(%w[lo eth0])
+      Dir.stubs(:entries).returns(%w[. .. lo eth0])
       backup.stubs(:metadata).returns('proxy_config' =>
                                       { 'dhcp' => false,
                                         'dhcp_interface' => 'eth0',
@@ -356,7 +356,7 @@ module ForemanMaintain
 
     it 'accepts backup when DHCP/DNS configured interfaces are found on system' do
       backup = subject.new(katello_standard_pulp2)
-      Dir.stubs(:children).returns(%w[lo eth0])
+      Dir.stubs(:entries).returns(%w[. .. lo eth0])
       backup.stubs(:metadata).returns('proxy_config' =>
                                       { 'dhcp' => true,
                                         'dhcp_interface' => 'eth0',
@@ -367,7 +367,7 @@ module ForemanMaintain
 
     it 'rejects backup when DHCP/DNS configured interfaces are not found on system' do
       backup = subject.new(katello_standard_pulp2)
-      Dir.stubs(:children).returns(%w[lo eth1])
+      Dir.stubs(:entries).returns(%w[. .. lo eth1])
       backup.stubs(:metadata).returns('proxy_config' =>
                                       { 'dhcp' => true,
                                         'dhcp_interface' => 'eth0',


### PR DESCRIPTION
Dir.children is new in Ruby 2.5 :(

Fixes: 81f60e1508f940574d3d59c8b9ab0e87c00bd6d2