### PR TITLE
Fixes #33829 - add disable Puppet command

### DIFF
--- a/definitions/checks/foreman/check_puppet_capsules.rb
+++ b/definitions/checks/foreman/check_puppet_capsules.rb
@@ -1,0 +1,43 @@
+module Checks
+  class CheckPuppetCapsules < ForemanMaintain::Check
+    metadata do
+      label :puppet_capsules
+      for_feature :foreman_database
+      description 'Check for Puppet capsules from the database'
+      manual_detection
+    end
+
+    def run
+      puppet_proxies = find_puppet_proxies.reject { |proxy| local_proxy?(proxy['url']) }
+      unless puppet_proxies.empty?
+        names = puppet_proxies.map { |proxy| proxy['name'] }
+        print('You have proxies with Puppet feature enabled, '\
+              "please disable Puppet on all proxies first.\n"\
+              "The following proxies have Puppet feature: #{names.join(', ')}.")
+        abort!
+      end
+    end
+
+    def find_puppet_proxies
+      feature(:foreman_database).query(puppet_proxies_query)
+    end
+
+    private
+
+    def local_proxy?(url)
+      URI.parse(url).hostname.casecmp(hostname) == 0
+    end
+
+    def puppet_proxies_query
+      <<-SQL
+        SELECT \"smart_proxies\".*
+          FROM \"smart_proxies\"
+            INNER JOIN \"smart_proxy_features\"
+              ON \"smart_proxies\".\"id\" = \"smart_proxy_features\".\"smart_proxy_id\"
+            INNER JOIN \"features\"
+              ON \"features\".\"id\" = \"smart_proxy_features\".\"feature_id\"
+          WHERE \"features\".\"name\" = 'Puppet'
+      SQL
+    end
+  end
+end

--- a/definitions/procedures/puppet/remove_puppet.rb
+++ b/definitions/procedures/puppet/remove_puppet.rb
@@ -1,0 +1,50 @@
+module Procedures::Puppet
+  class RemovePuppet < ForemanMaintain::Procedure
+    metadata do
+      description 'Remove Puppet feature'
+      confine do
+        feature(:puppet_server) &&
+          (check_min_version('foreman', '3.0') || check_min_version('foreman-proxy', '3.0'))
+      end
+      advanced_run false
+    end
+
+    def run
+      services = feature(:foreman_server).services + feature(:dynflow_sidekiq).services
+      Procedures::Service::Stop.new(:only => services)
+      execute!('foreman-rake db:migrate VERSION=0 SCOPE=foreman_puppet') if server_with_puppet?
+      feature(:installer).run(installer_arguments_disabling_puppet.join(' '), :interactive => false)
+      packages_action(:remove, packages_to_remove, :assumeyes => true)
+    end
+
+    private
+
+    def server_with_puppet?
+      find_package(foreman_plugin_name('foreman_puppet'))
+    end
+
+    def installer_arguments_disabling_puppet
+      answers = feature(:installer).answers
+
+      options = []
+      options << '--no-enable-puppet' if answers.key?('puppet')
+      options << '--no-enable-foreman-plugin-puppet' if answers['foreman::plugin::puppet']
+      options << '--no-enable-foreman-cli-puppet' if answers['foreman::cli::puppet']
+      if answers['foreman_proxy']
+        options << '--foreman-proxy-puppet false'
+        options << '--foreman-proxy-puppetca false'
+      end
+      options << '--foreman-proxy-content-puppet false' if answers.key?('foreman_proxy_content')
+      options
+    end
+
+    def packages_to_remove
+      packages = ['puppetserver']
+      if server_with_puppet?
+        packages << foreman_plugin_name('foreman_puppet')
+        packages << hammer_plugin_name('foreman_puppet')
+      end
+      packages
+    end
+  end
+end

--- a/definitions/procedures/puppet/remove_puppet_data.rb
+++ b/definitions/procedures/puppet/remove_puppet_data.rb
@@ -1,0 +1,21 @@
+module Procedures::Puppet
+  class RemovePuppetData < ForemanMaintain::Procedure
+    metadata do
+      description 'Remove Puppet data'
+    end
+
+    def run
+      execute!('foreman-rake purge:puppet')
+      execute!('rm -r ' + files_to_purge.join(' '))
+    end
+
+    private
+
+    def files_to_purge
+      %w[
+        /etc/puppetlabs
+        /opt/puppetlabs/server/data
+      ]
+    end
+  end
+end

--- a/definitions/scenarios/puppet.rb
+++ b/definitions/scenarios/puppet.rb
@@ -1,0 +1,22 @@
+module ForemanMaintain::Scenarios
+  module Puppet
+    class RemovePuppet < ForemanMaintain::Scenario
+      metadata do
+        description 'Remove Puppet feature'
+        tags :puppet_disable
+        label :puppet_disable
+        param :remove_data, 'Purge the Puppet data after disabling plugin'
+        confine do
+          check_min_version('foreman', '3.0') || check_min_version('foreman-proxy', '3.0')
+        end
+        manual_detection
+      end
+
+      def compose
+        add_step(Checks::CheckPuppetCapsules) if server?
+        add_step(Procedures::Puppet::RemovePuppet)
+        add_step(Procedures::Puppet::RemovePuppetData) if context.get(:remove_data)
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/cli.rb
+++ b/lib/foreman_maintain/cli.rb
@@ -11,6 +11,7 @@ require 'foreman_maintain/cli/restore_command'
 require 'foreman_maintain/cli/maintenance_mode_command'
 require 'foreman_maintain/cli/packages_command'
 require 'foreman_maintain/cli/content_command'
+require 'foreman_maintain/cli/plugin_command'
 
 module ForemanMaintain
   module Cli
@@ -25,6 +26,7 @@ module ForemanMaintain
       subcommand 'packages', 'Lock/Unlock package protection, install, update', PackagesCommand
       subcommand 'advanced', 'Advanced tools for server maintenance', AdvancedCommand
       subcommand 'content', 'Content related commands', ContentCommand
+      subcommand 'plugin', 'Manage optional plugins on your server', PluginCommand
       subcommand 'maintenance-mode', 'Control maintenance-mode for application',
                  MaintenanceModeCommand
       if ForemanMaintain.detector.feature(:satellite) &&

--- a/lib/foreman_maintain/cli/plugin_command.rb
+++ b/lib/foreman_maintain/cli/plugin_command.rb
@@ -1,0 +1,14 @@
+module ForemanMaintain
+  module Cli
+    class PluginCommand < Base
+      subcommand 'purge-puppet', 'Remove the Puppet feature' do
+        option ['-f', '--remove-all-data'], :flag, 'Purge all the Puppet data',
+               :attribute_name => :remove_data
+
+        def execute
+          run_scenarios_and_exit(Scenarios::Puppet::RemovePuppet.new(:remove_data => remove_data?))
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/concerns/system_helpers.rb
+++ b/lib/foreman_maintain/concerns/system_helpers.rb
@@ -196,21 +196,24 @@ module ForemanMaintain
       end
 
       def foreman_plugin_name(plugin)
-        if debian?
-          plugin.tr!('_', '-')
-        end
+        plugin = plugin.tr('_', '-') if debian?
         ruby_prefix + plugin
       end
 
       def proxy_plugin_name(plugin)
         if debian?
-          plugin.tr!('_', '-')
+          plugin = plugin.tr('_', '-')
           proxy_plugin_prefix = 'smart-proxy-'
         else
           proxy_plugin_prefix = 'smart_proxy_'
         end
         scl = check_min_version('foreman-proxy', '2.0')
         ruby_prefix(scl) + proxy_plugin_prefix + plugin
+      end
+
+      def hammer_plugin_name(plugin)
+        plugin = plugin.tr('_', '-') if debian?
+        [hammer_package, plugin].join(debian? ? '-' : '_')
       end
 
       def hammer_package

--- a/test/data/puppet/foreman-answers-default.yaml
+++ b/test/data/puppet/foreman-answers-default.yaml
@@ -1,0 +1,11 @@
+# foreman-answers-default.yaml
+# scenario: foreman
+# This is what foreman-installer ships out of the box, stripped of unrelated entries
+---
+foreman: {}
+foreman::cli: true
+foreman::cli::puppet: true
+foreman::plugin::puppet: true
+foreman_proxy: {}
+puppet:
+  server: true

--- a/test/data/puppet/foreman-answers-no-foreman-with-puppet.yaml
+++ b/test/data/puppet/foreman-answers-no-foreman-with-puppet.yaml
@@ -1,0 +1,11 @@
+# foreman-answers-no-foreman-with-puppet.yaml
+# scenario: foreman
+# This is only a foreman-proxy with Puppet enabled
+---
+foreman: false
+foreman::cli: false
+foreman::cli::puppet: false
+foreman::plugin::puppet: false
+foreman_proxy: {}
+puppet:
+  server: true

--- a/test/data/puppet/foreman-proxy-content-with-puppet.yaml
+++ b/test/data/puppet/foreman-proxy-content-with-puppet.yaml
@@ -1,0 +1,14 @@
+# foreman-proxy-content-answers-with-puppet.yaml
+# scenario: foreman-proxy-content
+# This is where a user enabled puppet
+---
+foreman_proxy:
+  puppet: true
+  puppetca: true
+foreman_proxy_content:
+  puppet: true
+puppet:
+  server: true
+  puppet_server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
+  puppet_server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
+  puppet_server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key

--- a/test/data/puppet/katello-answers-with-puppet.yaml
+++ b/test/data/puppet/katello-answers-with-puppet.yaml
@@ -1,0 +1,18 @@
+# katello-answers-with-puppet.yaml
+# scenario: katello
+# This is where a user enabled puppet
+---
+foreman: {}
+foreman::cli: true
+foreman::cli::puppet: true
+foreman::plugin::puppet: true
+foreman_proxy:
+  puppet: true
+  puppetca: true
+foreman_proxy_content:
+  puppet: true
+puppet:
+  server: true
+  puppet_server_foreman_ssl_ca: /etc/pki/katello/puppet/puppet_client_ca.crt
+  puppet_server_foreman_ssl_cert: /etc/pki/katello/puppet/puppet_client.crt
+  puppet_server_foreman_ssl_key: /etc/pki/katello/puppet/puppet_client.key

--- a/test/definitions/procedures/puppet/remove_puppet_test.rb
+++ b/test/definitions/procedures/puppet/remove_puppet_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+
+describe Procedures::Puppet::RemovePuppet do
+  include DefinitionsTestHelper
+
+  subject do
+    Procedures::Puppet::RemovePuppet.new
+  end
+
+  before do
+    mock_installer_package('foreman-installer')
+  end
+
+  describe '#installer_arguments_disabling_puppet' do
+    it 'works for foreman default' do
+      stub_installer_answers('foreman-answers-default.yaml')
+      expected_arguments = [
+        '--no-enable-foreman-cli-puppet',
+        '--no-enable-foreman-plugin-puppet',
+        '--foreman-proxy-puppet false',
+        '--foreman-proxy-puppetca false',
+        '--no-enable-puppet'
+      ]
+      _(subject.send(:installer_arguments_disabling_puppet).sort).must_equal expected_arguments.sort
+    end
+
+    it 'works for proxy with puppet' do
+      stub_installer_answers('foreman-answers-no-foreman-with-puppet.yaml')
+      expected_arguments = [
+        '--foreman-proxy-puppet false',
+        '--foreman-proxy-puppetca false',
+        '--no-enable-puppet'
+      ]
+      _(subject.send(:installer_arguments_disabling_puppet).sort).must_equal expected_arguments.sort
+    end
+
+    it 'works for katello' do
+      stub_installer_answers('katello-answers-with-puppet.yaml')
+      expected_arguments = [
+        '--no-enable-foreman-cli-puppet',
+        '--no-enable-foreman-plugin-puppet',
+        '--foreman-proxy-puppet false',
+        '--foreman-proxy-puppetca false',
+        '--foreman-proxy-content-puppet false',
+        '--no-enable-puppet'
+      ]
+      _(subject.send(:installer_arguments_disabling_puppet).sort).must_equal expected_arguments.sort
+    end
+
+    it 'works for proxy-content' do
+      stub_installer_answers('foreman-proxy-content-with-puppet.yaml')
+      expected_arguments = [
+        '--foreman-proxy-puppet false',
+        '--foreman-proxy-puppetca false',
+        '--foreman-proxy-content-puppet false',
+        '--no-enable-puppet'
+      ]
+      _(subject.send(:installer_arguments_disabling_puppet).sort).must_equal expected_arguments.sort
+    end
+  end
+
+  def stub_installer_answers(filename)
+    file = "test/data/puppet/#{filename}"
+    assume_feature_present(:installer, configuration: { answer_file: file })
+  end
+end

--- a/test/lib/cli/plugin_command_test.rb
+++ b/test/lib/cli/plugin_command_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+require 'foreman_maintain/cli'
+
+module ForemanMaintain
+  describe Cli::PluginCommand do
+    include CliAssertions
+    let :command do
+      %w[plugin]
+    end
+
+    it 'prints help' do
+      assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
+        Usage:
+            foreman-maintain plugin [OPTIONS] SUBCOMMAND [ARG] ...
+
+        Parameters:
+            SUBCOMMAND                    subcommand
+            [ARG] ...                     subcommand arguments
+
+        Subcommands:
+            purge-puppet                Remove the Puppet feature
+
+        Options:
+            -h, --help                    print help
+      OUTPUT
+    end
+
+    describe 'disable-puppet' do
+      let :command do
+        %w[plugin purge-puppet]
+      end
+
+      it 'runs purge-puppet' do
+        Cli::PluginCommand.any_instance.expects(:run_scenario).with do |scenario|
+          _(scenario.context.get(:remove_data)).must_equal nil
+          _(scenario.label).must_equal :puppet_disable
+        end
+        run_cmd
+      end
+
+      it 'passes remove_data flag' do
+        Cli::PluginCommand.any_instance.expects(:run_scenario).with do |scenario|
+          _(scenario.context.get(:remove_data)).must_equal true
+          _(scenario.label).must_equal :puppet_disable
+        end
+        run_cmd(['--remove-all-data'])
+      end
+    end
+  end
+end

--- a/test/lib/cli_test.rb
+++ b/test/lib/cli_test.rb
@@ -28,6 +28,7 @@ module ForemanMaintain
             packages                      Lock/Unlock package protection, install, update
             advanced                      Advanced tools for server maintenance
             content                       Content related commands
+            plugin                        Manage optional plugins on your server
             maintenance-mode              Control maintenance-mode for application
 
         Options:

--- a/test/lib/support/definitions/checks/check_puppet_capsules.rb
+++ b/test/lib/support/definitions/checks/check_puppet_capsules.rb
@@ -1,0 +1,12 @@
+module Checks
+  class CheckPuppetCapsules < ForemanMaintain::Check
+    metadata do
+      label :puppet_capsules
+      for_feature :foreman_database
+      description 'Check for Puppet capsules from the database'
+      manual_detection
+    end
+
+    def run; end
+  end
+end

--- a/test/lib/support/definitions/scenarios/puppet.rb
+++ b/test/lib/support/definitions/scenarios/puppet.rb
@@ -1,0 +1,15 @@
+module Scenarios::Puppet
+  class RemovePuppet < ForemanMaintain::Scenario
+    metadata do
+      description 'Remove Puppet feature'
+      tags :puppet_disable
+      label :puppet_disable
+      param :remove_data, 'Purge the Puppet data after disabling plugin'
+      manual_detection
+    end
+
+    def compose
+      add_steps([Checks::Dummy::Success])
+    end
+  end
+end


### PR DESCRIPTION
Adds command to disable Puppet plugin and remove all the Puppet data.
Adds also command to re-enable Puppet.