### PR TITLE
Fixes #33908 - use pulpcore-manager instead of django-admin

### DIFF
--- a/definitions/procedures/pulpcore/migrate.rb
+++ b/definitions/procedures/pulpcore/migrate.rb
@@ -18,7 +18,7 @@ module Procedures::Pulpcore
         spinner.update('Migrating pulpcore database')
         execute!('sudo PULP_SETTINGS=/etc/pulp/settings.py '\
           'DJANGO_SETTINGS_MODULE=pulpcore.app.settings '\
-          'python3-django-admin migrate --noinput')
+          'pulpcore-manager migrate --noinput')
       end
     end
   end


### PR DESCRIPTION
the pulpcore-manager name is guaranteed to be stable, while the django one is not