### PR TITLE
drop tomcat6 service name

### DIFF
--- a/definitions/features/candlepin.rb
+++ b/definitions/features/candlepin.rb
@@ -13,8 +13,7 @@ class Features::Candlepin < ForemanMaintain::Feature
 
   def services
     [
-      system_service('tomcat', 20),
-      system_service('tomcat6', 20)
+      system_service('tomcat', 20)
     ]
   end
 end


### PR DESCRIPTION
this is EL6 and we don't support EL6 anymore