### PR TITLE
Fixes #34100 - don't fail on new token duration setting

### DIFF
--- a/definitions/checks/foreman_proxy/check_tftp_storage.rb
+++ b/definitions/checks/foreman_proxy/check_tftp_storage.rb
@@ -44,7 +44,9 @@ module Checks::ForemanProxy
     def self.lookup_token_duration
       data = feature(:foreman_database). \
              query("select s.value, s.default from settings s \
-                    where category = 'Setting::Provisioning' and name = 'token_duration'")
+                    where category IN ('Setting::Provisioning','Setting') \
+                    and name = 'token_duration'")
+
       YAML.load(data[0]['value'] || data[0]['default'])
     end
   end


### PR DESCRIPTION
in [#33601](https://projects.theforeman.org/issues/33601) Foreman changed the category of the token_duration setting
from Setting::Provisioning to Setting, breaking our query