### PR TITLE
Fixes #34045 - adds a restart step after removing pulp2

### DIFF
--- a/definitions/procedures/pulp/remove.rb
+++ b/definitions/procedures/pulp/remove.rb
@@ -86,6 +86,8 @@ module Procedures::Pulp
       drop_migrations
 
       delete_pulp_data(rm_cmds) if rm_cmds.any?
+
+      restart_pulpcore_services
     end
 
     def remove_pulp
@@ -166,6 +168,16 @@ module Procedures::Pulp
           execute!(cmd)
         end
         spinner.update('Done deleting pulp2 data directories')
+      end
+    end
+
+    def restart_pulpcore_services
+      with_spinner('Restarting pulpcore services') do |spinner|
+        pulp_services = feature(:pulpcore).services
+
+        feature(:service).handle_services(spinner, 'stop', :only => pulp_services)
+        feature(:service).handle_services(spinner, 'start', :only => pulp_services)
+        spinner.update('Done restarting pulpcore services')
       end
     end
   end


### PR DESCRIPTION
After the removal of pulp2 items, restart pulpcore services. Without this step, users were often surprised by syncs that failed post -migration and pulp2 removal.