### PR TITLE
Fixes #34231 - Fix to check pulp group ownership to "/var/lib/pulp/content"

### DIFF
--- a/definitions/checks/pulpcore/group_ownership_check.rb
+++ b/definitions/checks/pulpcore/group_ownership_check.rb
@@ -2,13 +2,13 @@ module Checks
   module Pulpcore
     class GroupOwnershipCheck < ForemanMaintain::Check
       metadata do
-        description 'Check the group owner of /var/lib/pulp directory'
+        description 'Check the group owner of /var/lib/pulp/content directory'
         label :group_ownership_check_of_pulp_content
         manual_detection
       end
 
       def run
-        group_id = File.stat('/var/lib/pulp/').gid
+        group_id = File.stat('/var/lib/pulp/content/').gid
         if Etc.getgrgid(group_id).name != 'pulp'
           fail! "Please run 'foreman-maintain prep-6.10-upgrade' prior to upgrading."
         end


### PR DESCRIPTION
During upgrade check we are checking group ownership of "/var/lib/pulp" (pulp2 dir)
And, during "foreman-maintain prep-6.10-upgrade" we are checking group ownership "/var/lib/pulp/content" (pulp3) dir

Added a small fix pointing to correct "/var/lib/pulp/content" directory
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2037648