### PR TITLE
Fixes #34393 - use repoquery format that works on EL7 and EL8

### DIFF
--- a/definitions/checks/check_hotfix_installed.rb
+++ b/definitions/checks/check_hotfix_installed.rb
@@ -46,9 +46,11 @@ class Checks::CheckHotfixInstalled < ForemanMaintain::Check
   def installed_packages
     packages = []
     repoquery_cmd = execute!('which repoquery')
-    IO.popen([repoquery_cmd, '-a', '--installed', '--qf', '%{ui_from_repo} %{nvra}']) do |io|
+    query_format = '%{ui_from_repo} %{name}-%{evr}.%{arch}'
+    IO.popen([repoquery_cmd, '-a', '--installed', '--qf', query_format]) do |io|
       io.each do |line|
         repo, pkg = line.chomp.split
+        next if repo.nil? || pkg.nil?
         packages << pkg if /satellite|rhscl/ =~ repo[1..-1].downcase
       end
     end


### PR DESCRIPTION
On EL8 repoquery doesn't understand the `nvra` format, leading to the
following error:

    Error: 'Package' object has no attribute 'nvra'

And thus no data reported from that query.
Let's use `%{name}-%{evr}.%{arch}` instead, which is understood by
repoquery on EL7 and EL8.