### PR TITLE
Fixes #34403 - simplify hotfix check

### DIFF
--- a/definitions/checks/check_hotfix_installed.rb
+++ b/definitions/checks/check_hotfix_installed.rb
@@ -45,13 +45,12 @@ class Checks::CheckHotfixInstalled < ForemanMaintain::Check
 
   def installed_packages
     packages = []
-    repoquery_cmd = execute!('which repoquery')
     query_format = '%{ui_from_repo} %{name}-%{evr}.%{arch}'
-    IO.popen([repoquery_cmd, '-a', '--installed', '--qf', query_format]) do |io|
+    IO.popen(['repoquery', '-a', '--installed', '--qf', query_format]) do |io|
       io.each do |line|
         repo, pkg = line.chomp.split
         next if repo.nil? || pkg.nil?
-        packages << pkg if /satellite|rhscl/ =~ repo[1..-1].downcase
+        packages << pkg if /satellite|rhscl/ =~ repo.downcase
       end
     end
     packages


### PR DESCRIPTION
drop the "which" call, just use repoquery
don't remove the first character of the repo name