### PR TITLE
Fixes #34438 - don't try to find services for `nil`

### DIFF
--- a/definitions/features/instance.rb
+++ b/definitions/features/instance.rb
@@ -142,11 +142,15 @@ class Features::Instance < ForemanMaintain::Feature
   def component_features_map
     {
       'candlepin_auth' => %w[candlepin candlepin_database],
+      'candlepin_events' => %w[candlepin candlepin_database],
       'candlepin' => %w[candlepin candlepin_database],
       'pulp_auth' => %w[pulp2 mongo],
       'pulp' => %w[pulp2 mongo],
       'pulp3' => %w[pulpcore pulpcore_database],
-      'foreman_tasks' => %w[foreman_tasks]
+      'pulp3_content' => %w[pulpcore pulpcore_database],
+      'foreman_tasks' => %w[foreman_tasks],
+      'katello_agent' => %w[katello],
+      'katello_events' => %w[katello]
     }
   end
 
@@ -154,7 +158,7 @@ class Features::Instance < ForemanMaintain::Feature
     components = Array(components)
     cf_map = component_features_map
     # map ping components to features
-    features = components.map { |component| cf_map[component] }.flatten.uniq
+    features = components.map { |component| cf_map[component] }.flatten.uniq.compact
     # map features to existing services
     services_of_features = features.map do |name|
       feature(name.to_sym) ? feature(name.to_sym).services : []

--- a/test/definitions/features/instance_test.rb
+++ b/test/definitions/features/instance_test.rb
@@ -242,4 +242,35 @@ describe Features::Instance do
       end
     end
   end
+
+  describe '.component_services' do
+    let(:existing_pulpcore_api) { existing_system_service('pulpcore-api', 10) }
+    let(:existing_postgresql) { existing_system_service('postgresql', 10) }
+    let(:existing_qpidd) { existing_system_service('qpidd', 10) }
+    let(:existing_qdrouterd) { existing_system_service('qdrouterd', 10) }
+
+    it 'succeed with unknown service' do
+      subject.send(:component_services, ['unknown']).must_equal []
+    end
+
+    it 'succeed with pulp3' do
+      assume_feature_present(:pulpcore) do |feature_class|
+        feature_class.any_instance.stubs(:services).returns(existing_pulpcore_api)
+      end
+      assume_feature_present(:pulpcore_database) do |feature_class|
+        feature_class.any_instance.stubs(:services).returns(existing_postgresql)
+      end
+
+      subject.send(:component_services, ['pulp3']).
+        must_equal [existing_pulpcore_api, existing_postgresql]
+    end
+    it 'succeed with katello_agent' do
+      assume_feature_present(:katello) do |feature_class|
+        feature_class.any_instance.stubs(:services).returns([existing_qpidd, existing_qdrouterd])
+      end
+
+      subject.send(:component_services, ['katello_agent']).
+        must_equal [existing_qpidd, existing_qdrouterd]
+    end
+  end
 end


### PR DESCRIPTION
when there is no mapping from a component to a feature,
`component_features_map[component]` will return `nil` and `nil.to_sym`
ends badly.

ideally, each component would be present in the map, but this makes the
code more robust