### PR TITLE
Fixes #34463 - remove pulp2 automatically on upgrade to 7.0

### DIFF
--- a/definitions/scenarios/upgrade_to_satellite_7_0.rb
+++ b/definitions/scenarios/upgrade_to_satellite_7_0.rb
@@ -41,6 +41,7 @@ module Scenarios::Satellite_7_0
 
     def compose
       add_steps(find_procedures(:pre_migrations))
+      add_step(Procedures::Pulp::Remove.new(:assumeyes => true))
       add_step(Procedures::Service::Stop.new)
     end
   end


### PR DESCRIPTION
Adds a step to remove Pulp 2 during the 7.0 upgrade.  The Pulp 2 removal code has its own logic for ensuring that only the right commands get run, so I didn't put a check here for whether or not to run it.  I tested upgrading to 7.0 after running the `remove-pulp2` command, and it worked fine.

To test:

1) Patch in this PR.
1) Upgrade from Satellite 6.9 to 6.10.
1) Save a snapshot of your VM.
1) Upgrade to 7.0 and ensure Pulp is still okay.
1) Revert the snapshot.
1) Run `bin/foreman-maintain content remove-pulp2 --assumeyes`.
1) Upgrade to 7.0 and ensure Pulp is still okay once again.