### PR TITLE
Refs #34463 - remove pulp2 automatically on capsule upgrade to 7.0

### DIFF
--- a/definitions/scenarios/upgrade_to_capsule_7_0.rb
+++ b/definitions/scenarios/upgrade_to_capsule_7_0.rb
@@ -39,6 +39,7 @@ module Scenarios::Capsule_7_0
 
     def compose
       add_steps(find_procedures(:pre_migrations))
+      add_step(Procedures::Pulp::Remove.new(:assumeyes => true))
       add_step(Procedures::Service::Stop.new)
     end
   end


### PR DESCRIPTION
Runs the Pulp 2 removal code when upgrading a capsule to 7.0.

To test, upgrade a capsule from 6.9 up to 7.0 and check that Pulp 2 was indeed removed.
Also test that upgrading a 6.10 capsule without Pulp 2 to 7.0 still works fine.