### PR TITLE
Fixes #34631 - add command & procedure to update pulpcore artifact ownership

### DIFF
--- a/definitions/procedures/content/fix_pulpcore_artifact_permissions.rb
+++ b/definitions/procedures/content/fix_pulpcore_artifact_permissions.rb
@@ -1,0 +1,30 @@
+module Procedures::Content
+  class FixPulpcoreArtifactOwnership < ForemanMaintain::Procedure
+    metadata do
+      description 'Fix Pulpcore artifact ownership to be pulp:pulp'
+      param :assumeyes, 'Do not ask for confirmation', :default => false
+
+      confine do
+        check_min_version(foreman_plugin_name('katello'), '4.0')
+      end
+    end
+
+    def ask_to_proceed
+      question = "\nWARNING: Only proceed if your system is fully switched to Pulp 3.\n"
+      question += "\n\nDo you want to proceed?"
+      answer = ask_decision(question, actions_msg: 'y(yes), q(quit)')
+      abort! if answer != :yes
+    end
+
+    def run
+      assumeyes_val = @assumeyes.nil? ? assumeyes? : @assumeyes
+
+      ask_to_proceed unless assumeyes_val
+
+      with_spinner('Updating artifact ownership for Pulp 3') do |spinner|
+        spinner.update('# chown -hR pulp.pulp /var/lib/pulp/media/artifact')
+        FileUtils.chown_R 'pulp', 'pulp', '/var/lib/pulp/media/artifact'
+      end
+    end
+  end
+end

--- a/definitions/scenarios/content.rb
+++ b/definitions/scenarios/content.rb
@@ -129,10 +129,29 @@ module ForemanMaintain::Scenarios
 
       def set_context_mapping
         context.map(:assumeyes, Procedures::Pulp::Remove => :assumeyes)
+        context.map(:assumeyes, Procedures::Content::FixPulpcoreArtifactOwnership => :assumeyes)
       end
 
       def compose
         add_step_with_context(Procedures::Pulp::Remove)
+        add_step_with_context(Procedures::Content::FixPulpcoreArtifactOwnership)
+      end
+    end
+
+    class FixPulpcoreArtifactOwnership < ContentBase
+      metadata do
+        label :content_fix_pulpcore_artifact_ownership
+        description 'Fix Pulpcore artifact ownership to be pulp:pulp'
+        param :assumeyes, 'Do not ask for confirmation'
+        manual_detection
+      end
+
+      def set_context_mapping
+        context.map(:assumeyes, Procedures::Content::FixPulpcoreArtifactOwnership => :assumeyes)
+      end
+
+      def compose
+        add_step_with_context(Procedures::Content::FixPulpcoreArtifactOwnership)
       end
     end
   end

--- a/lib/foreman_maintain/cli/content_command.rb
+++ b/lib/foreman_maintain/cli/content_command.rb
@@ -54,6 +54,16 @@ module ForemanMaintain
           )
         end
       end
+
+      subcommand 'fix-pulpcore-artifact-ownership',
+                 'Update filesystem ownership for Pulpcore artifacts' do
+        interactive_option(%w[assumeyes plaintext])
+        def execute
+          run_scenarios_and_exit(
+            Scenarios::Content::FixPulpcoreArtifactOwnership.new(:assumeyes => assumeyes?)
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds a command to fix the pulpcore artifact ownership.  When it's apache:pulp, there are sync errors. It's likely that users have artifacts with these permissions due to old Pulp 2 to Pulp 3 migration bugs.

This new procedure also automatically runs when the user removes Pulp 2.

To test:

1) `chown -hR apache.pulp /var/lib/pulp/media/artifact` on any Katello machine running Pulp 3.
2) Run `foreman-maintain content fix-pulpcore-artifact-ownership`.
3) Check that the files under `/var/lib/pulp/media/artifact` are all owned by the pulp user.
4) Set up a Satellite 6.10 or Katello 4.x machine that still has Pulp 2.
5) Run the Pulp 2 removal procedure and see that the artifact ownership procedure is also run.