### PR TITLE
Refs #33620 - limit target version upto N+1

### DIFF
--- a/definitions/scenarios/self_upgrade.rb
+++ b/definitions/scenarios/self_upgrade.rb
@@ -13,7 +13,8 @@ module ForemanMaintain::Scenarios
     end
 
     def target_version
-      @target_version ||= context.get(:target_version)
+      current_full_version = feature(:instance).downstream.current_version
+      @target_version ||= current_full_version.bump
     end
 
     def current_version

--- a/lib/foreman_maintain/cli/self_upgrade_command.rb
+++ b/lib/foreman_maintain/cli/self_upgrade_command.rb
@@ -1,44 +1,29 @@
 module ForemanMaintain
   module Cli
     class SelfUpgradeCommand < Base
-      option ['--target-version'], 'TARGET_VERSION',\
-             'Major version of the Satellite or Capsule'\
-             ', e.g 6.11', :required => true
       option ['--maintenance-repo-label'], 'REPOSITORY_LABEL',\
              'Repository label from which packages should be updated.'\
              'This can be used when standard CDN repositories are unavailable.'
-
       def execute
-        allow_major_version_upgrade_only
         run_scenario(upgrade_scenario, upgrade_rescue_scenario)
       end
 
       def upgrade_scenario
-        Scenarios::SelfUpgrade.new(target_version: target_version,
-                                   maintenance_repo_label: maintenance_repo_label)
+        Scenarios::SelfUpgrade.new(target_version: allowed_next_version.to_s,
+          maintenance_repo_label: maintenance_repo_label)
       end
 
       def upgrade_rescue_scenario
-        Scenarios::SelfUpgradeRescue.new(target_version: target_version,
-                                         maintenance_repo_label: maintenance_repo_label)
+        Scenarios::SelfUpgradeRescue.new(target_version: allowed_next_version.to_s,
+          maintenance_repo_label: maintenance_repo_label)
       end
 
       def current_downstream_version
         ForemanMaintain.detector.feature(:instance).downstream.current_version
       end
 
-      def allow_major_version_upgrade_only
-        begin
-          next_version = Gem::Version.new(target_version)
-        rescue ArgumentError => err
-          raise Error::UsageError, "Invalid version! #{err}"
-        end
-        if current_downstream_version >= next_version
-          message = "The target-version #{target_version} should be "\
-                    "greater than existing version #{current_downstream_version},"\
-                    "\nand self-upgrade should be used for major version upgrades only!"
-          raise Error::UsageError, message
-        end
+      def allowed_next_version
+        current_downstream_version.bump
       end
     end
   end

--- a/lib/foreman_maintain/cli/self_upgrade_command.rb
+++ b/lib/foreman_maintain/cli/self_upgrade_command.rb
@@ -9,21 +9,15 @@ module ForemanMaintain
       end
 
       def upgrade_scenario
-        Scenarios::SelfUpgrade.new(target_version: allowed_next_version.to_s,
-          maintenance_repo_label: maintenance_repo_label)
+        Scenarios::SelfUpgrade.new(
+          maintenance_repo_label: maintenance_repo_label
+        )
       end
 
       def upgrade_rescue_scenario
-        Scenarios::SelfUpgradeRescue.new(target_version: allowed_next_version.to_s,
-          maintenance_repo_label: maintenance_repo_label)
-      end
-
-      def current_downstream_version
-        ForemanMaintain.detector.feature(:instance).downstream.current_version
-      end
-
-      def allowed_next_version
-        current_downstream_version.bump
+        Scenarios::SelfUpgradeRescue.new(
+          maintenance_repo_label: maintenance_repo_label
+        )
       end
     end
   end


### PR DESCRIPTION
This makes,
1. The target-version optional, actually I think if we agree on this then we don't require target-version at all.
2. Validates if target version is only N+1 where N is the current installed version.