### PR TITLE
Fixes #34821 - allow restoring miss-matched candlepin versions

### DIFF
--- a/definitions/procedures/restore/candlepin_reset_migrations.rb
+++ b/definitions/procedures/restore/candlepin_reset_migrations.rb
@@ -1,0 +1,14 @@
+module Procedures::Restore
+  class CandlepinResetMigrations < ForemanMaintain::Procedure
+    metadata do
+      description 'Ensure Candlepin runs all migrations after restoring the database'
+      confine do
+        feature(:candlepin_database)
+      end
+    end
+
+    def run
+      FileUtils.rm_f('/var/lib/candlepin/.puppet-candlepin-rpm-version')
+    end
+  end
+end

--- a/definitions/scenarios/restore.rb
+++ b/definitions/scenarios/restore.rb
@@ -46,7 +46,8 @@ module ForemanMaintain::Scenarios
       end
       restore_mongo_dump(backup)
       add_steps_with_context(Procedures::Pulp::Migrate,
-                             Procedures::Pulpcore::Migrate)
+                             Procedures::Pulpcore::Migrate,
+                             Procedures::Restore::CandlepinResetMigrations)
 
       add_steps_with_context(Procedures::Restore::RegenerateQueues) if backup.online_backup?
       add_steps_with_context(Procedures::Service::Start,


### PR DESCRIPTION
force DB migrations to run on restore