### PR TITLE
Fixes #34854 - disable custom repo if it was not enabled

### DIFF
--- a/definitions/scenarios/self_upgrade.rb
+++ b/definitions/scenarios/self_upgrade.rb
@@ -67,7 +67,10 @@ module ForemanMaintain::Scenarios
 
     def repos_ids_to_reenable
       repos_ids_to_reenable = stored_enabled_repos_ids - all_maintenance_repos
-      repos_ids_to_reenable << maintenance_repo(maintenance_repo_version)
+      if use_rhsm?
+        repos_ids_to_reenable << maintenance_repo(maintenance_repo_version)
+      end
+      repos_ids_to_reenable
     end
 
     def use_rhsm?
@@ -97,6 +100,7 @@ module ForemanMaintain::Scenarios
         add_step(Procedures::Repositories::Enable.new(repos: [maintenance_repo_id(target_version)],
                                                       use_rhsm: use_rhsm?))
         add_step(Procedures::Packages::Update.new(packages: pkgs_to_update, assumeyes: true))
+        disable_repos('*')
         enable_repos(repos_ids_to_reenable)
       end
     end
@@ -113,6 +117,7 @@ module ForemanMaintain::Scenarios
 
     def compose
       if check_min_version('foreman', '2.5') || check_min_version('foreman-proxy', '2.5')
+        disable_repos('*')
         enable_repos(repos_ids_to_reenable)
       end
     end

--- a/test/definitions/scenarios/self_upgrade_test.rb
+++ b/test/definitions/scenarios/self_upgrade_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+module Scenarios
+  describe ForemanMaintain::Scenarios::SelfUpgrade do
+    include DefinitionsTestHelper
+
+    let(:scenario) do
+      ForemanMaintain::Scenarios::SelfUpgrade.new
+    end
+
+    describe 'using CDN' do
+      it 'reenables maintenance repo' do
+        scenario.stubs(:stored_enabled_repos_ids).returns([])
+        scenario.stubs(:current_version).returns('6.10')
+        scenario.stubs(:el_major_version).returns(7)
+        assert_equal ['rhel-7-server-satellite-maintenance-6-rpms'], scenario.repos_ids_to_reenable
+      end
+    end
+
+    describe 'using custom repos' do
+      it 'does not reenable maintenance repo if it was disabled' do
+        scenario.stubs(:stored_enabled_repos_ids).returns([])
+        scenario.stubs(:current_version).returns('6.10')
+        scenario.stubs(:el_major_version).returns(7)
+        scenario.stubs(:maintenance_repo_label).returns('custom-maintenance')
+        assert_equal [], scenario.repos_ids_to_reenable
+      end
+
+      it 'reenables maintenance repo if it was enabled' do
+        scenario.stubs(:stored_enabled_repos_ids).returns(['custom-maintenance'])
+        scenario.stubs(:current_version).returns('6.10')
+        scenario.stubs(:el_major_version).returns(7)
+        scenario.stubs(:maintenance_repo_label).returns('custom-maintenance')
+        assert_equal ['custom-maintenance'], scenario.repos_ids_to_reenable
+      end
+    end
+  end
+end


### PR DESCRIPTION
With this change if custom repositoryl is provided using --maintenance-repo-label
or env variable --MAINTENANCE_REPO_LABEL is exported then
foreman-maintain keeps that custom repo enabled if system had it enabled.
If custom repository was not enabled on system and still provided either via option or
env var then custom repo will be disabled.