### PR TITLE
Fixes #34874: foreman_cache_data should be a config file for backups …

### DIFF
--- a/definitions/features/foreman_server.rb
+++ b/definitions/features/foreman_server.rb
@@ -34,7 +34,8 @@ module ForemanMaintain
           '/etc/selinux/targeted/contexts/files/file_contexts.subs',
           '/etc/sysconfig/foreman',
           '/usr/share/ruby/vendor_ruby/puppet/reports/foreman.rb',
-          '/var/lib/foreman'
+          '/var/lib/foreman',
+          '/opt/puppetlabs/puppet/cache/foreman_cache_data'
         ]
       end
 

--- a/definitions/features/puppet_server.rb
+++ b/definitions/features/puppet_server.rb
@@ -11,8 +11,6 @@ class Features::PuppetServer < ForemanMaintain::Feature
     [
       '/etc/puppet',
       '/etc/puppetlabs',
-      '/opt/puppetlabs/puppet/cache/foreman_cache_data',
-      '/var/lib/puppet/foreman_cache_data',
       '/opt/puppetlabs/puppet/ssl/',
       '/var/lib/puppet/ssl',
       '/var/lib/puppet',


### PR DESCRIPTION
…always

The foreman_cache_data directory contains a number of important secrets
that need to be present in a backup. This was listed as part of the Puppet Server
feature rather than Foreman server which means when we disabled Puppet
by default this path was being omitted.