### PR TITLE
Refs #34874: Include pulpcore_cache_data for installer in config_files

### DIFF
--- a/definitions/features/foreman_server.rb
+++ b/definitions/features/foreman_server.rb
@@ -34,8 +34,7 @@ module ForemanMaintain
           '/etc/selinux/targeted/contexts/files/file_contexts.subs',
           '/etc/sysconfig/foreman',
           '/usr/share/ruby/vendor_ruby/puppet/reports/foreman.rb',
-          '/var/lib/foreman',
-          '/opt/puppetlabs/puppet/cache/foreman_cache_data'
+          '/var/lib/foreman'
         ]
       end
 

--- a/definitions/features/installer.rb
+++ b/definitions/features/installer.rb
@@ -65,6 +65,7 @@ class Features::Installer < ForemanMaintain::Feature
     Dir.glob(File.join(config_directory, '**/*')) +
       [
         '/usr/local/bin/validate_postgresql_connection.sh',
+        '/opt/puppetlabs/puppet/cache/foreman_cache_data',
         '/opt/puppetlabs/puppet/cache/pulpcore_cache_data'
       ]
   end

--- a/definitions/features/installer.rb
+++ b/definitions/features/installer.rb
@@ -64,7 +64,8 @@ class Features::Installer < ForemanMaintain::Feature
   def config_files
     Dir.glob(File.join(config_directory, '**/*')) +
       [
-        '/usr/local/bin/validate_postgresql_connection.sh'
+        '/usr/local/bin/validate_postgresql_connection.sh',
+        '/opt/puppetlabs/puppet/cache/pulpcore_cache_data'
       ]
   end
 

--- a/test/definitions/features/installer_test.rb
+++ b/test/definitions/features/installer_test.rb
@@ -22,6 +22,7 @@ describe Features::Installer do
         "#{data_dir}/installer/simple_config/scenarios.d/foreman.yaml",
         "#{data_dir}/installer/simple_config/scenarios.d/last_scenario.yaml",
         '/usr/local/bin/validate_postgresql_connection.sh',
+        '/opt/puppetlabs/puppet/cache/foreman_cache_data',
         '/opt/puppetlabs/puppet/cache/pulpcore_cache_data'
       ].sort
       subject.config_files.sort.must_equal(expected_config_files)

--- a/test/definitions/features/installer_test.rb
+++ b/test/definitions/features/installer_test.rb
@@ -21,7 +21,8 @@ describe Features::Installer do
         "#{data_dir}/installer/simple_config/scenarios.d/foreman-answers.yaml",
         "#{data_dir}/installer/simple_config/scenarios.d/foreman.yaml",
         "#{data_dir}/installer/simple_config/scenarios.d/last_scenario.yaml",
-        '/usr/local/bin/validate_postgresql_connection.sh'
+        '/usr/local/bin/validate_postgresql_connection.sh',
+        '/opt/puppetlabs/puppet/cache/pulpcore_cache_data'
       ].sort
       subject.config_files.sort.must_equal(expected_config_files)
     end


### PR DESCRIPTION
I could see an argument for putting this in the Katello feature as well.