### PR TITLE
Fixes #35058 - upgrade scenario for Foreman and Katello nightly

### DIFF
--- a/definitions/features/capsule.rb
+++ b/definitions/features/capsule.rb
@@ -1,5 +1,6 @@
 class Features::Capsule < ForemanMaintain::Feature
   include ForemanMaintain::Concerns::Downstream
+  include ForemanMaintain::Concerns::Versions
 
   metadata do
     label :capsule

--- a/definitions/features/foreman_1_11_x.rb
+++ b/definitions/features/foreman_1_11_x.rb
@@ -1,9 +1,0 @@
-require 'features/foreman_1_7_x'
-
-class Features::Foreman_1_11_x < Features::Foreman_1_7_x
-  metadata do
-    confine do
-      check_min_version('foreman', '1.11')
-    end
-  end
-end

--- a/definitions/features/foreman_1_7_x.rb
+++ b/definitions/features/foreman_1_7_x.rb
@@ -1,9 +1,0 @@
-class Features::Foreman_1_7_x < ForemanMaintain::Feature
-  metadata do
-    label :foreman
-
-    confine do
-      check_min_version('foreman', '1.7')
-    end
-  end
-end

--- a/definitions/features/foreman_install.rb
+++ b/definitions/features/foreman_install.rb
@@ -1,0 +1,12 @@
+class Features::ForemanInstall < ForemanMaintain::Feature
+  include ForemanMaintain::Concerns::Upstream
+  include ForemanMaintain::Concerns::Versions
+
+  metadata do
+    label :foreman_install
+
+    confine do
+      !feature(:instance).downstream && !feature(:katello) && feature(:foreman_server)
+    end
+  end
+end

--- a/definitions/features/foreman_server.rb
+++ b/definitions/features/foreman_server.rb
@@ -1,6 +1,7 @@
 module ForemanMaintain
   module Features
     class ForemanServer < ForemanMaintain::Feature
+      include ForemanMaintain::Concerns::Versions
       metadata do
         label :foreman_server
         confine do
@@ -46,6 +47,10 @@ module ForemanMaintain
 
       def services_running?
         services.all?(&:running?)
+      end
+
+      def current_version
+        @current_version ||= package_version('foreman')
       end
     end
   end

--- a/definitions/features/installer.rb
+++ b/definitions/features/installer.rb
@@ -92,9 +92,16 @@ class Features::Installer < ForemanMaintain::Feature
   end
 
   def run(arguments = '', exec_options = {})
-    out = execute!("LANG=en_US.utf-8 #{installer_command} #{arguments}".strip, exec_options)
+    out = execute!("#{installer_command} #{arguments}".strip, exec_options)
     @configuration = nil
     out
+  end
+
+  def run_with_status(arguments = '', exec_options = {})
+    cmd_with_arguments = "#{installer_command} #{arguments}".strip
+    cmd_status, out = execute_with_status(cmd_with_arguments, exec_options)
+    @configuration = nil
+    [cmd_status, out]
   end
 
   def upgrade(exec_options = {})
@@ -105,13 +112,15 @@ class Features::Installer < ForemanMaintain::Feature
     installer_args = ''
 
     if feature(:foreman_proxy) &&
-       feature(:foreman_proxy).with_content?
+       feature(:foreman_proxy).with_content? &&
+       check_max_version('foreman-installer', '3.4')
       installer_args += ' --disable-system-checks'
     end
 
-    unless check_min_version('foreman', '2.1') || check_min_version('foreman-proxy', '2.1')
+    unless check_min_version('foreman-installer', '2.1')
       installer_args += ' --upgrade' if can_upgrade?
     end
+
     installer_args
   end
 

--- a/definitions/features/instance.rb
+++ b/definitions/features/instance.rb
@@ -60,8 +60,13 @@ class Features::Instance < ForemanMaintain::Feature
     end
   end
 
+  def foreman_server_ssl_ca
+    @foreman_server_ssl_ca ||= feature(:installer).answers['foreman']['server_ssl_ca']
+  end
+
   def server_connection
     net = Net::HTTP.new(ForemanMaintain.config.foreman_url, ForemanMaintain.config.foreman_port)
+    net.ca_file = foreman_server_ssl_ca
     net.use_ssl = true
     net
   end

--- a/definitions/features/katello.rb
+++ b/definitions/features/katello.rb
@@ -1,4 +1,6 @@
 class Features::Katello < ForemanMaintain::Feature
+  include ForemanMaintain::Concerns::Versions
+
   metadata do
     label :katello
 

--- a/definitions/features/katello_install.rb
+++ b/definitions/features/katello_install.rb
@@ -1,0 +1,12 @@
+class Features::KatelloInstall < ForemanMaintain::Feature
+  include ForemanMaintain::Concerns::Upstream
+  include ForemanMaintain::Concerns::Versions
+
+  metadata do
+    label :katello_install
+
+    confine do
+      !feature(:instance).downstream && feature(:katello)
+    end
+  end
+end

--- a/definitions/features/satellite.rb
+++ b/definitions/features/satellite.rb
@@ -1,5 +1,6 @@
 class Features::Satellite < ForemanMaintain::Feature
   include ForemanMaintain::Concerns::Downstream
+  include ForemanMaintain::Concerns::Versions
 
   metadata do
     label :satellite

--- a/definitions/procedures/packages/enable_modules.rb
+++ b/definitions/procedures/packages/enable_modules.rb
@@ -1,0 +1,19 @@
+module Procedures::Packages
+  class EnableModules < ForemanMaintain::Procedure
+    metadata do
+      description 'Enable the given stream modules'
+      confine do
+        package_manager.class.name == 'ForemanMaintain::PackageManager::Dnf'
+      end
+      param :module_names, 'Module names', :array => true, :required => true
+      param :assumeyes, 'Do not ask for confirmation'
+      advanced_run false
+    end
+
+    def run
+      assumeyes_val = @assumeyes.nil? ? assumeyes? : @assumeyes
+      dnf_option = assumeyes_val ? ' -y' : ''
+      execute!("dnf module enable #{@module_names.join(' ')} #{dnf_option}")
+    end
+  end
+end

--- a/definitions/procedures/packages/enable_modules.rb
+++ b/definitions/procedures/packages/enable_modules.rb
@@ -6,14 +6,11 @@ module Procedures::Packages
         package_manager.class.name == 'ForemanMaintain::PackageManager::Dnf'
       end
       param :module_names, 'Module names', :array => true, :required => true
-      param :assumeyes, 'Do not ask for confirmation'
       advanced_run false
     end
 
     def run
-      assumeyes_val = @assumeyes.nil? ? assumeyes? : @assumeyes
-      dnf_option = assumeyes_val ? ' -y' : ''
-      execute!("dnf module enable #{@module_names.join(' ')} #{dnf_option}")
+      execute!("dnf module enable #{@module_names.join(' ')} -y")
     end
   end
 end

--- a/definitions/scenarios/self_upgrade.rb
+++ b/definitions/scenarios/self_upgrade.rb
@@ -1,6 +1,8 @@
 module ForemanMaintain::Scenarios
   class SelfUpgradeBase < ForemanMaintain::Scenario
     include ForemanMaintain::Concerns::Downstream
+    include ForemanMaintain::Concerns::Versions
+
     def target_version
       @target_version ||= current_version.bump
     end

--- a/definitions/scenarios/upgrade_to_foreman_nightly.rb
+++ b/definitions/scenarios/upgrade_to_foreman_nightly.rb
@@ -1,0 +1,90 @@
+module Scenarios::Foreman_Nightly
+  class Abstract < ForemanMaintain::Scenario
+    def self.upgrade_metadata(&block)
+      metadata do
+        tags :upgrade_scenario
+        confine do
+          feature(:foreman_install) || ForemanMaintain.upgrade_in_progress == 'nightly'
+        end
+        instance_eval(&block)
+      end
+    end
+
+    def target_version
+      'nightly'
+    end
+  end
+
+  class PreUpgradeCheck < Abstract
+    upgrade_metadata do
+      description 'Checks before upgrading to Foreman nightly'
+      tags :pre_upgrade_checks
+      run_strategy :fail_slow
+    end
+
+    def compose
+      add_steps(find_checks(:default))
+      add_steps(find_checks(:pre_upgrade))
+    end
+  end
+
+  class PreMigrations < Abstract
+    upgrade_metadata do
+      description 'Procedures before upgrading to Foreman nightly'
+      tags :pre_migrations
+    end
+
+    def compose
+      add_steps(find_procedures(:pre_migrations))
+    end
+  end
+
+  class Migrations < Abstract
+    upgrade_metadata do
+      description 'Upgrade steps for Foreman nightly'
+      tags :migrations
+      run_strategy :fail_fast
+    end
+
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
+    def compose
+      add_step(Procedures::Repositories::Setup.new(:version => 'nightly'))
+      if el?
+        modules_to_enable = ["foreman:#{el_short_name}"]
+        add_step(Procedures::Packages::EnableModules.new(:module_names => modules_to_enable,
+                                                         :assumeyes => true))
+      end
+      add_step(Procedures::Packages::Update.new(:assumeyes => true))
+      add_step_with_context(Procedures::Installer::Upgrade)
+    end
+  end
+
+  class PostMigrations < Abstract
+    upgrade_metadata do
+      description 'Post upgrade procedures for Foreman nightly'
+      tags :post_migrations
+    end
+
+    def compose
+      add_step(Procedures::RefreshFeatures)
+      add_step(Procedures::Service::Start.new)
+      add_steps(find_procedures(:post_migrations))
+    end
+  end
+
+  class PostUpgradeChecks < Abstract
+    upgrade_metadata do
+      description 'Checks after upgrading to Foreman nightly'
+      tags :post_upgrade_checks
+      run_strategy :fail_slow
+    end
+
+    def compose
+      add_steps(find_checks(:default))
+      add_steps(find_checks(:post_upgrade))
+    end
+  end
+end

--- a/definitions/scenarios/upgrade_to_foreman_nightly.rb
+++ b/definitions/scenarios/upgrade_to_foreman_nightly.rb
@@ -54,8 +54,7 @@ module Scenarios::Foreman_Nightly
       add_step(Procedures::Repositories::Setup.new(:version => 'nightly'))
       if el?
         modules_to_enable = ["foreman:#{el_short_name}"]
-        add_step(Procedures::Packages::EnableModules.new(:module_names => modules_to_enable,
-                                                         :assumeyes => true))
+        add_step(Procedures::Packages::EnableModules.new(:module_names => modules_to_enable))
       end
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step_with_context(Procedures::Installer::Upgrade)

--- a/definitions/scenarios/upgrade_to_katello_nightly.rb
+++ b/definitions/scenarios/upgrade_to_katello_nightly.rb
@@ -1,0 +1,88 @@
+module Scenarios::Katello_Nightly
+  class Abstract < ForemanMaintain::Scenario
+    def self.upgrade_metadata(&block)
+      metadata do
+        tags :upgrade_scenario
+        confine do
+          feature(:katello_install) || ForemanMaintain.upgrade_in_progress == 'nightly'
+        end
+        instance_eval(&block)
+      end
+    end
+
+    def target_version
+      'nightly'
+    end
+  end
+
+  class PreUpgradeCheck < Abstract
+    upgrade_metadata do
+      description 'Checks before upgrading to Katello nightly'
+      tags :pre_upgrade_checks
+      run_strategy :fail_slow
+    end
+
+    def compose
+      add_steps(find_checks(:default))
+      add_steps(find_checks(:pre_upgrade))
+    end
+  end
+
+  class PreMigrations < Abstract
+    upgrade_metadata do
+      description 'Procedures before upgrading to Katello nightly'
+      tags :pre_migrations
+    end
+
+    def compose
+      add_steps(find_procedures(:pre_migrations))
+    end
+  end
+
+  class Migrations < Abstract
+    upgrade_metadata do
+      description 'Upgrade steps for Katello nightly'
+      tags :migrations
+      run_strategy :fail_fast
+    end
+
+    def set_context_mapping
+      context.map(:assumeyes, Procedures::Installer::Upgrade => :assumeyes)
+    end
+
+    def compose
+      add_step(Procedures::Repositories::Setup.new(:version => 'nightly'))
+      modules_to_enable = ["katello:#{el_short_name}", "pulpcore:#{el_short_name}"]
+      add_step(Procedures::Packages::EnableModules.new(:module_names => modules_to_enable,
+                                                       :assumeyes => true))
+      add_step(Procedures::Packages::Update.new(:assumeyes => true))
+      add_step_with_context(Procedures::Installer::Upgrade)
+    end
+  end
+
+  class PostMigrations < Abstract
+    upgrade_metadata do
+      description 'Post upgrade procedures for Katello nightly'
+      tags :post_migrations
+    end
+
+    def compose
+      add_step(Procedures::RefreshFeatures)
+      add_step(Procedures::Service::Start.new)
+      add_steps(find_procedures(:post_migrations))
+    end
+  end
+
+  class PostUpgradeChecks < Abstract
+    upgrade_metadata do
+      description 'Checks after upgrading to Katello nightly'
+      tags :post_upgrade_checks
+      run_strategy :fail_slow
+    end
+
+    def compose
+      add_steps(find_checks(:default))
+      add_steps(find_checks(:post_upgrade))
+    end
+  end
+end

--- a/definitions/scenarios/upgrade_to_katello_nightly.rb
+++ b/definitions/scenarios/upgrade_to_katello_nightly.rb
@@ -53,8 +53,7 @@ module Scenarios::Katello_Nightly
     def compose
       add_step(Procedures::Repositories::Setup.new(:version => 'nightly'))
       modules_to_enable = ["katello:#{el_short_name}", "pulpcore:#{el_short_name}"]
-      add_step(Procedures::Packages::EnableModules.new(:module_names => modules_to_enable,
-                                                       :assumeyes => true))
+      add_step(Procedures::Packages::EnableModules.new(:module_names => modules_to_enable))
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step_with_context(Procedures::Installer::Upgrade)
     end

--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -21,6 +21,7 @@ module ForemanMaintain
   require 'foreman_maintain/concerns/hammer'
   require 'foreman_maintain/concerns/base_database'
   require 'foreman_maintain/concerns/directory_marker'
+  require 'foreman_maintain/concerns/versions'
   require 'foreman_maintain/concerns/downstream'
   require 'foreman_maintain/concerns/upstream'
   require 'foreman_maintain/concerns/primary_checks'

--- a/lib/foreman_maintain/concerns/downstream.rb
+++ b/lib/foreman_maintain/concerns/downstream.rb
@@ -5,18 +5,6 @@ module ForemanMaintain
         raise NotImplementedError
       end
 
-      def less_than_version?(version)
-        Gem::Version.new(current_version) < Gem::Version.new(version)
-      end
-
-      def at_least_version?(version)
-        Gem::Version.new(current_version) >= Gem::Version.new(version)
-      end
-
-      def current_minor_version
-        current_version.to_s[/^\d+\.\d+/]
-      end
-
       def repository_manager
         ForemanMaintain.repository_manager
       end

--- a/lib/foreman_maintain/concerns/versions.rb
+++ b/lib/foreman_maintain/concerns/versions.rb
@@ -1,0 +1,17 @@
+module ForemanMaintain
+  module Concerns
+    module Versions
+      def less_than_version?(version)
+        Gem::Version.new(current_version) < Gem::Version.new(version)
+      end
+
+      def at_least_version?(version)
+        Gem::Version.new(current_version) >= Gem::Version.new(version)
+      end
+
+      def current_minor_version
+        current_version.to_s[/^\d+\.\d+/]
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/scenario.rb
+++ b/lib/foreman_maintain/scenario.rb
@@ -4,6 +4,7 @@ module ForemanMaintain
     include Concerns::SystemHelpers
     include Concerns::ScenarioMetadata
     include Concerns::Finders
+    include Concerns::Versions
     extend Concerns::Finders
 
     attr_reader :steps, :context

--- a/test/definitions/features/installer_test.rb
+++ b/test/definitions/features/installer_test.rb
@@ -48,7 +48,7 @@ describe Features::Installer do
       it '#upgrade runs the installer with correct params' do
         assume_feature_absent(:satellite)
         installer_inst.expects(:'execute!').
-          with('LANG=en_US.utf-8 foreman-installer --disable-system-checks --upgrade',
+          with('foreman-installer --disable-system-checks --upgrade',
                :interactive => true).
           returns(true)
         subject.upgrade(:interactive => true)
@@ -57,7 +57,7 @@ describe Features::Installer do
       it '#upgrade runs the installer with correct params in satellite' do
         assume_feature_present(:satellite)
         installer_inst.expects(:'execute!').
-          with('LANG=en_US.utf-8 satellite-installer --disable-system-checks --upgrade',
+          with('satellite-installer --disable-system-checks --upgrade',
                :interactive => true).
           returns(true)
         subject.upgrade(:interactive => true)
@@ -68,7 +68,7 @@ describe Features::Installer do
       it 'runs the installer with correct params' do
         assume_feature_absent(:satellite)
         installer_inst.expects(:'execute!').
-          with('LANG=en_US.utf-8 foreman-installer --password=changeme', :interactive => true).
+          with('foreman-installer --password=changeme', :interactive => true).
           returns(true)
         subject.run('--password=changeme', :interactive => true)
       end
@@ -76,7 +76,7 @@ describe Features::Installer do
       it 'runs the installer with correct params in satellite' do
         assume_feature_present(:satellite)
         installer_inst.expects(:'execute!').
-          with('LANG=en_US.utf-8 satellite-installer --password=changeme', :interactive => true).
+          with('satellite-installer --password=changeme', :interactive => true).
           returns(true)
         subject.run('--password=changeme', :interactive => true)
       end

--- a/test/lib/concerns/downstream_test.rb
+++ b/test/lib/concerns/downstream_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class FakeSatelliteFeature
   include ForemanMaintain::Concerns::SystemHelpers
   include ForemanMaintain::Concerns::Downstream
+  include ForemanMaintain::Concerns::Versions
 
   def package_name
     'satellite'


### PR DESCRIPTION
Depends on  https://github.com/theforeman/foreman_maintain/pull/626

The flow for the Foreman and Katello upgrade should be as below,

1. Have the correct repositories as per the version of the scenario. If scenario is for .z then update the release packages, in this case if package is missing update should install it and make relevant repositories available.
2. After getting the repositories, run the pre upgrade checks, procedures.
3. Enable correct modules if those are not enabled already.
4. Update the packages.
5. Run the installer
6. Execute any post upgrade procedures and checks.