### PR TITLE
Fixes #35261 - Run procedure FixPulpcoreArtifactOwnership during 6.11 upgrade

### DIFF
--- a/definitions/scenarios/upgrade_to_capsule_6_11.rb
+++ b/definitions/scenarios/upgrade_to_capsule_6_11.rb
@@ -40,6 +40,7 @@ module Scenarios::Capsule_6_11
     def compose
       add_steps(find_procedures(:pre_migrations))
       add_step(Procedures::Pulp::Remove.new(:assumeyes => true))
+      add_step(Procedures::Content::FixPulpcoreArtifactOwnership.new(:assumeyes => true))
       add_step(Procedures::Service::Stop.new)
     end
   end

--- a/definitions/scenarios/upgrade_to_capsule_6_11_z.rb
+++ b/definitions/scenarios/upgrade_to_capsule_6_11_z.rb
@@ -39,6 +39,7 @@ module Scenarios::Capsule_6_11_z
 
     def compose
       add_steps(find_procedures(:pre_migrations))
+      add_step(Procedures::Content::FixPulpcoreArtifactOwnership.new(:assumeyes => true))
       add_step(Procedures::Service::Stop.new)
     end
   end

--- a/definitions/scenarios/upgrade_to_satellite_6_11.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_11.rb
@@ -42,6 +42,7 @@ module Scenarios::Satellite_6_11
     def compose
       add_steps(find_procedures(:pre_migrations))
       add_step(Procedures::Pulp::Remove.new(:assumeyes => true))
+      add_step(Procedures::Content::FixPulpcoreArtifactOwnership.new(:assumeyes => true))
       add_step(Procedures::Service::Stop.new)
     end
   end

--- a/definitions/scenarios/upgrade_to_satellite_6_11_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_11_z.rb
@@ -39,6 +39,7 @@ module Scenarios::Satellite_6_11_z
 
     def compose
       add_steps(find_procedures(:pre_migrations))
+      add_step(Procedures::Content::FixPulpcoreArtifactOwnership.new(:assumeyes => true))
       add_step(Procedures::Service::Stop.new)
     end
   end


### PR DESCRIPTION
Correct permissions of artifacts directory with FixPulpcoreArtifactOwnership procedure automatically during 6.11 upgrade.