### PR TITLE
Fixes #35544 - Remove ansible-runner from non-RH package exception list

### DIFF
--- a/definitions/checks/non_rh_packages.rb
+++ b/definitions/checks/non_rh_packages.rb
@@ -11,8 +11,7 @@ class Checks::NonRhPackages < ForemanMaintain::Check
   def run
     rpm_query_format = '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH} : %{VENDOR}\n'
     all_packages = package_manager.list_installed_packages(rpm_query_format)
-    non_rh_packages = all_packages - \
-                      all_packages.grep(Regexp.union(rh_regexp_list + ansible_runner_regexp_list))
+    non_rh_packages = all_packages - all_packages.grep(Regexp.union(rh_regexp_list))
     assert(non_rh_packages.empty?, error_msg(non_rh_packages), :warn => true)
   end
 
@@ -26,9 +25,5 @@ class Checks::NonRhPackages < ForemanMaintain::Check
      /-puppet-client/, /-qpid-broker/, /-qpid-client-cert/, /-qpid-router-client/,
      /-qpid-router-server/, /java-client/, /pulp-client/, /katello-default-ca/, /katello-server-ca/,
      /katello-ca-consumer/, /gpg-pubkey/, /-tomcat/]
-  end
-
-  def ansible_runner_regexp_list
-    [/ansible-runner/, /[python\d]+-ansible-runner/]
   end
 end


### PR DESCRIPTION
The ansible-runner package is now shipped by both Foreman repositories and continues to be built and shipped by Red Hat repositories.

For additional references, see: https://github.com/theforeman/puppet-foreman_proxy/pull/780