### PR TITLE
Fixes #35404 - use current minor version for version bump

### DIFF
--- a/definitions/scenarios/self_upgrade.rb
+++ b/definitions/scenarios/self_upgrade.rb
@@ -2,8 +2,7 @@ module ForemanMaintain::Scenarios
   class SelfUpgradeBase < ForemanMaintain::Scenario
     include ForemanMaintain::Concerns::Downstream
     def target_version
-      current_full_version = feature(:instance).downstream.current_version
-      @target_version ||= current_full_version.bump
+      @target_version ||= current_version.bump
     end
 
     def current_version


### PR DESCRIPTION
(cherry picked from commit 6534d7d3abd140b1a4b3a32227ae53fcf192cad9)