### PR TITLE
Fixes #35404 - use current minor version for version bump

### DIFF
--- a/definitions/scenarios/self_upgrade.rb
+++ b/definitions/scenarios/self_upgrade.rb
@@ -2,8 +2,7 @@ module ForemanMaintain::Scenarios
   class SelfUpgradeBase < ForemanMaintain::Scenario
     include ForemanMaintain::Concerns::Downstream
     def target_version
-      current_full_version = feature(:instance).downstream.current_version
-      @target_version ||= current_full_version.bump
+      @target_version ||= current_version.bump
     end
 
     def current_version

--- a/foreman_maintain.gemspec
+++ b/foreman_maintain.gemspec
@@ -29,4 +29,5 @@ the Foreman/Satellite up and running."
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rubocop', '0.50.0' # rubocop >= 0.51.0 drops support for ruby 2.0
+  s.add_development_dependency 'minitest-stub-const'
 end


### PR DESCRIPTION
(cherry picked from commit 6534d7d3abd140b1a4b3a32227ae53fcf192cad9)