### PR TITLE
Include socket services while stopping services during restart

### DIFF
--- a/definitions/procedures/service/restart.rb
+++ b/definitions/procedures/service/restart.rb
@@ -13,7 +13,7 @@ module Procedures::Service
     PING_RETRY_INTERVAL = 30
 
     def run
-      run_service_action('restart', common_options)
+      run_service_action('restart', common_options.merge(:include_sockets => true))
       server_ping_retry if @wait_for_server_response
     end
 


### PR DESCRIPTION
**Fixes** https://bugzilla.redhat.com/show_bug.cgi?id=2067120

**Results**:
```
# foreman-maintain service restart --only foreman
Running Restart Services
================================================================================
Check if command is run as root user:                                 [OK]
--------------------------------------------------------------------------------
Restart applicable services:

Stopping the following service(s):
foreman, foreman.socket
\ All services stopped

Starting the following service(s):
foreman
/ All services started                                                [OK]
--------------------------------------------------------------------------------
```