### PR TITLE
Refs #35612 - Tuning requirements check when successful should return…

### DIFF
--- a/definitions/checks/foreman/check_tuning_requirements.rb
+++ b/definitions/checks/foreman/check_tuning_requirements.rb
@@ -22,7 +22,7 @@ module Checks
         cpu_message = check_cpu_cores(tuning_profile)
         memory_message = check_memory(tuning_profile)
 
-        return true unless cpu_message || memory_message
+        return unless cpu_message || memory_message
 
         message = failure_message(tuning_profile)
         if cpu_message

--- a/test/definitions/checks/foreman/check_tuning_profile_test.rb
+++ b/test/definitions/checks/foreman/check_tuning_profile_test.rb
@@ -15,7 +15,8 @@ describe Checks::Foreman::TuningRequirements do
     subject.stubs(:memory).returns(24 * 1024 * 1024)
     result = run_check(subject)
 
-    assert_equal 'true', result.output
+    assert_equal '', result.output
+    assert result.success?
   end
 
   it 'fails when system memory is less than tuning profile' do


### PR DESCRIPTION
… nothing

I goobered this and the test originally confirmed my goobering. This actually results in bad output and incorrect result.

```
--------------------------------------------------------------------------------
Check if system requirements match current tuning profile:            [FAIL]
true
```