### PR TITLE
Fixes #35720 - run tar with --no-check-device 

### DIFF
--- a/definitions/features/tar.rb
+++ b/definitions/features/tar.rb
@@ -43,6 +43,7 @@ class Features::Tar < ForemanMaintain::Feature
 
     tar_command = ['tar']
     tar_command << '--selinux'
+    tar_command << '--no-check-device'
     tar_command << "--#{options.fetch(:command, 'create')}"
     tar_command << "--file=#{options.fetch(:archive)}"
 


### PR DESCRIPTION
This should prevent incremental backups of LVM hosted archives from growing to full size backups after a system reboot

https://bugzilla.redhat.com/show_bug.cgi?id=1885552