### PR TITLE
Fixes #35856 - Use the FQDN while checking the smart-proxy features

### DIFF
--- a/definitions/features/foreman_proxy.rb
+++ b/definitions/features/foreman_proxy.rb
@@ -144,7 +144,7 @@ class Features::ForemanProxy < ForemanMaintain::Feature
 
     cmd = "curl -w '\n%{http_code}' -s "
     cmd += format_shell_args('--cert' => ssl_cert, '--key' => ssl_key, '--cacert' => ssl_ca)
-    cmd += " https://$(hostname):#{proxy_settings[:https_port]}"
+    cmd += " https://#{hostname}:#{proxy_settings[:https_port]}"
     cmd
   end
 


### PR DESCRIPTION
This change should ensure that we are using the FQDN of the smart-proxy\foreman instance while accessing the smart-proxy features.