### PR TITLE
don't check both exists? and enabled? when enable? is enough

### DIFF
--- a/definitions/features/gofer.rb
+++ b/definitions/features/gofer.rb
@@ -4,7 +4,6 @@ class Features::Gofer < ForemanMaintain::Feature
 
     confine do
       find_package('gofer') &&
-        ForemanMaintain::Utils::Service::Systemd.new('goferd', 0).exist? &&
         ForemanMaintain::Utils::Service::Systemd.new('goferd', 0).enabled?
     end
   end

--- a/definitions/features/pulp2.rb
+++ b/definitions/features/pulp2.rb
@@ -7,7 +7,6 @@ class Features::Pulp < ForemanMaintain::Feature
 
     confine do
       !check_min_version('katello-common', '4.0') &&
-        ForemanMaintain::Utils::Service::Systemd.new('pulp_resource_manager', 0).exist? &&
         ForemanMaintain::Utils::Service::Systemd.new('pulp_resource_manager', 0).enabled?
     end
   end

--- a/definitions/features/pulpcore.rb
+++ b/definitions/features/pulpcore.rb
@@ -5,8 +5,7 @@ class Features::Pulpcore < ForemanMaintain::Feature
     label :pulpcore
 
     confine do
-      ForemanMaintain::Utils::Service::Systemd.new('pulpcore-api', 0).exist? &&
-        ForemanMaintain::Utils::Service::Systemd.new('pulpcore-api', 0).enabled?
+      ForemanMaintain::Utils::Service::Systemd.new('pulpcore-api', 0).enabled?
     end
   end
 

--- a/definitions/features/salt_server.rb
+++ b/definitions/features/salt_server.rb
@@ -4,7 +4,6 @@ class Features::SaltServer < ForemanMaintain::Feature
 
     confine do
       find_package('salt-master') &&
-        ForemanMaintain::Utils::Service::Systemd.new('salt-master', 0).exist? &&
         ForemanMaintain::Utils::Service::Systemd.new('salt-master', 0).enabled?
     end
   end
@@ -17,8 +16,7 @@ class Features::SaltServer < ForemanMaintain::Feature
 
   def services
     salt_services = [system_service('salt-master', 30)]
-    if ForemanMaintain::Utils::Service::Systemd.new('salt-api', 0).exist? &&
-       ForemanMaintain::Utils::Service::Systemd.new('salt-api', 0).enabled?
+    if ForemanMaintain::Utils::Service::Systemd.new('salt-api', 0).enabled?
       salt_services += [system_service('salt-api', 30)]
     end
     salt_services


### PR DESCRIPTION
enabled? implies exists? - exists just also accepts "disabled" as a valid state, so there is no point in checking for that explicitly if all we need is enabled