### PR TITLE
Factor out the target version to a method

### DIFF
--- a/definitions/scenarios/upgrade_to_foreman_nightly.rb
+++ b/definitions/scenarios/upgrade_to_foreman_nightly.rb
@@ -1,23 +1,39 @@
 module Scenarios::Foreman_Nightly
   class Abstract < ForemanMaintain::Scenario
+    def self.target_version
+      'nightly'
+    end
+
     def self.upgrade_metadata(&block)
+      target_version = self.target_version
+
       metadata do
         tags :upgrade_scenario
         confine do
-          feature(:foreman_install) || ForemanMaintain.upgrade_in_progress == 'nightly'
+          feature(:foreman_install) || ForemanMaintain.upgrade_in_progress == target_version
         end
+
+        @target_version = target_version
+        def target_version
+          @target_version
+        end
+
+        def target
+          "Foreman #{target_version}"
+        end
+
         instance_eval(&block)
       end
     end
 
     def target_version
-      'nightly'
+      self.target_version
     end
   end
 
   class PreUpgradeCheck < Abstract
     upgrade_metadata do
-      description 'Checks before upgrading to Foreman nightly'
+      description "Checks before upgrading to #{target}"
       tags :pre_upgrade_checks
       run_strategy :fail_slow
     end
@@ -30,7 +46,7 @@ module Scenarios::Foreman_Nightly
 
   class PreMigrations < Abstract
     upgrade_metadata do
-      description 'Procedures before upgrading to Foreman nightly'
+      description "Procedures before upgrading to #{target}"
       tags :pre_migrations
     end
 
@@ -41,7 +57,7 @@ module Scenarios::Foreman_Nightly
 
   class Migrations < Abstract
     upgrade_metadata do
-      description 'Upgrade steps for Foreman nightly'
+      description "Upgrade steps for #{target}"
       tags :migrations
       run_strategy :fail_fast
     end
@@ -51,7 +67,7 @@ module Scenarios::Foreman_Nightly
     end
 
     def compose
-      add_step(Procedures::Repositories::Setup.new(:version => 'nightly'))
+      add_step(Procedures::Repositories::Setup.new(:version => target_version))
       if el?
         modules_to_enable = ["foreman:#{el_short_name}"]
         add_step(Procedures::Packages::EnableModules.new(:module_names => modules_to_enable))
@@ -63,7 +79,7 @@ module Scenarios::Foreman_Nightly
 
   class PostMigrations < Abstract
     upgrade_metadata do
-      description 'Post upgrade procedures for Foreman nightly'
+      description "Post upgrade procedures for #{target}"
       tags :post_migrations
     end
 
@@ -76,7 +92,7 @@ module Scenarios::Foreman_Nightly
 
   class PostUpgradeChecks < Abstract
     upgrade_metadata do
-      description 'Checks after upgrading to Foreman nightly'
+      description "Checks after upgrading to #{target}"
       tags :post_upgrade_checks
       run_strategy :fail_slow
     end


### PR DESCRIPTION
This allows copying the scenario without having to modify the target version everywhere. Ideally more steps would be taken out and reused.

This should probably be applied to many files, but first I'd like to get approval on the idea before I put in too much effort only to have to redo it.