### PR TITLE
Fixes #35678 - Trim RPM Changelogs on upgrade to pulp_rpm 3.17.5+

### DIFF
--- a/definitions/procedures/pulpcore/trim_rpm_changelogs.rb
+++ b/definitions/procedures/pulpcore/trim_rpm_changelogs.rb
@@ -1,0 +1,23 @@
+module Procedures::Pulpcore
+  class TrimRpmChangelogs < ForemanMaintain::Procedure
+    include ForemanMaintain::Concerns::SystemService
+
+    metadata do
+      description 'Trim RPM changelogs in the pulpcore db'
+      for_feature :pulpcore
+    end
+
+    def run
+      with_spinner('Trimming RPM changelogs in the pulpcore db') do |spinner|
+        necessary_services = feature(:pulpcore_database).services
+
+        feature(:service).handle_services(spinner, 'start', :only => necessary_services)
+
+        spinner.update('Trimming RPM changelogs')
+        execute!('sudo PULP_SETTINGS=/etc/pulp/settings.py '\
+          'DJANGO_SETTINGS_MODULE=pulpcore.app.settings '\
+          'pulpcore-manager rpm-trim-changelogs')
+      end
+    end
+  end
+end

--- a/definitions/scenarios/upgrade_to_satellite_6_11.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_11.rb
@@ -76,6 +76,7 @@ module Scenarios::Satellite_6_11
     def compose
       add_step(Procedures::RefreshFeatures)
       add_step(Procedures::Service::Start.new)
+      add_step(Procedures::Pulpcore::TrimRpmChangelogs.new)
       add_steps(find_procedures(:post_migrations))
     end
   end

--- a/definitions/scenarios/upgrade_to_satellite_6_12.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_12.rb
@@ -73,6 +73,7 @@ module Scenarios::Satellite_6_12
     def compose
       add_step(Procedures::RefreshFeatures)
       add_step(Procedures::Service::Start.new)
+      add_step(Procedures::Pulpcore::TrimRpmChangelogs.new)
       add_steps(find_procedures(:post_migrations))
     end
   end

--- a/definitions/scenarios/upgrade_to_satellite_6_12_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_12_z.rb
@@ -72,6 +72,7 @@ module Scenarios::Satellite_6_12_z
     def compose
       add_step(Procedures::RefreshFeatures)
       add_step(Procedures::Service::Start.new)
+      add_step(Procedures::Pulpcore::TrimRpmChangelogs.new)
       add_steps(find_procedures(:post_migrations))
     end
   end

--- a/test/definitions/procedures/pulpcore/trim_rpm_changelogs_test.rb
+++ b/test/definitions/procedures/pulpcore/trim_rpm_changelogs_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+describe Procedures::Pulpcore::TrimRpmChangelogs do
+  include DefinitionsTestHelper
+
+  subject do
+    Procedures::Pulpcore::TrimRpmChangelogs.new
+  end
+
+  before do
+    assume_feature_present(:pulpcore, :services => [])
+    assume_feature_present(:pulpcore_database, :configuration => {})
+  end
+
+  it 'trims RPM changelogs' do
+    trim_command = 'sudo PULP_SETTINGS=/etc/pulp/settings.py '\
+      'DJANGO_SETTINGS_MODULE=pulpcore.app.settings '\
+      'pulpcore-manager rpm-trim-changelogs'
+
+    subject.stubs(:'execute!').with(trim_command).returns(0)
+    result = run_procedure(subject)
+    assert result.success?, 'the procedure was expected to succeed'
+  end
+end


### PR DESCRIPTION
(cherry picked from commit 4da3d936e088860ed91a2ec3623b3f77015c84db)