### PR TITLE
Fixes #35992 - add delayed tasks from rh_cloud to exclude list

### DIFF
--- a/definitions/features/foreman_tasks.rb
+++ b/definitions/features/foreman_tasks.rb
@@ -17,6 +17,7 @@ class Features::ForemanTasks < ForemanMaintain::Feature
     Actions::Candlepin::ListenOnCandlepinEvents
     Actions::Katello::EventQueue::Monitor
     Actions::Insights::EmailPoller
+    ForemanInventoryUpload::Async::GenerateAllReportsJob
     ForemanInventoryUpload::Async::GenerateReportJob
     ForemanInventoryUpload::Async::QueueForUploadJob
     ForemanInventoryUpload::Async::UploadReportJob
@@ -24,6 +25,7 @@ class Features::ForemanTasks < ForemanMaintain::Feature
     InsightsCloud::Async::InsightsFullSync
     InsightsCloud::Async::InsightsResolutionsSync
     InsightsCloud::Async::InsightsRulesSync
+    InsightsCloud::Async::InsightsScheduledSync
     InventorySync::Async::InventoryFullSync
     InventorySync::Async::InventoryHostsSync
     InventorySync::Async::InventoryScheduledSync


### PR DESCRIPTION
Since foreman_rh_cloud 6.0.44 several tasks are "delayed" (= they have an action that does delay their execution by a timer). This makes these tasks show up in the "tasks running" list while they are not really running. It's safe to add them to the exclude list.