### PR TITLE
Fixes #35998: Setting token_duration fetching via database is broken

### DIFF
--- a/definitions/checks/foreman_proxy/check_tftp_storage.rb
+++ b/definitions/checks/foreman_proxy/check_tftp_storage.rb
@@ -42,12 +42,8 @@ module Checks::ForemanProxy
     end
 
     def lookup_token_duration
-      data = feature(:foreman_database). \
-             query("select s.value, s.default from settings s \
-                    where category IN ('Setting::Provisioning','Setting') \
-                    and name = 'token_duration'")
-
-      YAML.load(data[0]['value'] || data[0]['default'])
+      data = feature(:hammer).run('--output yaml settings info --id token_duration')
+      YAML.load(data)['Value']
     end
   end
 end


### PR DESCRIPTION
As part of the tftp_storage check before an upgrade, the setting token_duration was being fetched using a direct database query. As the table changed,
 this query also changed. This method of direct database access is unreliable
as it is not beholden to an API that is stable. This switches to using hammer to extract the value.