### PR TITLE
Fixes #36012 - restore properly backups created with -t option

### DIFF
--- a/definitions/features/tar.rb
+++ b/definitions/features/tar.rb
@@ -51,13 +51,11 @@ class Features::Tar < ForemanMaintain::Feature
     end
 
     if volume_size
-      split_tar_script = default_split_tar_script
       tar_command << "--tape-length=#{volume_size}"
-      tar_command << "--new-volume-script=#{split_tar_script}"
     end
 
     tar_command << '--overwrite' if options[:overwrite]
-    tar_command << '--gzip' if options[:gzip]
+    tar_command << (options[:gzip] ? '--gzip' : "--new-volume-script=#{default_split_tar_script}")
 
     exclude = options.fetch(:exclude, [])
     exclude.each do |ex|


### PR DESCRIPTION
Use --new-volume-script option for every tar (not gz) command to ensure also tar extract can "swap tapes" automatically.

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>