### PR TITLE
add an advanced command to list detected features

### DIFF
--- a/definitions/procedures/foreman_maintain_features.rb
+++ b/definitions/procedures/foreman_maintain_features.rb
@@ -1,0 +1,10 @@
+class Procedures::ForemanMaintainFeatures < ForemanMaintain::Procedure
+  metadata do
+    description 'List detected Foreman Maintain features'
+  end
+
+  def run
+    features = ForemanMaintain.available_features
+    output << features.map(&:inspect).join("\n")
+  end
+end

--- a/test/definitions/procedures/foreman_maintain_features_test.rb
+++ b/test/definitions/procedures/foreman_maintain_features_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+describe Procedures::ForemanMaintainFeatures do
+  include DefinitionsTestHelper
+
+  subject do
+    Procedures::ForemanMaintainFeatures.new
+  end
+
+  it 'lists features' do
+    assume_feature_present(:hammer)
+    result = run_procedure(subject)
+    assert result.success?, 'the procedure was expected to succeed'
+    assert_includes result.output, 'hammer<Features::Hammer>'
+  end
+end


### PR DESCRIPTION
this is useful for debugging whether detection of features worked

example output:

    # foreman-maintain advanced procedure run foreman-maintain-features
    Running ForemanMaintain::Scenario
    ================================================================================
    List detected Foreman Maintain features:
    apache<Features::Apache>
    dynflow_sidekiq<Features::DynflowSidekiq>
    foreman_database<Features::ForemanDatabase>
    foreman_install<Features::ForemanInstall>
    foreman_proxy<Features::ForemanProxy>
    foreman_server<ForemanMaintain::Features::ForemanServer>
    foreman_tasks<Features::ForemanTasks>
    hammer<Features::Hammer>
    installer<Features::Installer>
    instance<Features::Instance>
    iptables<Features::Iptables>
    nftables<Features::Nftables>
    puppet_server<Features::PuppetServer>
    service<Features::Service>
    sync_plans<Features::SyncPlans>
    tar<Features::Tar>                                                    [OK]
    --------------------------------------------------------------------------------