### PR TITLE
check for systemd by looking at /run/systemd/system

### DIFF
--- a/lib/foreman_maintain/concerns/system_helpers.rb
+++ b/lib/foreman_maintain/concerns/system_helpers.rb
@@ -30,7 +30,7 @@ module ForemanMaintain
       end
 
       def systemd_installed?
-        File.exist?('/usr/bin/systemctl')
+        File.exist?('/run/systemd/system/')
       end
 
       def check_min_version(name, minimal_version)


### PR DESCRIPTION
This is the official, documented way to check whether a system has booted with systemd [1].
While the method is called `systemd_installed?`, we really want to know if we're running with systemd, as otherwise calls to `systemctl` wouldn't work anyway. But I didn't feel like refactoring the rest of the code.

In some future, we might want to completely drop that check, as we do not support non-systemd installations anyway, but again, I was aiming at the smallest possible change to fix an issue a user had (their system did have /bin/systemctl but not /usr/bin/systemctl for some weird reason).

[1] https://www.freedesktop.org/software/systemd/man/sd_booted.html