### PR TITLE
Fixes #36233 - Run container-repair-media-type script on upgrade

### DIFF
--- a/definitions/procedures/pulpcore/repair_container_media_type.rb
+++ b/definitions/procedures/pulpcore/repair_container_media_type.rb
@@ -1,0 +1,23 @@
+module Procedures::Pulpcore
+  class RepairContainerMediaType < ForemanMaintain::Procedure
+    include ForemanMaintain::Concerns::SystemService
+
+    metadata do
+      description 'Repair container media type in the pulpcore db'
+      for_feature :pulpcore
+    end
+
+    def run
+      with_spinner('Repairing container media type in the pulpcore db') do |spinner|
+        necessary_services = feature(:pulpcore_database).services
+
+        feature(:service).handle_services(spinner, 'start', :only => necessary_services)
+
+        spinner.update('Repairing container media type')
+        execute!('PULP_SETTINGS=/etc/pulp/settings.py '\
+                 'DJANGO_SETTINGS_MODULE=pulpcore.app.settings '\
+                 'pulpcore-manager container-repair-media-type')
+      end
+    end
+  end
+end

--- a/definitions/scenarios/upgrade_to_satellite_6_11.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_11.rb
@@ -77,6 +77,7 @@ module Scenarios::Satellite_6_11
       add_step(Procedures::RefreshFeatures)
       add_step(Procedures::Service::Start.new)
       add_step(Procedures::Pulpcore::TrimRpmChangelogs.new)
+      add_step(Procedures::Pulpcore::ContainerRepairMediaType.new)
       add_steps(find_procedures(:post_migrations))
     end
   end

--- a/definitions/scenarios/upgrade_to_satellite_6_11_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_11_z.rb
@@ -72,6 +72,7 @@ module Scenarios::Satellite_6_11_z
     def compose
       add_step(Procedures::RefreshFeatures)
       add_step(Procedures::Service::Start.new)
+      add_step(Procedures::Pulpcore::ContainerRepairMediaType.new)
       add_steps(find_procedures(:post_migrations))
     end
   end

--- a/definitions/scenarios/upgrade_to_satellite_6_12.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_12.rb
@@ -76,6 +76,7 @@ module Scenarios::Satellite_6_12
       add_step(Procedures::RefreshFeatures)
       add_step(Procedures::Service::Start.new)
       add_step(Procedures::Pulpcore::TrimRpmChangelogs.new)
+      add_step(Procedures::Pulpcore::ContainerRepairMediaType.new)
       add_steps(find_procedures(:post_migrations))
     end
   end

--- a/definitions/scenarios/upgrade_to_satellite_6_12_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_12_z.rb
@@ -75,6 +75,7 @@ module Scenarios::Satellite_6_12_z
       add_step(Procedures::RefreshFeatures)
       add_step(Procedures::Service::Start.new)
       add_step(Procedures::Pulpcore::TrimRpmChangelogs.new)
+      add_step(Procedures::Pulpcore::ContainerRepairMediaType.new)
       add_steps(find_procedures(:post_migrations))
     end
   end

--- a/definitions/scenarios/upgrade_to_satellite_6_13.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_13.rb
@@ -76,6 +76,7 @@ module Scenarios::Satellite_6_13
       add_step(Procedures::RefreshFeatures)
       add_step(Procedures::Service::Start.new)
       add_step(Procedures::Pulpcore::TrimRpmChangelogs.new)
+      add_step(Procedures::Pulpcore::ContainerRepairMediaType.new)
       add_steps(find_procedures(:post_migrations))
     end
   end

--- a/test/definitions/procedures/pulpcore/repair_container_media_type_test.rb
+++ b/test/definitions/procedures/pulpcore/repair_container_media_type_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+describe Procedures::Pulpcore::RepairContainerMediaType do
+  include DefinitionsTestHelper
+
+  subject do
+    Procedures::Pulpcore::RepairContainerMediaType.new
+  end
+
+  before do
+    assume_feature_present(:pulpcore, :services => [])
+    assume_feature_present(:pulpcore_database, :configuration => {})
+  end
+
+  it 'repairs container media type' do
+    repair_command = 'PULP_SETTINGS=/etc/pulp/settings.py '\
+                     'DJANGO_SETTINGS_MODULE=pulpcore.app.settings '\
+                     'pulpcore-manager container-repair-media-type'
+
+    subject.stubs(:'execute!').with(repair_command).returns(0)
+    result = run_procedure(subject)
+    assert result.success?, 'the procedure was expected to succeed'
+  end
+end


### PR DESCRIPTION
I think we could run this on other upgrades as well. Does foreman_maintain have a check to ensure that the procedure doesn't run again next time if we already ran it, though?