### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+---
+name: Release
+
+on:
+  create:
+    ref_type: tag
+
+jobs:
+  release:
+    name: Release gem
+    uses: theforeman/actions/.github/workflows/release-gem.yml@v0
+    with:
+      allowed_owner: theforeman
+    secrets:
+      api_key: ${{ secrets.RUBYGEM_API_KEY }}


### PR DESCRIPTION
I've already created an API key on rubygems.org only for the foreman_maintain gem and added it as a secret. This should make it sufficient to push a git tag and GHA should create the gem.