### PR TITLE
always add Rubocop tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,12 +18,6 @@ namespace :test do
 end
 task :test => ['test:lib', 'test:definitions']
 
-if RUBY_VERSION >= '2.0'
-  # Latest ruobcop doesn't work with Ruby 1.8.7, but unless it let's us to
-  # write 1.8.7-compatible code, we are ok
-  require 'rubocop/rake_task'
-  RuboCop::RakeTask.new
-  task :default => [:rubocop, :test]
-else
-  task :default => [:test]
-end
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
+task :default => [:rubocop, :test]


### PR DESCRIPTION
We don't support anything older than Ruby 2.0 for a looong time.