### PR TITLE
Add enabling satellite-maintenance if present (#690)

### DIFF
--- a/definitions/scenarios/self_upgrade.rb
+++ b/definitions/scenarios/self_upgrade.rb
@@ -58,7 +58,9 @@ module ForemanMaintain::Scenarios
       manual_detection
     end
 
-    def compose
+    def compose(pkgs_to_update)
+      ForemanMaintain.enable_maintenance_module
+
       if check_min_version('foreman', '2.5') || check_min_version('foreman-proxy', '2.5')
         pkgs_to_update = %w[satellite-maintain rubygem-foreman_maintain]
         yum_options = req_repos_to_update_pkgs.map do |id|

--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -175,6 +175,9 @@ module ForemanMaintain
       package_name, command = pkg_and_cmd_name
 
       puts "Checking for new version of #{package_name}..."
+
+      enable_maintenance_module
+
       if ForemanMaintain.package_manager.update_available?(main_package_name)
         puts "\nUpdating #{package_name} package."
         ForemanMaintain.package_manager.update(main_package_name, :assumeyes => true)
@@ -183,6 +186,19 @@ module ForemanMaintain
         exit 75
       end
       puts "Nothing to update, can't find new version of #{package_name}."
+    end
+
+    def enable_maintenance_module
+      return unless el? && !el7?
+
+      maintenance_module = 'satellite-maintenance:el8'
+      package_manager = ForemanMaintain.package_manager
+
+      if package_manager.module_exists?(maintenance_module) &&
+         !package_manager.module_enabled?(maintenance_module)
+        puts "\nEnabling #{maintenance_module} module"
+        package_manager.enable_module(maintenance_module)
+      end
     end
 
     def main_package_name

--- a/lib/foreman_maintain/package_manager/dnf.rb
+++ b/lib/foreman_maintain/package_manager/dnf.rb
@@ -9,6 +9,24 @@ module ForemanMaintain::PackageManager
       true
     end
 
+    def module_enabled?(name)
+      _status, result = info(name)
+      result.match?(/Stream.+\[e\].+/)
+    end
+
+    def enable_module(name)
+      dnf_action('module enable', name, assumeyes: true)
+    end
+
+    def module_exists?(name)
+      status, _result = info(name)
+      status == 0
+    end
+
+    def info(name)
+      dnf_action('module info', name, with_status: true, assumeyes: true)
+    end
+
     private
 
     def dnf_action(action, packages, with_status: false, assumeyes: false)

--- a/test/lib/cli/upgrade_command_test.rb
+++ b/test/lib/cli/upgrade_command_test.rb
@@ -10,6 +10,7 @@ module ForemanMaintain
       ForemanMaintain.detector.refresh
       UpgradeRunner.clear_current_target_version
     end
+
     let :command do
       %w[upgrade]
     end

--- a/test/lib/foreman_maintain_test.rb
+++ b/test/lib/foreman_maintain_test.rb
@@ -34,4 +34,40 @@ describe ForemanMaintain do
       err.message.must_equal 'No supported package manager was found'
     end
   end
+
+  describe 'enable_maintenance_module' do
+    before do
+      subject.stubs(:el?).returns(true)
+      subject.stubs(:el7?).returns(false)
+    end
+
+    let(:package_manager) { ForemanMaintain.package_manager }
+
+    it 'should enable the maintenance module' do
+      package_manager.expects(:module_exists?).with('satellite-maintenance:el8').returns(true)
+      package_manager.expects(:module_enabled?).with('satellite-maintenance:el8').returns(false)
+      package_manager.expects(:enable_module).with('satellite-maintenance:el8').returns(true)
+
+      assert_output("\nEnabling satellite-maintenance:el8 module\n") do
+        subject.enable_maintenance_module
+      end
+    end
+
+    it 'should not enable the maintenance module if module does not exist' do
+      package_manager.expects(:module_exists?).with('satellite-maintenance:el8').returns(false)
+
+      assert_output('') do
+        subject.enable_maintenance_module
+      end
+    end
+
+    it 'should not enable the maintenance module if module is already enabled' do
+      package_manager.expects(:module_exists?).with('satellite-maintenance:el8').returns(true)
+      package_manager.expects(:module_enabled?).with('satellite-maintenance:el8').returns(true)
+
+      assert_output('') do
+        subject.enable_maintenance_module
+      end
+    end
+  end
 end

--- a/test/lib/package_manager/dnf_test.rb
+++ b/test/lib/package_manager/dnf_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+require 'tempfile'
+require 'foreman_maintain/package_manager'
+
+module ForemanMaintain
+  describe PackageManager::Dnf do
+    def expect_execute_with_status(command, response: [0, ''])
+      ForemanMaintain::Utils::SystemHelpers.
+        expects(:execute_with_status).
+        with(command, :interactive => false).
+        returns(response)
+    end
+
+    def expect_execute!(command, response: true)
+      ForemanMaintain::Utils::SystemHelpers.
+        expects(:execute!).
+        with(command, :interactive => false).
+        returns(response)
+    end
+
+    subject { PackageManager::Dnf.new }
+    let(:enabled_module) { 'Stream           : el8 [e] [a]' }
+    let(:disabled_module) { 'Stream           : el8' }
+    let(:non_existent_module) { 'Unable to resolve argument satellit' }
+
+    describe 'module_enabled?' do
+      it 'checks if a module is enabled' do
+        expect_execute_with_status(
+          'dnf -y module info test-module:el8',
+          :response => [0, enabled_module]
+        )
+        assert subject.module_enabled?('test-module:el8')
+      end
+
+      it 'returns false if module does not exist' do
+        expect_execute_with_status(
+          'dnf -y module info test-module:el8',
+          :response => [1, non_existent_module]
+        )
+        assert !subject.module_enabled?('test-module:el8')
+      end
+
+      it 'returns false if module exists but is not enabled' do
+        expect_execute_with_status(
+          'dnf -y module info test-module:el8',
+          :response => [0, disabled_module]
+        )
+        assert !subject.module_enabled?('test-module:el8')
+      end
+    end
+
+    describe 'enable_module' do
+      it 'enables a module by name' do
+        expect_execute!('dnf -y module enable test-module:el8')
+        assert subject.enable_module('test-module:el8')
+      end
+    end
+
+    describe 'module_exists?' do
+      it 'check if a module exists' do
+        expect_execute_with_status('dnf -y module info test-module:el8')
+        assert subject.module_exists?('test-module:el8')
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -70,6 +70,14 @@ class FakePackageManager < ForemanMaintain::PackageManager::Base
   def version_locking_supported?
     true
   end
+
+  def module_enabled?(_name)
+    true
+  end
+
+  def module_exists?(_name)
+    false
+  end
 end
 
 module PackageManagerTestHelper


### PR DESCRIPTION
* Add enabling satellite-maintenance if present

When performing a self-upgrade for Satellite, it should first check if satellite-maintenance:el8 is present and enabled. If present, it should enable it before upgrading.

---------

Co-authored-by: Evgeni Golov <evgeni@golov.de>
(cherry picked from commit f5002fc640574c7337b61820cca44a5004f76403)