### PR TITLE
Fixes #36282: Pre-download packages before stopping services

### DIFF
--- a/definitions/procedures/packages/update.rb
+++ b/definitions/procedures/packages/update.rb
@@ -27,7 +27,11 @@ module Procedures::Packages
     end
 
     def description
-      "Update package(s) #{@packages.join(', ')}"
+      if @yum_options.include?('--downloadonly')
+        "Download package(s) #{@packages.join(', ')}"
+      else
+        "Update package(s) #{@packages.join(', ')}"
+      end
     end
   end
 end

--- a/definitions/scenarios/upgrade_to_capsule_6_14.rb
+++ b/definitions/scenarios/upgrade_to_capsule_6_14.rb
@@ -40,7 +40,6 @@ module Scenarios::Capsule_6_14
 
     def compose
       add_steps(find_procedures(:pre_migrations))
-      add_step(Procedures::Service::Stop.new)
     end
   end
 
@@ -58,7 +57,9 @@ module Scenarios::Capsule_6_14
       add_step(Procedures::Repositories::Setup.new(:version => '6.14'))
       modules_to_enable = ["satellite-capsule:#{el_short_name}"]
       add_step(Procedures::Packages::EnableModules.new(:module_names => modules_to_enable))
-      add_step(Procedures::Packages::UnlockVersions.new)
+      add_step(Procedures::Packages::Update.new(:assumeyes => true,
+        :yum_options => ['--downloadonly']))
+      add_step(Procedures::Service::Stop.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step_with_context(Procedures::Installer::Upgrade)
     end

--- a/definitions/scenarios/upgrade_to_capsule_6_14_z.rb
+++ b/definitions/scenarios/upgrade_to_capsule_6_14_z.rb
@@ -40,7 +40,6 @@ module Scenarios::Capsule_6_14_z
 
     def compose
       add_steps(find_procedures(:pre_migrations))
-      add_step(Procedures::Service::Stop.new)
     end
   end
 
@@ -58,7 +57,9 @@ module Scenarios::Capsule_6_14_z
       add_step(Procedures::Repositories::Setup.new(:version => '6.14'))
       modules_to_enable = ["satellite-capsule:#{el_short_name}"]
       add_step(Procedures::Packages::EnableModules.new(:module_names => modules_to_enable))
-      add_step(Procedures::Packages::UnlockVersions.new)
+      add_step(Procedures::Packages::Update.new(:assumeyes => true,
+        :yum_options => ['--downloadonly']))
+      add_step(Procedures::Service::Stop.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step_with_context(Procedures::Installer::Upgrade)
     end

--- a/definitions/scenarios/upgrade_to_katello_nightly.rb
+++ b/definitions/scenarios/upgrade_to_katello_nightly.rb
@@ -54,6 +54,9 @@ module Scenarios::Katello_Nightly
       add_step(Procedures::Repositories::Setup.new(:version => 'nightly'))
       modules_to_enable = ["katello:#{el_short_name}", "pulpcore:#{el_short_name}"]
       add_step(Procedures::Packages::EnableModules.new(:module_names => modules_to_enable))
+      add_step(Procedures::Packages::Update.new(:assumeyes => true,
+        :yum_options => ['--downloadonly']))
+      add_step(Procedures::Service::Stop.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step_with_context(Procedures::Installer::Upgrade)
     end

--- a/definitions/scenarios/upgrade_to_satellite_6_14.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_14.rb
@@ -40,7 +40,6 @@ module Scenarios::Satellite_6_14
 
     def compose
       add_steps(find_procedures(:pre_migrations))
-      add_step(Procedures::Service::Stop.new)
     end
   end
 
@@ -59,7 +58,9 @@ module Scenarios::Satellite_6_14
       add_step(Procedures::Repositories::Setup.new(:version => '6.14'))
       modules_to_enable = ["satellite:#{el_short_name}"]
       add_step(Procedures::Packages::EnableModules.new(:module_names => modules_to_enable))
-      add_step(Procedures::Packages::UnlockVersions.new)
+      add_step(Procedures::Packages::Update.new(:assumeyes => true,
+        :yum_options => ['--downloadonly']))
+      add_step(Procedures::Service::Stop.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step_with_context(Procedures::Installer::Upgrade)
       add_step(Procedures::Installer::UpgradeRakeTask)

--- a/definitions/scenarios/upgrade_to_satellite_6_14_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_14_z.rb
@@ -40,7 +40,6 @@ module Scenarios::Satellite_6_14_z
 
     def compose
       add_steps(find_procedures(:pre_migrations))
-      add_step(Procedures::Service::Stop.new)
     end
   end
 
@@ -58,7 +57,9 @@ module Scenarios::Satellite_6_14_z
       add_step(Procedures::Repositories::Setup.new(:version => '6.14'))
       modules_to_enable = ["satellite:#{el_short_name}"]
       add_step(Procedures::Packages::EnableModules.new(:module_names => modules_to_enable))
-      add_step(Procedures::Packages::UnlockVersions.new)
+      add_step(Procedures::Packages::Update.new(:assumeyes => true,
+        :yum_options => ['--downloadonly']))
+      add_step(Procedures::Service::Stop.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step_with_context(Procedures::Installer::Upgrade)
       add_step(Procedures::Installer::UpgradeRakeTask)

--- a/test/definitions/procedures/update_package_test.rb
+++ b/test/definitions/procedures/update_package_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+describe Procedures::Packages::Update do
+  include DefinitionsTestHelper
+
+  it 'updates all packages' do
+    ForemanMaintain.stubs(:el?).returns(true)
+    procedure = Procedures::Packages::Update.new
+    procedure.expects(:packages_action).with(:update, [],
+      { :assumeyes => false, :yum_options => [] })
+    result = run_procedure(procedure)
+    assert result.success?
+  end
+
+  it 'updates all packages with --downloadonly' do
+    ForemanMaintain.stubs(:el?).returns(true)
+    procedure = Procedures::Packages::Update.new(:yum_options => ['--downloadonly'])
+    procedure.expects(:packages_action).with(:update, [],
+      { :assumeyes => false, :yum_options => ["--downloadonly"] })
+    result = run_procedure(procedure)
+    assert result.success?
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -83,6 +83,10 @@ class FakePackageManager < ForemanMaintain::PackageManager::Base
   def module_exists?(_name)
     false
   end
+
+  def clean_cache(_assumeyes)
+    true
+  end
 end
 
 module PackageManagerTestHelper

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,7 +10,7 @@ require File.expand_path('lib/support/log_reporter', __dir__)
 Mocha.configure do |c|
   c.strict_keyword_argument_matching = true
 end
-Minitest::Reporters.use!
+Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new(:color => true)]
 
 module CliAssertions
   def assert_cmd(expected_output, args = [], ignore_whitespace: false)


### PR DESCRIPTION
In upgrade scenarios, update packages using --downloadonly option with dnf to stage the packages without having to stop services. Then stop services and actually perform the update. This will cut down on the downtime during the upgrade process.