### PR TITLE
Fixes #33947 - only check directory permissions for backups with dumps

### DIFF
--- a/definitions/checks/backup/directory_ready.rb
+++ b/definitions/checks/backup/directory_ready.rb
@@ -6,11 +6,13 @@ module Checks::Backup
       manual_detection
       param :backup_dir, 'Directory where to backup to', :required => true
       param :preserve_dir, 'Directory where to backup to', :flag => true, :default => false
+      param :postgres_access, 'Whether the postgres user needs access', :flag => true,
+        :default => false
     end
 
     def run
       assert(File.directory?(@backup_dir), "Backup directory (#{@backup_dir}) does not exist.")
-      if feature(:instance).postgresql_local?
+      if feature(:instance).postgresql_local? && @postgres_access
         result = system("runuser - postgres -c 'test -w #{@backup_dir}'")
         assert(result, "Postgres user needs write access to the backup directory \n" \
           "Please allow the postgres user write access to #{@backup_dir}" \

--- a/definitions/scenarios/backup.rb
+++ b/definitions/scenarios/backup.rb
@@ -109,10 +109,9 @@ module ForemanMaintain::Scenarios
     private
 
     def prepare_directory
-      add_steps_with_context(
-        Procedures::Backup::PrepareDirectory,
-        Checks::Backup::DirectoryReady
-      )
+      add_step_with_context(Procedures::Backup::PrepareDirectory)
+      add_step_with_context(Checks::Backup::DirectoryReady,
+        :postgres_access => online_backup? || include_db_dumps?)
     end
 
     def logical_volume_confirmation


### PR DESCRIPTION
offline backups are performed as root and don't need write permissions for the postgres user