### PR TITLE
Fix intermittent test failure

### DIFF
--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -180,10 +180,11 @@ module ForemanMaintain
       puts "Checking for new version of #{package_name}..."
 
       enable_maintenance_module
+      package_manager = ForemanMaintain.package_manager
 
-      if ForemanMaintain.package_manager.update_available?(main_package_name)
+      if package_manager.update_available?(main_package_name)
         puts "\nUpdating #{package_name} package."
-        ForemanMaintain.package_manager.update(main_package_name, :assumeyes => true)
+        package_manager.update(main_package_name, :assumeyes => true)
         puts "\nThe #{package_name} package successfully updated."\
              "\nRe-run #{command} with required options!"
         exit 75

--- a/lib/foreman_maintain/package_manager.rb
+++ b/lib/foreman_maintain/package_manager.rb
@@ -5,12 +5,12 @@ require 'foreman_maintain/package_manager/apt'
 
 module ForemanMaintain
   def self.package_manager
-    @package_manager ||= if el?
-                           ForemanMaintain::PackageManager::Dnf.new
-                         elsif debian_or_ubuntu?
-                           ForemanMaintain::PackageManager::Apt.new
-                         else
-                           raise 'No supported package manager was found'
-                         end
+    if el?
+      ForemanMaintain::PackageManager::Dnf.new
+    elsif debian_or_ubuntu?
+      ForemanMaintain::PackageManager::Apt.new
+    else
+      raise 'No supported package manager was found'
+    end
   end
 end

--- a/test/lib/cli/upgrade_command_test.rb
+++ b/test/lib/cli/upgrade_command_test.rb
@@ -6,12 +6,12 @@ module ForemanMaintain
   describe Cli::UpgradeCommand do
     include CliAssertions
     before do
+      ForemanMaintain.stubs(:el?).returns(true)
       ForemanMaintain.detector.refresh
       UpgradeRunner.clear_current_target_version
     end
 
     def foreman_maintain_update_available
-      ForemanMaintain.stubs(:el?).returns(true)
       PackageManagerTestHelper.mock_package_manager
       FakePackageManager.any_instance.stubs(:update).with('rubygem-foreman_maintain',
         :assumeyes => true).returns(true)
@@ -21,34 +21,35 @@ module ForemanMaintain
     end
 
     def foreman_maintain_update_unavailable
-      ForemanMaintain.stubs(:el?).returns(true)
       PackageManagerTestHelper.mock_package_manager
       # rubocop:disable Layout/LineLength
       FakePackageManager.any_instance.stubs(:update_available?).with('rubygem-foreman_maintain').returns(false)
       # rubocop:enable Layout/LineLength
     end
 
-    let :command do
-      %w[upgrade]
-    end
+    describe 'help' do
+      let :command do
+        %w[upgrade]
+      end
 
-    it 'prints help' do
-      assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
-        Usage:
-            foreman-maintain upgrade [OPTIONS] SUBCOMMAND [ARG] ...
+      it 'prints help' do
+        assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
+          Usage:
+              foreman-maintain upgrade [OPTIONS] SUBCOMMAND [ARG] ...
 
-        Parameters:
-            SUBCOMMAND                    subcommand
-            [ARG] ...                     subcommand arguments
+          Parameters:
+              SUBCOMMAND                    subcommand
+              [ARG] ...                     subcommand arguments
 
-        Subcommands:
-            list-versions                 List versions this system is upgradable to
-            check                         Run pre-upgrade checks before upgrading to specified version
-            run                           Run full upgrade to a specified version
+          Subcommands:
+              list-versions                 List versions this system is upgradable to
+              check                         Run pre-upgrade checks before upgrading to specified version
+              run                           Run full upgrade to a specified version
 
-        Options:
-            -h, --help                    print help
-      OUTPUT
+          Options:
+              -h, --help                    print help
+        OUTPUT
+      end
     end
 
     describe 'list-versions' do

--- a/test/lib/foreman_maintain_test.rb
+++ b/test/lib/foreman_maintain_test.rb
@@ -33,12 +33,13 @@ describe ForemanMaintain do
       subject.stubs(:el?).returns(true)
     end
 
-    let(:package_manager) { ForemanMaintain.package_manager }
+    let(:package_manager) { ForemanMaintain::PackageManager::Dnf }
 
     it 'should enable the maintenance module' do
-      package_manager.expects(:module_exists?).with('satellite-maintenance:el8').returns(true)
-      package_manager.expects(:module_enabled?).with('satellite-maintenance:el8').returns(false)
-      package_manager.expects(:enable_module).with('satellite-maintenance:el8').returns(true)
+      package_manager.any_instance.stubs(:module_exists?).returns(true)
+      package_manager.any_instance.stubs(:module_enabled?).returns(false)
+
+      package_manager.any_instance.expects(:enable_module).with('satellite-maintenance:el8').once
 
       assert_output("\nEnabling satellite-maintenance:el8 module\n") do
         subject.enable_maintenance_module
@@ -46,7 +47,9 @@ describe ForemanMaintain do
     end
 
     it 'should not enable the maintenance module if module does not exist' do
-      package_manager.expects(:module_exists?).with('satellite-maintenance:el8').returns(false)
+      package_manager.any_instance.stubs(:module_exists?).returns(false)
+
+      package_manager.any_instance.expects(:enable_module).with('satellite-maintenance:el8').never
 
       assert_output('') do
         subject.enable_maintenance_module
@@ -54,8 +57,10 @@ describe ForemanMaintain do
     end
 
     it 'should not enable the maintenance module if module is already enabled' do
-      package_manager.expects(:module_exists?).with('satellite-maintenance:el8').returns(true)
-      package_manager.expects(:module_enabled?).with('satellite-maintenance:el8').returns(true)
+      package_manager.any_instance.stubs(:module_exists?).returns(true)
+      package_manager.any_instance.stubs(:module_enabled?).returns(true)
+
+      package_manager.any_instance.expects(:enable_module).with('satellite-maintenance:el8').never
 
       assert_output('') do
         subject.enable_maintenance_module


### PR DESCRIPTION
On some test runs this test fail like so:

```
 FAIL ForemanMaintain::Cli::UpgradeCommand::run#test_0008_with --phase it runs only a specific phase of the upgrade (0.07s)
        --- expected
        +++ actual
        @@ -1,3 +1,3 @@
         "Checking for new version of rubygem-foreman_maintain...
        -Nothing to update, can't find new version of rubygem-foreman_maintain.
        +undefined method `module_exists?' for #<ForemanMaintain::PackageManager::Apt:0xXXXXXX>
         "
        /home/ehelms/workspace/upstream/installer/foreman_maintain/test/test_helper.rb:22:in `assert_cmd'
        /home/ehelms/workspace/upstream/installer/foreman_maintain/test/lib/cli/upgrade_command_test.rb:234:in `block (3 levels) in <module:ForemanMaintain>'
```