### PR TITLE
Fixes #36365 - Drop usage of sudo for any pulpcore-manager commands

### DIFF
--- a/definitions/procedures/pulpcore/migrate.rb
+++ b/definitions/procedures/pulpcore/migrate.rb
@@ -16,9 +16,8 @@ module Procedures::Pulpcore
         feature(:service).handle_services(spinner, 'stop', :only => pulp_services)
 
         spinner.update('Migrating pulpcore database')
-        execute!('sudo PULP_SETTINGS=/etc/pulp/settings.py '\
-          'DJANGO_SETTINGS_MODULE=pulpcore.app.settings '\
-          'pulpcore-manager migrate --noinput')
+        execute!('PULP_SETTINGS=/etc/pulp/settings.py '\
+          'runuser -u pulp -- pulpcore-manager migrate --noinput')
       end
     end
   end

--- a/definitions/procedures/pulpcore/trim_rpm_changelogs.rb
+++ b/definitions/procedures/pulpcore/trim_rpm_changelogs.rb
@@ -14,9 +14,8 @@ module Procedures::Pulpcore
         feature(:service).handle_services(spinner, 'start', :only => necessary_services)
 
         spinner.update('Trimming RPM changelogs')
-        execute!('sudo PULP_SETTINGS=/etc/pulp/settings.py '\
-          'DJANGO_SETTINGS_MODULE=pulpcore.app.settings '\
-          'pulpcore-manager rpm-trim-changelogs')
+        execute!('PULP_SETTINGS=/etc/pulp/settings.py '\
+          'runuser -u pulp -- pulpcore-manager rpm-trim-changelogs')
       end
     end
   end

--- a/test/definitions/procedures/pulpcore/trim_rpm_changelogs_test.rb
+++ b/test/definitions/procedures/pulpcore/trim_rpm_changelogs_test.rb
@@ -13,9 +13,8 @@ describe Procedures::Pulpcore::TrimRpmChangelogs do
   end
 
   it 'trims RPM changelogs' do
-    trim_command = 'sudo PULP_SETTINGS=/etc/pulp/settings.py '\
-      'DJANGO_SETTINGS_MODULE=pulpcore.app.settings '\
-      'pulpcore-manager rpm-trim-changelogs'
+    trim_command = 'PULP_SETTINGS=/etc/pulp/settings.py '\
+      'runuser -u pulp -- pulpcore-manager rpm-trim-changelogs'
 
     subject.stubs(:'execute!').with(trim_command).returns(0)
     result = run_procedure(subject)


### PR DESCRIPTION
If root is not allowed to use sudo , users will bound to run into either of these issues during upgrade or restore 

~~~
E, [2023-03-10 03:48:22+0000 #49723] ERROR -- : Failed executing sudo PULP_SETTINGS=/etc/pulp/settings.py DJANGO_SETTINGS_MODULE=pulpcore.app.settings pulpcore-managern migrate --noinput, exit status 1:
sudo: sudoers specifies that root is not allowed to sudo (ForemanMaintain::Error::ExecutionError)
~~~
or
~~~
Failed executing sudo PULP_SETTINGS=/etc/pulp/settings.py DJANGO_SETTINGS_MODULE=pulpcore.app.settings pulpcore-manager rpm-trim-changelogs, exit status 1:
Sorry, user root is not allowed to execute '/usr/bin/pulpcore-manager rpm-trim-changelogs' as root on satellite.example.com
~~~

Since we anyway run foreman-maintain\satellite-maintain as the root user, Let's remove the usage of sudo to run those commands normally. 

I did a test for restore and upgrade with these changes and they worked just fine.

It would also probably need to go in 1.2.X ( if any future releases are planned )