### PR TITLE
Fixes #36369 - Exit code 0 is a valid exit status

### DIFF
--- a/lib/foreman_maintain/package_manager/yum.rb
+++ b/lib/foreman_maintain/package_manager/yum.rb
@@ -68,7 +68,7 @@ module ForemanMaintain::PackageManager
     end
 
     def check_update(packages: nil, with_status: false)
-      yum_action('check-update', packages, :assumeyes => true, :valid_exit_statuses => [100],
+      yum_action('check-update', packages, :assumeyes => true, :valid_exit_statuses => [0, 100],
                                            :with_status => with_status)
     end
 


### PR DESCRIPTION
Right now in [yum.rb](https://github.com/theforeman/foreman_maintain/blob/master/lib/foreman_maintain/package_manager/yum.rb#L70-L73), we only consider exit code 100 as the code_of_success.

But if no package updates are available, Then foreman-maintain fails the check-update step as the exit code, in this case, would be 0.

If no package updates are present and the exit code from yum is 0, then also the check-update action should pass as a successful execution.