### PR TITLE
Fix foreman service being enabled after disable

### DIFF
--- a/definitions/features/foreman_server.rb
+++ b/definitions/features/foreman_server.rb
@@ -10,11 +10,7 @@ module ForemanMaintain
       end
 
       def services
-        if execute?('systemctl is-enabled foreman')
-          [system_service('foreman', 30, :socket => 'foreman')]
-        else
-          [system_service('httpd', 30)]
-        end
+        [system_service('foreman', 30, :socket => 'foreman')]
       end
 
       def plugins


### PR DESCRIPTION
The conditional is no longer needed since having Puma as our app server for foreman. This code path introduced a bug where once foreman was disabled it would never be enabled again.