### PR TITLE
don't overwrite dnf.Plugin.__init__

### DIFF
--- a/extras/foreman_protector/dnf/foreman-protector.py
+++ b/extras/foreman_protector/dnf/foreman-protector.py
@@ -8,10 +8,6 @@ class ForemanProtector(dnf.Plugin):
     name = 'foreman-protector'
     config_name = 'foreman-protector'
 
-    def __init__(self,base,cli):
-        self.base = base
-        self.cli = cli
-
     def _get_whitelist_file_url(self):
         try:
              parser = self.read_config(self.base.conf)


### PR DESCRIPTION
we do the very same as the main init method, so no need to do it at all.