### PR TITLE
Fixes #36464 - always manage pulpcore services

### DIFF
--- a/definitions/features/pulpcore.rb
+++ b/definitions/features/pulpcore.rb
@@ -5,17 +5,13 @@ class Features::Pulpcore < ForemanMaintain::Feature
 
   metadata do
     label :pulpcore
-
-    confine do
-      ForemanMaintain::Utils::Service::Systemd.new('pulpcore-api', 0).enabled?
-    end
   end
 
   def services
     redis_services = feature(:redis) ? feature(:redis).services : []
 
     self.class.pulpcore_common_services + configured_workers +
-      redis_services + feature(:apache).services
+      redis_services
   end
 
   def configured_workers
@@ -27,15 +23,6 @@ class Features::Pulpcore < ForemanMaintain::Feature
     end
   end
 
-  def self.pulpcore_migration_services
-    pulpcore_common_services + [
-      ForemanMaintain::Utils.system_service('pulpcore-worker@1', 20),
-      ForemanMaintain::Utils.system_service('pulpcore-worker@2', 20),
-      ForemanMaintain::Utils.system_service('pulpcore-worker@3', 20),
-      ForemanMaintain::Utils.system_service('pulpcore-worker@4', 20),
-    ]
-  end
-
   def config_files
     [
       '/etc/pulp/settings.py',
@@ -44,22 +31,9 @@ class Features::Pulpcore < ForemanMaintain::Feature
   end
 
   def self.pulpcore_common_services
-    common_services = [
+    [
       ForemanMaintain::Utils.system_service('pulpcore-api', 10, :socket => 'pulpcore-api'),
       ForemanMaintain::Utils.system_service('pulpcore-content', 10, :socket => 'pulpcore-content'),
     ]
-    common_services + pulpcore_resource_manager_service
-  end
-
-  def self.pulpcore_resource_manager_service
-    # The pulpcore_resource_manager is only required on 3.14+
-    # if the old tasking system is being used
-    # The foreman-installer does not create unit file for this service,
-    # if the new tasking system is being used
-    if feature(:service).unit_file_available?('pulpcore-resource-manager.service')
-      return [ForemanMaintain::Utils.system_service('pulpcore-resource-manager', 10)]
-    end
-
-    []
   end
 end


### PR DESCRIPTION
Old, old code confined Pulp services to if they were enabled or not. However, if the 'service disable' command is used those services are naturally disabled and now no longer manageable by the service command. This also cleans up some old bits that no longer apply to the Pulp architecture.