### PR TITLE
Fixes #36480 - add restore_dir option to backup_local

### DIFF
--- a/definitions/procedures/backup/offline/candlepin_db.rb
+++ b/definitions/procedures/backup/offline/candlepin_db.rb
@@ -36,7 +36,8 @@ module Procedures::Backup
             pg_backup_file,
             :listed_incremental => File.join(@backup_dir, '.postgres.snar'),
             :volume_size => @tar_volume_size,
-            :data_dir => pg_data_dir
+            :data_dir => pg_data_dir,
+            :restore_dir => feature(:candlepin_database).data_dir
           )
         end
       end

--- a/definitions/procedures/backup/offline/foreman_db.rb
+++ b/definitions/procedures/backup/offline/foreman_db.rb
@@ -39,12 +39,13 @@ module Procedures::Backup
       end
 
       def do_backup(pg_dir, cmd)
+        restore_dir = el? ? feature(:foreman_database).data_dir : pg_dir
         feature(:foreman_database).backup_local(
           pg_backup_file,
           :listed_incremental => File.join(@backup_dir, '.postgres.snar'),
           :volume_size => @tar_volume_size,
           :data_dir => pg_dir,
-          :restore_dir => feature(:foreman_database).data_dir,
+          :restore_dir => restore_dir,
           :command => cmd
         )
       end

--- a/definitions/procedures/backup/offline/foreman_db.rb
+++ b/definitions/procedures/backup/offline/foreman_db.rb
@@ -44,6 +44,7 @@ module Procedures::Backup
           :listed_incremental => File.join(@backup_dir, '.postgres.snar'),
           :volume_size => @tar_volume_size,
           :data_dir => pg_dir,
+          :restore_dir => feature(:foreman_database).data_dir,
           :command => cmd
         )
       end

--- a/definitions/procedures/backup/offline/pulpcore_db.rb
+++ b/definitions/procedures/backup/offline/pulpcore_db.rb
@@ -36,7 +36,8 @@ module Procedures::Backup
             pg_backup_file,
             :listed_incremental => File.join(@backup_dir, '.postgres.snar'),
             :volume_size => @tar_volume_size,
-            :data_dir => pg_data_dir
+            :data_dir => pg_data_dir,
+            :restore_dir => feature(:pulpcore_database).data_dir
           )
         end
       end

--- a/lib/foreman_maintain/concerns/base_database.rb
+++ b/lib/foreman_maintain/concerns/base_database.rb
@@ -101,13 +101,14 @@ module ForemanMaintain
 
       def backup_local(backup_file, extra_tar_options = {})
         dir = extra_tar_options.fetch(:data_dir, data_dir)
+        restore_dir = extra_tar_options.fetch(:restore_dir, data_dir)
         command = extra_tar_options.fetch(:command, 'create')
 
         FileUtils.cd(dir) do
           tar_options = {
             :archive => backup_file,
             :command => command,
-            :transform => "s,^,#{dir[1..]},S",
+            :transform => "s,^,#{restore_dir[1..]},S",
             :files => '*',
           }.merge(extra_tar_options)
           feature(:tar).run(tar_options)


### PR DESCRIPTION
Without a restore_dir option, snapshot backups cannot be restored with "foreman-maintain restore".

