### PR TITLE
Refs #36233 - Fix name of container repair media type procedure

### DIFF
--- a/definitions/procedures/pulpcore/container_repair_media_type.rb
+++ b/definitions/procedures/pulpcore/container_repair_media_type.rb
@@ -1,5 +1,5 @@
 module Procedures::Pulpcore
-  class RepairContainerMediaType < ForemanMaintain::Procedure
+  class ContainerRepairMediaType < ForemanMaintain::Procedure
     include ForemanMaintain::Concerns::SystemService
 
     metadata do

--- a/test/definitions/procedures/pulpcore/container_repair_media_type_test.rb
+++ b/test/definitions/procedures/pulpcore/container_repair_media_type_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
 
-describe Procedures::Pulpcore::RepairContainerMediaType do
+describe Procedures::Pulpcore::ContainerRepairMediaType do
   include DefinitionsTestHelper
 
   subject do
-    Procedures::Pulpcore::RepairContainerMediaType.new
+    Procedures::Pulpcore::ContainerRepairMediaType.new
   end
 
   before do


### PR DESCRIPTION
Fixing a bug due to inconsistent naming. Sticking with the same ordering as the actual command: `pulpcore-manager container-repair-media-type`, this renames the class and also moves the files.

Thanks @lpramuk and @odilhao

Alternative to https://github.com/theforeman/foreman_maintain/pull/740