### PR TITLE
Fixes #37158: Explicitly define upgrade steps in upgrade scenario

### DIFF
--- a/definitions/procedures/sync_plans/disable.rb
+++ b/definitions/procedures/sync_plans/disable.rb
@@ -4,7 +4,6 @@ module Procedures::SyncPlans
     metadata do
       for_feature :sync_plans
       description 'disable active sync plans'
-      tags :pre_migrations, :maintenance_mode_on
 
       confine do
         feature(:katello)

--- a/definitions/procedures/sync_plans/enable.rb
+++ b/definitions/procedures/sync_plans/enable.rb
@@ -4,8 +4,6 @@ module Procedures::SyncPlans
     metadata do
       for_feature :sync_plans
       description 're-enable sync plans'
-      tags :post_migrations, :maintenance_mode_off
-      before :disk_io
 
       confine do
         feature(:katello)

--- a/definitions/scenarios/restore.rb
+++ b/definitions/scenarios/restore.rb
@@ -14,7 +14,7 @@ module ForemanMaintain::Scenarios
     def compose
       backup = ForemanMaintain::Utils::Backup.new(context.get(:backup_dir))
 
-      add_steps(find_checks(:root_user))
+      add_step(Checks::RootUser)
       add_steps_with_context(Checks::Restore::ValidateBackup,
         Checks::Restore::ValidateHostname,
         Checks::Restore::ValidateInterfaces,

--- a/definitions/scenarios/services.rb
+++ b/definitions/scenarios/services.rb
@@ -8,7 +8,7 @@ module ForemanMaintain::Scenarios
     end
 
     def compose
-      add_steps(find_checks(:root_user))
+      add_step(Checks::RootUser)
       add_steps_with_context(Procedures::Service::Restart)
     end
 
@@ -33,7 +33,7 @@ module ForemanMaintain::Scenarios
     end
 
     def compose
-      add_steps(find_checks(:root_user))
+      add_step(Checks::RootUser)
       add_steps_with_context(Procedures::Service::Stop)
     end
 
@@ -55,7 +55,7 @@ module ForemanMaintain::Scenarios
     end
 
     def compose
-      add_steps(find_checks(:root_user))
+      add_step(Checks::RootUser)
       add_steps_with_context(Procedures::Service::Start)
     end
 
@@ -98,7 +98,7 @@ module ForemanMaintain::Scenarios
     end
 
     def compose
-      add_steps(find_checks(:root_user))
+      add_step(Checks::RootUser)
       add_steps_with_context(Procedures::Service::Enable)
     end
 
@@ -120,7 +120,7 @@ module ForemanMaintain::Scenarios
     end
 
     def compose
-      add_steps(find_checks(:root_user))
+      add_step(Checks::RootUser)
       add_steps_with_context(Procedures::Service::Disable)
     end
 

--- a/lib/foreman_maintain/concerns/finders.rb
+++ b/lib/foreman_maintain/concerns/finders.rb
@@ -13,10 +13,6 @@ module ForemanMaintain
         ensure_one_object(:check, label)
       end
 
-      def find_checks(conditions)
-        detector.available_checks(conditions)
-      end
-
       def procedure(label)
         ensure_one_object(:procedure, label)
       end

--- a/test/lib/support/definitions/scenarios/missing_upgrade.rb
+++ b/test/lib/support/definitions/scenarios/missing_upgrade.rb
@@ -13,7 +13,11 @@ module Scenarios::MissingUpgrade
     end
 
     def compose
-      add_steps(find_checks(:default))
+      add_steps(
+        Checks::PresentServiceIsRunning,
+        Checks::ServiceIsStopped,
+        Checks::MissingServiceIsRunning,
+      )
     end
   end
 end

--- a/test/lib/support/definitions/scenarios/present_upgrade.rb
+++ b/test/lib/support/definitions/scenarios/present_upgrade.rb
@@ -15,8 +15,11 @@ module Scenarios::PresentUpgrade
     end
 
     def compose
-      add_steps(find_checks(:default))
-      add_step(procedure(Procedures::PresentServiceRestart))
+      add_steps(
+        Checks::PresentServiceIsRunning,
+        Checks::ServiceIsStopped,
+        Procedures::PresentServiceRestart,
+      )
     end
   end
 
@@ -35,7 +38,10 @@ module Scenarios::PresentUpgrade
     end
 
     def compose
-      add_steps(find_procedures(:pre_migrations))
+      add_steps(
+        Procedures::StopService,
+        Procedures::Upgrade::PreMigration
+      )
     end
   end
 
@@ -54,7 +60,9 @@ module Scenarios::PresentUpgrade
     end
 
     def compose
-      add_steps(find_procedures(:migrations))
+      add_steps(
+        Procedures::Upgrade::Migration,
+      )
     end
   end
 
@@ -73,7 +81,9 @@ module Scenarios::PresentUpgrade
     end
 
     def compose
-      add_steps(find_procedures(:post_migrations))
+      add_steps(
+        Procedures::Upgrade::PostMigration,
+      )
     end
   end
 
@@ -92,7 +102,9 @@ module Scenarios::PresentUpgrade
     end
 
     def compose
-      add_steps(find_checks(:post_upgrade_checks))
+      add_steps(
+        Procedures::Upgrade::PostUpgradeCheck,
+      )
     end
   end
 end


### PR DESCRIPTION
This is a draft as I am using it to help understand what is happening, to prune the set of checks, and to help decide if we want to move away from the "magic" and to a more explicit layout of these items.

Right now the design of foreman-maintain is to define metadata and in some cases constraints about a check and then have the system automagically figure everything out. This puts all the logic into the check but makes it harder to tell what is happening when you look at a scenario that is then using these.

There are a few other properties a check can define:

 1. Conditions that must be met for a check to run (e.g. a package existing, or a plugin)
 2. Before / after another check
 3. A block of code (or even another check) that is executed prior to a check
 
Example:

```
    class CheckOld < ForemanMaintain::Check
      metadata do
        label :check_old_foreman_tasks
        for_feature :foreman_tasks
        tags :pre_upgrade
        description 'Check for old tasks in paused/stopped state'
        before :check_foreman_tasks_in_pending_state
        after :foreman_tasks_not_paused
      end
```

Initially, I am not a huge fan of #1 and #2 as this puts condition knowledge into the check, rather than letting the functions of the tool define when to run what and where. For things like upgrade scenarios, or health checks, or backup and restore I tend towards being as explicit as possible to make the code understandable both when debugging and performing new development. I think I would rather define a well defined list of checks for a given scenario and then use that within the top-level CLI functions. I do think the conditions (#1) can be useful if restricted to feature flag style only (e.g. `feature(:foreman_proxy).dhcp_isc_provider?`) 
 