### PR TITLE
only add metadata once to the backup

### DIFF
--- a/definitions/scenarios/backup.rb
+++ b/definitions/scenarios/backup.rb
@@ -25,7 +25,7 @@ module ForemanMaintain::Scenarios
       accessibility_confirmation
       prepare_directory
       logical_volume_confirmation
-      add_step_with_context(Procedures::Backup::Metadata)
+      add_step_with_context(Procedures::Backup::Metadata, :online_backup => online_backup?)
 
       case strategy
       when :online
@@ -199,7 +199,6 @@ module ForemanMaintain::Scenarios
         Procedures::Backup::Online::ForemanDB,
         Procedures::Backup::Online::PulpcoreDB
       )
-      add_step_with_context(Procedures::Backup::Metadata, :online_backup => true)
     end
 
     def strategy


### PR DESCRIPTION
the old code would add the metadata once with "online=false" and then if it's an online backup overwrite it completely with "online=true"

instead we can just write it once correctly, saving one round of metadata gathering in the case of an online backup