### PR TITLE
Add final upgrade step to check if reboot needed

### DIFF
--- a/definitions/procedures/packages/check_for_reboot.rb
+++ b/definitions/procedures/packages/check_for_reboot.rb
@@ -1,0 +1,16 @@
+module Procedures::Packages
+  class CheckForReboot < ForemanMaintain::Procedure
+    metadata do
+      description 'Check if system needs reboot'
+    end
+
+    def run
+      status, output = execute_with_status('dnf needs-restarting --reboothint')
+      if status == 1
+        set_status(:warning, output)
+      else
+        set_status(:success, output)
+      end
+    end
+  end
+end

--- a/definitions/scenarios/upgrade_to_capsule_6_15.rb
+++ b/definitions/scenarios/upgrade_to_capsule_6_15.rb
@@ -87,6 +87,7 @@ module Scenarios::Capsule_6_15
     def compose
       add_steps(find_checks(:default))
       add_steps(find_checks(:post_upgrade))
+      add_step(Procedures::Packages::CheckForReboot)
     end
   end
 end

--- a/definitions/scenarios/upgrade_to_capsule_6_15_z.rb
+++ b/definitions/scenarios/upgrade_to_capsule_6_15_z.rb
@@ -87,6 +87,7 @@ module Scenarios::Capsule_6_15_z
     def compose
       add_steps(find_checks(:default))
       add_steps(find_checks(:post_upgrade))
+      add_step(Procedures::Packages::CheckForReboot)
     end
   end
 end

--- a/definitions/scenarios/upgrade_to_satellite_6_15.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_15.rb
@@ -89,6 +89,7 @@ module Scenarios::Satellite_6_15
     def compose
       add_steps(find_checks(:default))
       add_steps(find_checks(:post_upgrade))
+      add_step(Procedures::Packages::CheckForReboot)
     end
   end
 end

--- a/definitions/scenarios/upgrade_to_satellite_6_15_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_15_z.rb
@@ -88,6 +88,7 @@ module Scenarios::Satellite_6_15_z
     def compose
       add_steps(find_checks(:default))
       add_steps(find_checks(:post_upgrade))
+      add_step(Procedures::Packages::CheckForReboot)
     end
   end
 end


### PR DESCRIPTION
This is intended to automate into the procedure and be able to drop from our documentation running the command explicitly. I have included example outputs below. My only concern is whether this is too "hidden" of output for the user and if instead we need more of special post upgrade output (similar to the installer) that clearly articulates any upgrade considerations.

Output if reboot needed:

```
Running Checks after upgrading to Satellite 6.15.z
================================================================================
Clean old Kernel and initramfs files from tftp-boot:                  [OK]
--------------------------------------------------------------------------------
Check number of fact names in database:                               [OK]
--------------------------------------------------------------------------------
Check whether all services are running:                               [OK]
--------------------------------------------------------------------------------
Check whether all services are running using the ping call:           [OK]
--------------------------------------------------------------------------------
Check for paused tasks:                                               [OK]
--------------------------------------------------------------------------------
Check whether system is self-registered or not:                       [OK]
--------------------------------------------------------------------------------
Check if only installed assets are present on the system: 
| Checking for presence of non-original assets...                     [OK]      
--------------------------------------------------------------------------------
Check if system needs reboot: 
Updating Subscription Management repositories.
Core libraries or services have been updated since boot-up:
  * dbus
  * dbus-daemon
  * kernel
  * linux-firmware
  * systemd

Reboot is required to fully utilize these updates.
More information: https://access.redhat.com/solutions/27943           [OK]
--------------------------------------------------------------------------------


--------------------------------------------------------------------------------
Upgrade finished.
```

Example if no reboot:

```
Running Checks after upgrading to Satellite 6.15.z
================================================================================
Clean old Kernel and initramfs files from tftp-boot:                  [OK]
--------------------------------------------------------------------------------
Check number of fact names in database:                               [OK]
--------------------------------------------------------------------------------
Check whether all services are running:                               [OK]
--------------------------------------------------------------------------------
Check whether all services are running using the ping call:           [OK]
--------------------------------------------------------------------------------
Check for paused tasks:                                               [OK]
--------------------------------------------------------------------------------
Check whether system is self-registered or not:                       [OK]
--------------------------------------------------------------------------------
Check if only installed assets are present on the system: 
| Checking for presence of non-original assets...                     [OK]      
--------------------------------------------------------------------------------
Check if system needs reboot: 
No core libraries or services have been updated since boot-up.
Reboot should not be necessary.
More information: https://access.redhat.com/solutions/27943           [OK]
--------------------------------------------------------------------------------


--------------------------------------------------------------------------------
Upgrade finished.
```