### PR TITLE
Refs #36877 - Remove unneeded yaml requires from katello-agent check

### DIFF
--- a/definitions/checks/katello_agent.rb
+++ b/definitions/checks/katello_agent.rb
@@ -1,5 +1,3 @@
-require 'yaml'
-
 class Checks::CheckKatelloAgentEnabled < ForemanMaintain::Check
   metadata do
     label :check_katello_agent_enabled


### PR DESCRIPTION
Missed this when I was updating based on review feedback