### PR TITLE
do not back up validate_postgresql_connection.sh

### DIFF
--- a/definitions/features/installer.rb
+++ b/definitions/features/installer.rb
@@ -30,7 +30,6 @@ class Features::Installer < ForemanMaintain::Feature
   def config_files
     Dir.glob(File.join(config_directory, '**/*')) +
       [
-        '/usr/local/bin/validate_postgresql_connection.sh',
         '/opt/puppetlabs/puppet/cache/foreman_cache_data',
         '/opt/puppetlabs/puppet/cache/pulpcore_cache_data',
       ]

--- a/test/definitions/features/installer_test.rb
+++ b/test/definitions/features/installer_test.rb
@@ -19,7 +19,6 @@ describe Features::Installer do
         "#{data_dir}/installer/simple_config/scenarios.d/foreman-answers.yaml",
         "#{data_dir}/installer/simple_config/scenarios.d/foreman.yaml",
         "#{data_dir}/installer/simple_config/scenarios.d/last_scenario.yaml",
-        '/usr/local/bin/validate_postgresql_connection.sh',
         '/opt/puppetlabs/puppet/cache/foreman_cache_data',
         '/opt/puppetlabs/puppet/cache/pulpcore_cache_data',
       ].sort


### PR DESCRIPTION
it's not a config file, it contains nothing important and the installer can recreate it if necessary