### PR TITLE
Issue warning if reboot needed but exit with success

### DIFF
--- a/definitions/procedures/packages/check_for_reboot.rb
+++ b/definitions/procedures/packages/check_for_reboot.rb
@@ -7,7 +7,7 @@ module Procedures::Packages
     def run
       status, output = execute_with_status('dnf needs-restarting --reboothint')
       if status == 1
-        set_status(:warning, output)
+        set_info_warn(output)
       else
         set_status(:success, output)
       end

--- a/lib/foreman_maintain/executable.rb
+++ b/lib/foreman_maintain/executable.rb
@@ -5,7 +5,7 @@ module ForemanMaintain
     attr_reader :options
 
     def_delegators :execution,
-      :success?, :skipped?, :fail?, :aborted?, :warning?, :output,
+      :success?, :skipped?, :fail?, :aborted?, :warning?, :info_warning?, :output,
       :assumeyes?, :whitelisted?, :ask_decision,
       :execution, :puts, :print, :with_spinner, :ask, :storage
 
@@ -89,6 +89,10 @@ module ForemanMaintain
 
     def set_warn(message)
       set_status(:warning, message)
+    end
+
+    def set_info_warn(message)
+      set_status(:info_warning, message)
     end
 
     def set_skip(message)

--- a/lib/foreman_maintain/reporter/cli_reporter.rb
+++ b/lib/foreman_maintain/reporter/cli_reporter.rb
@@ -276,7 +276,8 @@ module ForemanMaintain
                     :running => { :label => '[RUNNING]', :color => :blue },
                     :skipped => { :label => '[SKIPPED]', :color => :yellow },
                     :already_run => { :label => '[ALREADY RUN]', :color => :yellow },
-                    :warning => { :label => '[WARNING]', :color => :yellow } }
+                    :warning => { :label => '[WARNING]', :color => :yellow },
+                    :info_warning => { :label => '[WARNING]', :color => :yellow } }
         properties = mapping[status]
         if @plaintext
           properties[:label]

--- a/lib/foreman_maintain/runner/execution.rb
+++ b/lib/foreman_maintain/runner/execution.rb
@@ -63,6 +63,10 @@ module ForemanMaintain
         @status == :warning
       end
 
+      def info_warning?
+        @status == :info_warning
+      end
+
       # yaml storage to preserve key/value pairs between runs.
       def storage
         @storage || ForemanMaintain.storage(:default)

--- a/lib/foreman_maintain/scenario.rb
+++ b/lib/foreman_maintain/scenario.rb
@@ -119,6 +119,10 @@ module ForemanMaintain
       filter_whitelisted(executed_steps.find_all(&:warning?), options)
     end
 
+    def steps_with_info_warning(options = {})
+      filter_whitelisted(executed_steps.find_all(&:info_warning?), options)
+    end
+
     def steps_with_skipped(options = {})
       filter_whitelisted(executed_steps.find_all(&:skipped?), options)
     end
@@ -141,6 +145,10 @@ module ForemanMaintain
 
     def warning?
       !steps_with_warning(:whitelisted => false).empty?
+    end
+
+    def info_warning?
+      !steps_with_info_warning(:whitelisted => false).empty?
     end
 
     def failed?


### PR DESCRIPTION
When a reboot is required we want to bring attention to it via a warning but we do not want to fail the upgrade. This introduces a new option to issue a informational warning that still exits 0.