### PR TITLE
Fixes #37175: Add dedicated update command

### DIFF
--- a/definitions/checks/repositories/validate.rb
+++ b/definitions/checks/repositories/validate.rb
@@ -12,7 +12,7 @@ module Checks::Repositories
 
       param :version,
         'Version for which repositories needs to be validated',
-        :required => true
+        :required => false
 
       manual_detection
     end
@@ -21,6 +21,8 @@ module Checks::Repositories
       if feature(:instance).downstream.subscribed_using_activation_key?
         skip 'Your system is subscribed using custom activation key'
       else
+        @version ||= package_version(feature(:instance).downstream.package_name)
+
         with_spinner("Validating availability of repositories for #{@version}") do |spinner|
           find_absent_repos(spinner)
         end

--- a/definitions/scenarios/update.rb
+++ b/definitions/scenarios/update.rb
@@ -1,0 +1,126 @@
+module Scenarios::Update
+  class Abstract < ForemanMaintain::Scenario
+    def self.update_metadata(&block)
+      metadata do
+        tags :update_scenario
+        instance_eval(&block)
+      end
+    end
+  end
+
+  class PreUpdateCheck < Abstract
+    update_metadata do
+      description 'Checks before updating'
+      tags :pre_update_checks
+      run_strategy :fail_slow
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    def compose
+      add_steps(
+        Checks::Foreman::FactsNames, # if Foreman database present
+        Checks::ForemanProxy::CheckTftpStorage, # if Satellite with foreman-proxy+tftp
+        Checks::ForemanProxy::VerifyDhcpConfigSyntax, # if foreman-proxy+dhcp-isc
+        Checks::ForemanTasks::NotPaused, # if foreman-tasks present
+        Checks::Puppet::VerifyNoEmptyCacertRequests, # if puppetserver
+        Checks::ServerPing,
+        Checks::ServicesUp,
+        Checks::SystemRegistration,
+        Checks::CheckHotfixInstalled,
+        Checks::CheckTmout,
+        Checks::CheckUpstreamRepository,
+        Checks::Disk::AvailableSpace,
+        Checks::Disk::AvailableSpaceCandlepin, # if candlepin
+        Checks::Foreman::ValidateExternalDbVersion, # if external database
+        Checks::Foreman::CheckCorruptedRoles,
+        Checks::Foreman::CheckDuplicatePermissions,
+        Checks::Foreman::TuningRequirements, # if katello present
+        Checks::ForemanOpenscap::InvalidReportAssociations, # if foreman-openscap
+        Checks::ForemanTasks::Invalid::CheckOld, # if foreman-tasks
+        Checks::ForemanTasks::Invalid::CheckPendingState, # if foreman-tasks
+        Checks::ForemanTasks::Invalid::CheckPlanningState, # if foreman-tasks
+        Checks::ForemanTasks::NotRunning, # if foreman-tasks
+        Checks::NonRhPackages,
+        Checks::PackageManager::Dnf::ValidateDnfConfig,
+        Checks::Repositories::CheckNonRhRepository,
+        Checks::Repositories::Validate
+      )
+    end
+    # rubocop:enable Metrics/MethodLength
+  end
+
+  class PreMigrations < Abstract
+    update_metadata do
+      description 'Procedures before migrating'
+      tags :pre_migrations
+    end
+
+    def compose
+      add_steps(
+        Procedures::Packages::Update.new(
+          :assumeyes => true,
+          :dnf_options => ['--downloadonly']
+        ),
+        Procedures::MaintenanceMode::EnableMaintenanceMode,
+        Procedures::Crond::Stop,
+        Procedures::SyncPlans::Disable
+      )
+    end
+  end
+
+  class Migrations < Abstract
+    update_metadata do
+      description 'Migration scripts'
+      tags :migrations
+      run_strategy :fail_fast
+    end
+
+    def compose
+      add_steps(
+        Procedures::Service::Stop,
+        Procedures::Packages::Update.new(:assumeyes => true, :clean_cache => false),
+        Procedures::Installer::Run.new(:assumeyes => true),
+        Procedures::Installer::UpgradeRakeTask
+      )
+    end
+  end
+
+  class PostMigrations < Abstract
+    update_metadata do
+      description 'Procedures after migrating'
+      tags :post_migrations
+    end
+
+    def compose
+      add_steps(
+        Procedures::RefreshFeatures,
+        Procedures::Service::Start,
+        Procedures::Crond::Start,
+        Procedures::SyncPlans::Enable,
+        Procedures::MaintenanceMode::DisableMaintenanceMode
+      )
+    end
+  end
+
+  class PostUpdateChecks < Abstract
+    update_metadata do
+      description 'Checks after update'
+      tags :post_update_checks
+      run_strategy :fail_slow
+    end
+
+    def compose
+      add_steps(
+        Checks::Foreman::FactsNames, # if Foreman database present
+        Checks::ForemanProxy::CheckTftpStorage, # if Satellite with foreman-proxy+tftp
+        Checks::ForemanProxy::VerifyDhcpConfigSyntax, # if foreman-proxy+dhcp-isc
+        Checks::ForemanTasks::NotPaused, # if foreman-tasks present
+        Checks::Puppet::VerifyNoEmptyCacertRequests, # if puppetserver
+        Checks::ServerPing,
+        Checks::ServicesUp,
+        Checks::SystemRegistration,
+        Procedures::Packages::CheckForReboot
+      )
+    end
+  end
+end

--- a/lib/foreman_maintain/cli.rb
+++ b/lib/foreman_maintain/cli.rb
@@ -12,6 +12,7 @@ require 'foreman_maintain/cli/maintenance_mode_command'
 require 'foreman_maintain/cli/packages_command'
 require 'foreman_maintain/cli/plugin_command'
 require 'foreman_maintain/cli/self_upgrade_command'
+require 'foreman_maintain/cli/update_command'
 
 Clamp.allow_options_after_parameters = true
 
@@ -22,6 +23,7 @@ module ForemanMaintain
 
       subcommand 'health', 'Health related commands', HealthCommand
       subcommand 'upgrade', 'Upgrade related commands', UpgradeCommand
+      subcommand 'update', 'Update related commands', UpdateCommand
       subcommand 'service', 'Control applicable services', ServiceCommand
       subcommand 'backup', 'Backup server', BackupCommand
       subcommand 'restore', 'Restore a backup', RestoreCommand

--- a/lib/foreman_maintain/cli/update_command.rb
+++ b/lib/foreman_maintain/cli/update_command.rb
@@ -1,0 +1,48 @@
+require 'foreman_maintain/update_runner'
+
+module ForemanMaintain
+  module Cli
+    class UpdateCommand < Base
+      def self.disable_self_update_option
+        option '--disable-self-update', :flag, 'Disable automatic self update',
+          :default => false
+      end
+
+      def update_runner
+        update_runner = ForemanMaintain::UpdateRunner.new(
+          reporter,
+          :assumeyes => assumeyes?,
+          :whitelist => whitelist || [],
+          :force => force?
+        )
+        update_runner.load
+        update_runner
+      end
+
+      subcommand 'check', 'Run pre-update checks before updating' do
+        interactive_option
+        disable_self_update_option
+
+        def execute
+          ForemanMaintain.validate_downstream_packages
+          ForemanMaintain.perform_self_upgrade unless disable_self_update?
+          update_runner.run_phase(:pre_update_checks)
+          exit update_runner.exit_code
+        end
+      end
+
+      subcommand 'run', 'Run an update' do
+        interactive_option
+        disable_self_update_option
+
+        def execute
+          ForemanMaintain.validate_downstream_packages
+          ForemanMaintain.perform_self_upgrade unless disable_self_update?
+          update_runner.run
+          update_runner.save
+          exit update_runner.exit_code
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/executable.rb
+++ b/lib/foreman_maintain/executable.rb
@@ -138,7 +138,11 @@ module ForemanMaintain
     def __run__(execution)
       setup_execution_state(execution)
       unless skipped?
-        run
+        if defined?(self.class.present?)
+          run if self.class.present?
+        else
+          run
+        end
       end
     rescue Error::Skip => e
       set_skip(e.message)

--- a/lib/foreman_maintain/package_manager/dnf.rb
+++ b/lib/foreman_maintain/package_manager/dnf.rb
@@ -133,7 +133,7 @@ module ForemanMaintain::PackageManager
 
     private
 
-    # rubocop:disable Metrics/LineLength, Metrics/ParameterLists
+    # rubocop:disable Layout/LineLength, Metrics/ParameterLists
     def dnf_action(action, packages, with_status: false, assumeyes: false, dnf_options: [], valid_exit_statuses: [0], download_only: false)
       packages = [packages].flatten(1)
 
@@ -159,7 +159,7 @@ module ForemanMaintain::PackageManager
         )
       end
     end
-    # rubocop:enable Metrics/LineLength, Metrics/ParameterLists
+    # rubocop:enable Layout/LineLength, Metrics/ParameterLists
 
     def protector_config
       File.exist?(protector_config_file) ? File.read(protector_config_file) : ''

--- a/lib/foreman_maintain/scenario.rb
+++ b/lib/foreman_maintain/scenario.rb
@@ -163,14 +163,14 @@ module ForemanMaintain
       scenarios
     end
 
-    def add_steps(steps)
-      steps.each do |step|
+    def add_steps(*steps)
+      steps.flatten.each do |step|
         self.steps << step.ensure_instance
       end
     end
 
     def add_step(step)
-      add_steps([step]) unless step.nil?
+      add_steps(step) unless step.nil?
     end
 
     def add_step_with_context(definition, extra_params = {})

--- a/lib/foreman_maintain/update_runner.rb
+++ b/lib/foreman_maintain/update_runner.rb
@@ -1,0 +1,156 @@
+module ForemanMaintain
+  class UpdateRunner < Runner
+    include Concerns::Finders
+
+    PHASES = [
+      :pre_update_checks,
+      :pre_migrations,
+      :migrations,
+      :post_migrations,
+      :post_update_checks,
+    ].freeze
+
+    attr_reader :phase
+
+    def initialize(reporter, options = {})
+      super(reporter, [], options)
+      @scenario_cache = {}
+      self.phase = :pre_update_checks
+    end
+
+    def find_scenario(phase)
+      return @scenario_cache[phase] if @scenario_cache.key?(phase)
+
+      condition = { :tags => [:update_scenario, phase] }
+      matching_scenarios = find_scenarios(condition)
+      @scenario_cache[phase] = matching_scenarios.first
+    end
+
+    def run
+      PHASES.each do |phase|
+        return run_rollback if quit?
+
+        run_phase(phase)
+      end
+
+      finish_update unless quit?
+    end
+
+    def run_rollback
+      # we only are able to rollback from pre_migrations phase
+      if phase == :pre_migrations
+        rollback_pre_migrations
+      end
+    end
+
+    def finish_update
+      @finished = true
+      @reporter.hline
+      @reporter.puts("Update finished.")
+    end
+
+    def storage
+      ForemanMaintain.storage("update")
+    end
+
+    # serializes the state of the run to storage
+    def save
+      if @finished
+        storage.delete(:serialized)
+      else
+        storage[:serialized] = to_hash
+      end
+      storage.save
+    end
+
+    # deserializes the state of the run from the storage
+    def load
+      return unless storage[:serialized]
+
+      load_from_hash(storage[:serialized])
+    end
+
+    def run_phase(phase)
+      scenario = find_scenario(phase)
+      return if scenario.nil? || scenario.steps.empty?
+
+      confirm_scenario(scenario)
+      return if quit?
+
+      self.phase = phase
+      run_scenario(scenario)
+      # if we started from the :pre_update_checks, ensure to ask before
+      # continuing with the rest of the update
+      @ask_to_confirm_update = phase == :pre_update_checks
+    end
+
+    private
+
+    def rollback_pre_migrations
+      raise "Unexpected phase #{phase}, expecting pre_migrations" unless phase == :pre_migrations
+
+      rollback_needed = scenario(:pre_migrations).steps.any? { |s| s.executed? && s.success? }
+      if rollback_needed
+        @quit = false
+        # prevent the unnecessary confirmation questions
+        @last_scenario = nil
+        @last_scenario_continuation_confirmed = true
+        [:post_migrations, :post_update_checks].each do |phase|
+          run_phase(phase)
+        end
+      end
+      self.phase = :pre_update_checks # rollback finished
+      @reporter.puts("The update failed and system was restored to pre-update state.")
+    end
+
+    def with_non_empty_scenario(phase)
+      next_scenario = scenario(phase)
+      unless next_scenario.nil? || next_scenario.steps.empty?
+        yield next_scenario
+      end
+    end
+
+    def to_hash
+      ret = { :phase => phase, :scenarios => {} }
+      @scenario_cache.each do |key, scenario|
+        ret[:scenarios][key] = scenario.to_hash
+      end
+      ret
+    end
+
+    def load_from_hash(hash)
+      unless @scenario_cache.empty?
+        raise "Some scenarios are already initialized: #{@scenario_cache.keys}"
+      end
+
+      self.phase = hash[:phase]
+      hash[:scenarios].each do |key, scenario_hash|
+        @scenario_cache[key] = Scenario.new_from_hash(scenario_hash)
+      end
+    end
+
+    def confirm_scenario(scenario)
+      decision = super(scenario)
+      # we have not asked the user already about next steps
+      if decision.nil? && @ask_to_confirm_update
+        response = reporter.ask_decision(<<-MESSAGE.strip_heredoc.strip)
+            The pre-update checks indicate that the system is ready for update.
+            It's recommended to perform a backup at this stage.
+            Confirm to continue with the modification part of the update
+        MESSAGE
+        if [:no, :quit].include?(response)
+          ask_to_quit
+        end
+      end
+      response
+    ensure
+      @ask_to_confirm_update = false
+    end
+
+    def phase=(phase)
+      raise "Unknown phase #{phase}" unless PHASES.include?(phase)
+
+      @phase = phase
+    end
+  end
+end

--- a/test/definitions/checks/disk/available_space_postgresql13_test.rb
+++ b/test/definitions/checks/disk/available_space_postgresql13_test.rb
@@ -6,7 +6,9 @@ describe Checks::Disk::AvailableSpacePostgresql13 do
   let(:check) { described_class.new }
 
   before do
-    assume_feature_present(:foreman_database)
+    assume_feature_present(:instance) do |feature|
+      feature.any_instance.stubs(:postgresql_local?).returns(true)
+    end
   end
 
   it 'executes successfully for disks with sufficient space' do

--- a/test/definitions/checks/foreman/check_corrupted_roles_test.rb
+++ b/test/definitions/checks/foreman/check_corrupted_roles_test.rb
@@ -7,8 +7,12 @@ describe Checks::Foreman::CheckCorruptedRoles do
     Checks::Foreman::CheckCorruptedRoles.new
   end
 
+  before do
+    subject.class.expects(:present?).returns(true)
+  end
+
   it 'passes when no corupted roles detected' do
-    assume_feature_present(:foreman_database, :query => [])
+    subject.expects(:find_filter_permissions).returns([])
     result = run_check(subject)
     assert result.success?, 'Check expected to succeed'
   end

--- a/test/definitions/checks/system_registration_test.rb
+++ b/test/definitions/checks/system_registration_test.rb
@@ -13,7 +13,8 @@ describe Checks::SystemRegistration do
     let(:rhsm_hostname_cmd) { "grep '\\bhostname\\b' < /etc/rhsm/rhsm.conf" }
 
     before do
-      subject.stubs(:file_exists?).returns(true)
+      subject.class.stubs(:file_exists?).returns(true)
+      subject.class.expects(:present?).returns(true)
     end
 
     context 'smart-proxy' do

--- a/test/definitions/procedures/foreman_tasks/ui_investigate_test.rb
+++ b/test/definitions/procedures/foreman_tasks/ui_investigate_test.rb
@@ -7,6 +7,10 @@ describe Procedures::ForemanTasks::Resume do
     Procedures::ForemanTasks::UiInvestigate.new('search_query' => 'state = paused')
   end
 
+  before do
+    assume_feature_present(:foreman_tasks)
+  end
+
   it 'prints information about where to look in UI for resolving the problem' do
     subject.stubs(:hostname => 'example.com')
     result = run_procedure(subject)

--- a/test/lib/cli/update_command_test.rb
+++ b/test/lib/cli/update_command_test.rb
@@ -1,0 +1,149 @@
+require 'test_helper'
+require 'foreman_maintain'
+
+module ForemanMaintain
+  include CliAssertions
+  describe Cli::UpdateCommand do
+    include CliAssertions
+    before do
+      ForemanMaintain.stubs(:el?).returns(true)
+      ForemanMaintain.detector.refresh
+    end
+
+    def foreman_maintain_update_available
+      PackageManagerTestHelper.mock_package_manager
+      FakePackageManager.any_instance.stubs(:update).with('rubygem-foreman_maintain',
+        :assumeyes => true).returns(true)
+      # rubocop:disable Layout/LineLength
+      FakePackageManager.any_instance.stubs(:update_available?).with('rubygem-foreman_maintain').returns(true)
+      # rubocop:enable Layout/LineLength
+    end
+
+    def foreman_maintain_update_unavailable
+      PackageManagerTestHelper.mock_package_manager
+      # rubocop:disable Layout/LineLength
+      FakePackageManager.any_instance.stubs(:update_available?).with('rubygem-foreman_maintain').returns(false)
+      # rubocop:enable Layout/LineLength
+    end
+
+    describe 'help' do
+      let :command do
+        %w[update]
+      end
+
+      it 'prints help' do
+        assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
+          Usage:
+              foreman-maintain update [OPTIONS] SUBCOMMAND [ARG] ...
+
+          Parameters:
+              SUBCOMMAND                    subcommand
+              [ARG] ...                     subcommand arguments
+
+          Subcommands:
+              check                         Run pre-update checks before updating
+              run                           Run an update
+
+          Options:
+              -h, --help                    print help
+        OUTPUT
+      end
+    end
+
+    describe 'check' do
+      let :command do
+        %w[update check]
+      end
+
+      it 'should raise UsageError and exit with code 1' do
+        Cli::MainCommand.any_instance.stubs(:exit!)
+
+        run_cmd([])
+      end
+
+      it 'run self update if update available for foreman-maintain' do
+        foreman_maintain_update_available
+        assert_cmd <<-OUTPUT.strip_heredoc
+        Checking for new version of rubygem-foreman_maintain...
+
+        Updating rubygem-foreman_maintain package.
+
+        The rubygem-foreman_maintain package successfully updated.
+        Re-run foreman-maintain with required options!
+        OUTPUT
+      end
+
+      it 'runs the update checks when update is not available for foreman-maintain' do
+        foreman_maintain_update_unavailable
+        UpdateRunner.any_instance.expects(:run_phase).with(:pre_update_checks)
+        assert_cmd <<-OUTPUT.strip_heredoc
+        Checking for new version of rubygem-foreman_maintain...
+        Nothing to update, can't find new version of rubygem-foreman_maintain.
+        OUTPUT
+      end
+
+      it 'runs the update checks for version with disable-self-update' do
+        foreman_maintain_update_available
+        command << '--disable-self-update'
+        UpdateRunner.any_instance.expects(:run_phase).with(:pre_update_checks)
+        run_cmd
+      end
+    end
+
+    describe 'run' do
+      let :command do
+        %w[update run]
+      end
+
+      it 'run self update if update available for foreman-maintain' do
+        foreman_maintain_update_available
+        assert_cmd <<-OUTPUT.strip_heredoc
+        Checking for new version of rubygem-foreman_maintain...
+
+        Updating rubygem-foreman_maintain package.
+
+        The rubygem-foreman_maintain package successfully updated.
+        Re-run foreman-maintain with required options!
+        OUTPUT
+      end
+
+      it 'runs the update when update is not available for foreman-maintain' do
+        foreman_maintain_update_unavailable
+        UpdateRunner.any_instance.expects(:run)
+        assert_cmd <<-OUTPUT.strip_heredoc
+        Checking for new version of rubygem-foreman_maintain...
+        Nothing to update, can't find new version of rubygem-foreman_maintain.
+        OUTPUT
+      end
+
+      it 'skip self update and runs the full update for version' do
+        command << '--disable-self-update'
+        UpdateRunner.any_instance.expects(:run)
+        run_cmd
+      end
+
+      it 'runs the self update when update available for rubygem-foreman_maintain' do
+        foreman_maintain_update_available
+        assert_cmd <<-OUTPUT.strip_heredoc
+        Checking for new version of rubygem-foreman_maintain...
+
+        Updating rubygem-foreman_maintain package.
+
+        The rubygem-foreman_maintain package successfully updated.
+        Re-run foreman-maintain with required options!
+        OUTPUT
+
+        run_cmd
+
+        assert_cmd(<<-OUTPUT.strip_heredoc)
+        Checking for new version of rubygem-foreman_maintain...
+
+        Updating rubygem-foreman_maintain package.
+
+        The rubygem-foreman_maintain package successfully updated.
+        Re-run foreman-maintain with required options!
+        OUTPUT
+      end
+    end
+  end
+end

--- a/test/lib/cli_test.rb
+++ b/test/lib/cli_test.rb
@@ -22,6 +22,7 @@ module ForemanMaintain
         Subcommands:
             health                        Health related commands
             upgrade                       Upgrade related commands
+            update                        Update related commands
             service                       Control applicable services
             backup                        Backup server
             restore                       Restore a backup


### PR DESCRIPTION
This changes adds a dedicated command for z-stream style updates and is intended to be run like:

```
foreman-maintain update run
```

This introduces a dedicated update scenario intended to work for all installation scenarios letting the various checks and processes handle the state of the system (e.g. what installer scenario is present). This does not remove using the upgrade command to do a z-stream "upgrade" as my goal is to introduce a new update command alongside these first before doing major demolition.

I am putting this in draft status for now in order to add testing.