### PR TITLE
Use fetch in block form when retrieving the hostname

### DIFF
--- a/lib/foreman_maintain/config.rb
+++ b/lib/foreman_maintain/config.rb
@@ -21,7 +21,7 @@ module ForemanMaintain
         @options.fetch(:completion_cache_file, '~/.cache/foreman_maintain_completion.yml')
       )
       @disable_commands = @options.fetch(:disable_commands, [])
-      @foreman_url = @options.fetch(:foreman_url, `hostname -f`.chomp)
+      @foreman_url = @options.fetch(:foreman_url) { `hostname -f`.chomp }
       @foreman_port = @options.fetch(:foreman_port, 443)
     end
 


### PR DESCRIPTION
This avoids executing hostname unconditionally and is now only called when it's needed.