### PR TITLE
Fixes #37357 - Add container migration to upgrade

### DIFF
--- a/definitions/procedures/pulpcore/container_handle_image_metadata.rb
+++ b/definitions/procedures/pulpcore/container_handle_image_metadata.rb
@@ -1,0 +1,23 @@
+module Procedures::Pulpcore
+  class ContainerHandleImageMetadata < ForemanMaintain::Procedure
+    include ForemanMaintain::Concerns::SystemService
+    include ForemanMaintain::Concerns::PulpCommon
+
+    metadata do
+      description 'Initialize and expose container image metadata in the pulpcore db'
+      for_feature :pulpcore
+    end
+
+    def run
+      with_spinner('Initialize and expose container image metadata in the pulpcore db') do |spinner|
+        necessary_services = feature(:pulpcore_database).services
+
+        feature(:service).handle_services(spinner, 'start', :only => necessary_services)
+
+        spinner.update('Adding image metadata to pulp. You can continue using the ' \
+               'system normally while the task runs in the background.')
+        execute!(pulpcore_manager('container-handle-image-data'))
+      end
+    end
+  end
+end

--- a/definitions/scenarios/foreman_upgrade.rb
+++ b/definitions/scenarios/foreman_upgrade.rb
@@ -134,7 +134,8 @@ module Scenarios::ForemanUpgrade
         Checks::ServerPing,
         Checks::ServicesUp,
         Checks::SystemRegistration,
-        Procedures::Packages::CheckForReboot
+        Procedures::Packages::CheckForReboot,
+        Procedures::Pulpcore::ContainerHandleImageMetadata
       )
     end
   end

--- a/definitions/scenarios/upgrade_to_capsule_6_16.rb
+++ b/definitions/scenarios/upgrade_to_capsule_6_16.rb
@@ -95,6 +95,7 @@ module Scenarios::Capsule_6_16
       add_steps(find_checks(:default))
       add_steps(find_checks(:post_upgrade))
       add_step(Procedures::Packages::CheckForReboot)
+      add_step(Procedures::Pulpcore::ContainerHandleImageMetadata)
     end
   end
 end

--- a/definitions/scenarios/upgrade_to_satellite_6_16.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_16.rb
@@ -98,6 +98,7 @@ module Scenarios::Satellite_6_16
       add_steps(find_checks(:default))
       add_steps(find_checks(:post_upgrade))
       add_step(Procedures::Packages::CheckForReboot)
+      add_step(Procedures::Pulpcore::ContainerHandleImageMetadata)
     end
   end
 end


### PR DESCRIPTION
Adding container-handle-image-data migration to post-upgrade tasks with upgraded pulp.