### PR TITLE
Check service status in preparation steps before hammer setup

### DIFF
--- a/definitions/procedures/hammer_setup.rb
+++ b/definitions/procedures/hammer_setup.rb
@@ -2,6 +2,9 @@ class Procedures::HammerSetup < ForemanMaintain::Procedure
   metadata do
     description 'Setup hammer'
     for_feature :hammer
+    preparation_steps do
+      Checks::ServicesUp.new
+    end
   end
 
   def run


### PR DESCRIPTION
Before this change a user would just see the following if a service was down:

```
Nothing to update, can't find new version of satellite-maintain.
Running preparation steps required to run the next scenarios
================================================================================
Setup hammer: 
Configuring Hammer CLI...
Hammer admin password: 
                                                                      [FAIL]
Hammer configuration failed: Incorrect credential for admin user.
```

Which is rather confusing as it's not the password that's the problem.