### PR TITLE
Fix update command exit code

### DIFF
--- a/lib/foreman_maintain/cli/update_command.rb
+++ b/lib/foreman_maintain/cli/update_command.rb
@@ -26,8 +26,9 @@ module ForemanMaintain
         def execute
           ForemanMaintain.validate_downstream_packages
           ForemanMaintain.perform_self_upgrade unless disable_self_update?
-          update_runner.run_phase(:pre_update_checks)
-          exit update_runner.exit_code
+          runner = update_runner
+          runner.run_phase(:pre_update_checks)
+          exit runner.exit_code
         end
       end
 
@@ -38,9 +39,10 @@ module ForemanMaintain
         def execute
           ForemanMaintain.validate_downstream_packages
           ForemanMaintain.perform_self_upgrade unless disable_self_update?
-          update_runner.run
-          update_runner.save
-          exit update_runner.exit_code
+          runner = update_runner
+          runner.run
+          runner.save
+          exit runner.exit_code
         end
       end
     end


### PR DESCRIPTION
The previous code was creating a new instance of the UpdateRunner class every time and therefore throwing away the saved exit code.