### PR TITLE
drop Procedures::Packages::Update from foreman premigrations

### DIFF
--- a/definitions/scenarios/foreman_upgrade.rb
+++ b/definitions/scenarios/foreman_upgrade.rb
@@ -64,10 +64,6 @@ module Scenarios::ForemanUpgrade
 
     def compose
       add_steps(
-        Procedures::Packages::Update.new(
-          :assumeyes => true,
-          :dnf_options => ['--downloadonly']
-        ),
         Procedures::MaintenanceMode::EnableMaintenanceMode,
         Procedures::Crond::Stop,
         Procedures::SyncPlans::Disable


### PR DESCRIPTION
this already happens (correctly) in the migrations phase
