### PR TITLE
drop dynflowd support

### DIFF
--- a/definitions/features/foreman_tasks.rb
+++ b/definitions/features/foreman_tasks.rb
@@ -125,14 +125,6 @@ class Features::ForemanTasks < ForemanMaintain::Feature
     puts "\nTimeout: #{e.message}. Try again."
   end
 
-  def services
-    feature(:dynflow_sidekiq) ? [] : [system_service(service_name, 30)]
-  end
-
-  def service_name
-    'dynflowd'
-  end
-
   private
 
   def check_task_count(state, spinner)


### PR DESCRIPTION
we do not deploy dynflowd, only dynflow_sidekiq since
https://projects.theforeman.org/issues/28421 (RPM)
https://projects.theforeman.org/issues/28068 (DEB)
