### PR TITLE
don't backup postgresql.service

### DIFF
--- a/lib/foreman_maintain/concerns/base_database.rb
+++ b/lib/foreman_maintain/concerns/base_database.rb
@@ -41,12 +41,6 @@ module ForemanMaintain
         raise NotImplementedError
       end
 
-      def config_files
-        [
-          '/etc/systemd/system/postgresql.service',
-        ]
-      end
-
       def local?(config = configuration)
         ['localhost', '127.0.0.1', `hostname`.strip].include? config['host']
       end


### PR DESCRIPTION
1/ it's not present in most cases
2/ even if it was, puppet/installer would manage it just fine
