### PR TITLE
don't backup dynflow_sidekiq service symlinks

### DIFF
--- a/definitions/features/dynflow_sidekiq.rb
+++ b/definitions/features/dynflow_sidekiq.rb
@@ -8,14 +8,9 @@ class Features::DynflowSidekiq < ForemanMaintain::Feature
   end
 
   def config_files
-    # Workaround until foreman-installer can deploy scaled workers
-    service_symlinks = configured_instances.map do |service|
-      "/etc/systemd/system/multi-user.target.wants/#{service}.service"
-    end
     [
       '/etc/foreman/dynflow',
-      service_symlinks,
-    ].flatten
+    ]
   end
 
   def services


### PR DESCRIPTION
This was introduced in 8fda535020c58dae1f811d19f757def24596c8da and
later changed in e6547a9a8627d6053f1a120a722c0250d75a5c07 but it never
has matched a file as the symlinks are
`dynflow_sidekiq@<instance>.service` while the code only looked for
`<instance>.service`

Given nobody complained about dynflow not working after a restore in the
last 4 years, I am rather sure we can just not back those up and still
be happy.
