### PR TITLE
don't start services or reload systemd after restore

### DIFF
--- a/definitions/scenarios/restore.rb
+++ b/definitions/scenarios/restore.rb
@@ -51,8 +51,6 @@ module ForemanMaintain::Scenarios
         add_step_with_context(Procedures::Restore::ReindexDatabases)
       end
 
-      add_steps_with_context(Procedures::Service::Start,
-        Procedures::Service::DaemonReload)
       add_step(Procedures::Installer::Run.new(:assumeyes => true))
       add_step_with_context(Procedures::Installer::UpgradeRakeTask)
       add_step_with_context(Procedures::Crond::Start) if feature(:cron)


### PR DESCRIPTION
1/ reloading of systemd should come before starting services
2/ we don't backup any systemd files, so a reload is not required
3/ the installer will start all required services for us
