### PR TITLE
don't make pulpcore optional in backups

### DIFF
--- a/definitions/procedures/restore/drop_databases.rb
+++ b/definitions/procedures/restore/drop_databases.rb
@@ -19,9 +19,7 @@ module Procedures::Restore
         feature(:service).handle_services(spinner, 'start', :only => ['postgresql'])
         drop_foreman(backup, spinner)
         drop_candlepin(backup, spinner)
-        if feature(:pulpcore)
-          drop_pulpcore(backup, spinner)
-        end
+        drop_pulpcore(backup, spinner)
       end
     end
 

--- a/definitions/scenarios/restore.rb
+++ b/definitions/scenarios/restore.rb
@@ -59,9 +59,7 @@ module ForemanMaintain::Scenarios
     # rubocop:enable Metrics/CyclomaticComplexity
 
     def drop_dbs(backup)
-      if backup.file_map[:candlepin_dump][:present] ||
-         backup.file_map[:foreman_dump][:present] ||
-         backup.file_map[:pulpcore_dump][:present]
+      if backup.sql_dump_files_exist?
         add_steps_with_context(Procedures::Restore::DropDatabases)
       end
     end

--- a/definitions/scenarios/restore.rb
+++ b/definitions/scenarios/restore.rb
@@ -61,7 +61,7 @@ module ForemanMaintain::Scenarios
     def drop_dbs(backup)
       if backup.file_map[:candlepin_dump][:present] ||
          backup.file_map[:foreman_dump][:present] ||
-         (feature(:pulpcore) && backup.file_map[:pulpcore_dump][:present])
+         backup.file_map[:pulpcore_dump][:present]
         add_steps_with_context(Procedures::Restore::DropDatabases)
       end
     end
@@ -73,7 +73,7 @@ module ForemanMaintain::Scenarios
       if backup.file_map[:foreman_dump][:present]
         add_steps_with_context(Procedures::Restore::ForemanDump)
       end
-      if feature(:pulpcore) && backup.file_map[:pulpcore_dump][:present]
+      if backup.file_map[:pulpcore_dump][:present]
         add_steps_with_context(Procedures::Restore::PulpcoreDump)
       end
     end

--- a/lib/foreman_maintain/utils/backup.rb
+++ b/lib/foreman_maintain/utils/backup.rb
@@ -226,7 +226,7 @@ module ForemanMaintain
       def sql_dump_files_exist?
         file_map[:foreman_dump][:present] ||
           file_map[:candlepin_dump][:present] ||
-          (feature(:pulpcore_database) && file_map[:pulpcore_dump][:present])
+          file_map[:pulpcore_dump][:present]
       end
 
       def incremental?


### PR DESCRIPTION
when we were in the pulp 2to3 migration, users could end up with backup
that had both pulp2 and pulp3 databases, but only really had to restore
pulp2. now that pulp2 is gone, we can always assume that if a backup has
pulpcore DB, the user wants it restored
