### PR TITLE
Only reindex container metadata on Foreman server

### DIFF
--- a/definitions/procedures/pulpcore/container_handle_image_metadata.rb
+++ b/definitions/procedures/pulpcore/container_handle_image_metadata.rb
@@ -17,9 +17,6 @@ module Procedures::Pulpcore
         spinner.update('Adding image metadata to pulp. You can continue using the ' \
                'system normally while the task runs in the background.')
         execute!(pulpcore_manager('container-handle-image-data'))
-        spinner.update('Adding image metadata to katello. You can continue using the ' \
-               'system normally while the task runs in the background.')
-        execute!('foreman-rake katello:import_container_manifest_labels')
       end
     end
   end

--- a/definitions/procedures/repositories/index_katello_repositories_container_metadata.rb
+++ b/definitions/procedures/repositories/index_katello_repositories_container_metadata.rb
@@ -1,0 +1,17 @@
+module Procedures::Repositories
+  class IndexKatelloRepositoriesContainerMetatdata < ForemanMaintain::Procedure
+    metadata do
+      description 'Import container manifest metadata'
+      confine do
+        feature(:katello)
+      end
+    end
+
+    def run
+      with_spinner(('Adding image metadata. You can continue using the ' \
+                    'system normally while the task runs in the background.')) do
+        execute!('foreman-rake katello:import_container_manifest_labels')
+      end
+    end
+  end
+end

--- a/definitions/scenarios/foreman_upgrade.rb
+++ b/definitions/scenarios/foreman_upgrade.rb
@@ -135,7 +135,8 @@ module Scenarios::ForemanUpgrade
         Checks::ServicesUp,
         Checks::SystemRegistration,
         Procedures::Packages::CheckForReboot,
-        Procedures::Pulpcore::ContainerHandleImageMetadata
+        Procedures::Pulpcore::ContainerHandleImageMetadata,
+        Procedures::Repositories::IndexKatelloRepositoriesContainerMetatdata
       )
     end
   end

--- a/definitions/scenarios/satellite_upgrade.rb
+++ b/definitions/scenarios/satellite_upgrade.rb
@@ -99,6 +99,7 @@ module Scenarios::Satellite
       add_steps(find_checks(:post_upgrade))
       add_step(Procedures::Packages::CheckForReboot)
       add_step(Procedures::Pulpcore::ContainerHandleImageMetadata)
+      add_step(Procedures::Repositories::IndexKatelloRepositoriesContainerMetatdata)
     end
   end
 end


### PR DESCRIPTION
We need to confine katello db indexing to run only on Satellite and not capsules. Refactoring a little to do that.