### PR TITLE
Don't disable maintenance mode in BackupRescue scenario

### DIFF
--- a/definitions/scenarios/backup.rb
+++ b/definitions/scenarios/backup.rb
@@ -136,7 +136,6 @@ module ForemanMaintain::Scenarios
     def compose
       if strategy == :offline
         add_step_with_context(Procedures::Service::Start)
-        add_steps_with_context(find_procedures(:maintenance_mode_off))
       end
       add_step_with_context(Procedures::Backup::Clean)
     end


### PR DESCRIPTION
We don't enable maintenance mode anymore for backups, so we don't need
to disable it.

Fixes: f0e78f70b57fd357ba5c302709f23e45602d5b73
