### PR TITLE
don't fail when chown to postgres fails

### DIFF
--- a/definitions/procedures/backup/prepare_directory.rb
+++ b/definitions/procedures/backup/prepare_directory.rb
@@ -6,6 +6,7 @@ module Procedures::Backup
       param :backup_dir, 'Directory where to backup to', :required => true
       param :preserve_dir, 'Directory where to backup to', :flag => true
       param :incremental_dir, 'Changes since specified backup only'
+      param :online_backup, 'Select for online backup', :flag => true, :default => false
     end
 
     def run
@@ -15,7 +16,7 @@ module Procedures::Backup
         FileUtils.mkdir_p @backup_dir
         FileUtils.chmod_R 0o770, @backup_dir
 
-        if feature(:instance).postgresql_local?
+        if feature(:instance).postgresql_local? && @online_backup
           FileUtils.chown_R(nil, 'postgres', @backup_dir)
         end
       end

--- a/definitions/procedures/backup/prepare_directory.rb
+++ b/definitions/procedures/backup/prepare_directory.rb
@@ -11,9 +11,9 @@ module Procedures::Backup
 
     # rubocop:disable Metrics/MethodLength
     def run
-      puts "Creating backup folder #{@backup_dir}"
-
       unless @preserve_dir
+        puts "Creating backup folder #{@backup_dir}"
+
         FileUtils.mkdir_p @backup_dir
         FileUtils.chmod_R 0o770, @backup_dir
 

--- a/definitions/procedures/backup/prepare_directory.rb
+++ b/definitions/procedures/backup/prepare_directory.rb
@@ -14,10 +14,10 @@ module Procedures::Backup
       unless @preserve_dir
         FileUtils.mkdir_p @backup_dir
         FileUtils.chmod_R 0o770, @backup_dir
-      end
 
-      if feature(:instance).postgresql_local? && !@preserve_dir
-        FileUtils.chown_R(nil, 'postgres', @backup_dir)
+        if feature(:instance).postgresql_local?
+          FileUtils.chown_R(nil, 'postgres', @backup_dir)
+        end
       end
 
       FileUtils.rm(Dir.glob(File.join(@backup_dir, '.*.snar'))) if @preserve_dir

--- a/definitions/scenarios/backup.rb
+++ b/definitions/scenarios/backup.rb
@@ -20,7 +20,8 @@ module ForemanMaintain::Scenarios
       check_valid_strategy
       safety_confirmation
       add_step_with_context(Procedures::Backup::AccessibilityConfirmation) if strategy == :offline
-      add_step_with_context(Procedures::Backup::PrepareDirectory)
+      add_step_with_context(Procedures::Backup::PrepareDirectory,
+        :online_backup => strategy == :online)
       add_step_with_context(Procedures::Backup::Metadata, :online_backup => strategy == :online)
 
       case strategy

--- a/test/definitions/procedures/backup/prepare_directory_test.rb
+++ b/test/definitions/procedures/backup/prepare_directory_test.rb
@@ -1,0 +1,63 @@
+require 'test_helper'
+
+describe Procedures::Backup::PrepareDirectory do
+  include DefinitionsTestHelper
+
+  let(:backup_dir) { '/mnt/backup' }
+
+  context 'with default params' do
+    subject do
+      Procedures::Backup::PrepareDirectory.new(:backup_dir => backup_dir)
+    end
+
+    it 'creates backup directory for local DB' do
+      assume_feature_present(:instance, :postgresql_local? => true)
+
+      FileUtils.expects(:mkdir_p).with(backup_dir).once
+      FileUtils.expects(:chmod_R).with(0o770, backup_dir).once
+      FileUtils.expects(:chown_R).with(nil, 'postgres', backup_dir).once
+
+      result = run_procedure(subject)
+      assert result.success?, 'the procedure was expected to succeed'
+    end
+
+    it 'creates backup directory for remote DB' do
+      assume_feature_present(:instance, :postgresql_local? => false)
+
+      FileUtils.expects(:mkdir_p).with(backup_dir).once
+      FileUtils.expects(:chmod_R).with(0o770, backup_dir).once
+      FileUtils.expects(:chown_R).with(nil, 'postgres', backup_dir).never
+
+      result = run_procedure(subject)
+      assert result.success?, 'the procedure was expected to succeed'
+    end
+  end
+
+  context 'with preserve_dir=>true' do
+    subject do
+      Procedures::Backup::PrepareDirectory.new(:backup_dir => backup_dir, :preserve_dir => true)
+    end
+
+    it 'does not create backup directory for local DB' do
+      assume_feature_present(:instance, :postgresql_local? => true)
+
+      FileUtils.expects(:mkdir_p).with(backup_dir).never
+      FileUtils.expects(:chmod_R).with(0o770, backup_dir).never
+      FileUtils.expects(:chown_R).with(nil, 'postgres', backup_dir).never
+
+      result = run_procedure(subject)
+      assert result.success?, 'the procedure was expected to succeed'
+    end
+
+    it 'does not create backup directory for remote DB' do
+      assume_feature_present(:instance, :postgresql_local? => false)
+
+      FileUtils.expects(:mkdir_p).with(backup_dir).never
+      FileUtils.expects(:chmod_R).with(0o770, backup_dir).never
+      FileUtils.expects(:chown_R).with(nil, 'postgres', backup_dir).never
+
+      result = run_procedure(subject)
+      assert result.success?, 'the procedure was expected to succeed'
+    end
+  end
+end

--- a/test/definitions/procedures/backup/prepare_directory_test.rb
+++ b/test/definitions/procedures/backup/prepare_directory_test.rb
@@ -15,6 +15,34 @@ describe Procedures::Backup::PrepareDirectory do
 
       FileUtils.expects(:mkdir_p).with(backup_dir).once
       FileUtils.expects(:chmod_R).with(0o770, backup_dir).once
+      FileUtils.expects(:chown_R).with(nil, 'postgres', backup_dir).never
+
+      result = run_procedure(subject)
+      assert result.success?, 'the procedure was expected to succeed'
+    end
+
+    it 'creates backup directory for remote DB' do
+      assume_feature_present(:instance, :postgresql_local? => false)
+
+      FileUtils.expects(:mkdir_p).with(backup_dir).once
+      FileUtils.expects(:chmod_R).with(0o770, backup_dir).once
+      FileUtils.expects(:chown_R).with(nil, 'postgres', backup_dir).never
+
+      result = run_procedure(subject)
+      assert result.success?, 'the procedure was expected to succeed'
+    end
+  end
+
+  context 'with online_backup=>true' do
+    subject do
+      Procedures::Backup::PrepareDirectory.new(:backup_dir => backup_dir, :online_backup => true)
+    end
+
+    it 'creates backup directory for local DB' do
+      assume_feature_present(:instance, :postgresql_local? => true)
+
+      FileUtils.expects(:mkdir_p).with(backup_dir).once
+      FileUtils.expects(:chmod_R).with(0o770, backup_dir).once
       FileUtils.expects(:chown_R).with(nil, 'postgres', backup_dir).once
 
       result = run_procedure(subject)


### PR DESCRIPTION
- **add prepare directory tests**
- **move chown postgres inside unless preserve**
- **only chown to postgres group for online backups with local DB**
- **don't fail when chown to postgres fails**
