### PR TITLE
don't fail upstream update with "undefined method `current_minor_version'"

### DIFF
--- a/definitions/scenarios/satellite_upgrade.rb
+++ b/definitions/scenarios/satellite_upgrade.rb
@@ -4,7 +4,7 @@ module Scenarios::Satellite
       metadata do
         tags :upgrade_scenario
         confine do
-          (feature(:instance).downstream.current_minor_version == '6.15' || \
+          (feature(:instance).downstream&.current_minor_version == '6.15' || \
             ForemanMaintain.upgrade_in_progress == '6.16')
         end
         instance_eval(&block)


### PR DESCRIPTION
    [root@centos8-stream-katello-nightly ~]# foreman-maintain update check
    Checking for new version of rubygem-foreman_maintain...
    Nothing to update, can't find new version of rubygem-foreman_maintain.
    undefined method `current_minor_version' for nil:NilClass

    I, [2024-06-25 11:46:51+0000 #12497]  INFO -- : Running foreman-maintain command with arguments [["update", "check"]]
    E, [2024-06-25 11:46:54+0000 #12497] ERROR -- : undefined method `current_minor_version' for nil:NilClass (NoMethodError)
    /usr/share/gems/gems/foreman_maintain-1.6.10/definitions/scenarios/satellite_upgrade.rb:7:in `block (2 levels) in upgrade_metadata'
    /usr/share/gems/gems/foreman_maintain-1.6.10/lib/foreman_maintain/concerns/metadata.rb:230:in `instance_exec'
    /usr/share/gems/gems/foreman_maintain-1.6.10/lib/foreman_maintain/concerns/metadata.rb:230:in `block in evaluate_confines'
    /usr/share/gems/gems/foreman_maintain-1.6.10/lib/foreman_maintain/concerns/metadata.rb:229:in `all?'
    /usr/share/gems/gems/foreman_maintain-1.6.10/lib/foreman_maintain/concerns/metadata.rb:229:in `evaluate_confines'
    /usr/share/gems/gems/foreman_maintain-1.6.10/lib/foreman_maintain/concerns/metadata.rb:204:in `present?'
    /usr/share/gems/gems/foreman_maintain-1.6.10/lib/foreman_maintain/detector.rb:62:in `block in available_scenarios'
    /usr/share/gems/gems/foreman_maintain-1.6.10/lib/foreman_maintain/detector.rb:61:in `select'
    /usr/share/gems/gems/foreman_maintain-1.6.10/lib/foreman_maintain/detector.rb:61:in `available_scenarios'
    /usr/share/gems/gems/foreman_maintain-1.6.10/lib/foreman_maintain/concerns/finders.rb:29:in `find_scenarios'
    /usr/share/gems/gems/foreman_maintain-1.6.10/lib/foreman_maintain/update_runner.rb:25:in `find_scenario'
    /usr/share/gems/gems/foreman_maintain-1.6.10/lib/foreman_maintain/update_runner.rb:74:in `run_phase'
    /usr/share/gems/gems/foreman_maintain-1.6.10/lib/foreman_maintain/cli/update_command.rb:30:in `execute'
    /usr/share/gems/gems/clamp-1.3.2/lib/clamp/command.rb:66:in `run'
    /usr/share/gems/gems/clamp-1.3.2/lib/clamp/subcommand/execution.rb:18:in `execute'
    /usr/share/gems/gems/clamp-1.3.2/lib/clamp/command.rb:66:in `run'
    /usr/share/gems/gems/clamp-1.3.2/lib/clamp/subcommand/execution.rb:18:in `execute'
    /usr/share/gems/gems/clamp-1.3.2/lib/clamp/command.rb:66:in `run'
    /usr/share/gems/gems/foreman_maintain-1.6.10/lib/foreman_maintain/cli.rb:40:in `run'
    /usr/share/gems/gems/clamp-1.3.2/lib/clamp/command.rb:140:in `run'
    /usr/share/gems/gems/foreman_maintain-1.6.10/bin/foreman-maintain:15:in `<top (required)>'
    /bin/foreman-maintain:23:in `load'
    /bin/foreman-maintain:23:in `<main>'
