### PR TITLE
Auto-detect if colors are supported

### DIFF
--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -68,6 +68,7 @@ module ForemanMaintain
 
       # using a queue, we can log the messages which are generated before initializing logger
       self.config = Config.new(options)
+      configure_highline
       load_definitions
       init_logger
       update_path
@@ -100,6 +101,10 @@ module ForemanMaintain
         file_paths = File.expand_path(File.join(definitions_dir, '**', '*.rb'))
         Dir.glob(file_paths).sort.each { |f| require f }
       end
+    end
+
+    def configure_highline
+      HighLine.use_color = config.use_color?
     end
 
     def cache

--- a/lib/foreman_maintain/config.rb
+++ b/lib/foreman_maintain/config.rb
@@ -25,6 +25,11 @@ module ForemanMaintain
       @foreman_port = @options.fetch(:foreman_port, 443)
     end
 
+    def use_color?
+      ENV['TERM'] && ENV.fetch('NO_COLOR', '') == '' && \
+        system('command -v tput', out: File.open('/dev/null')) && `tput colors`.to_i > 0
+    end
+
     private
 
     def load_log_configs

--- a/test/lib/cli/health_command_test.rb
+++ b/test/lib/cli/health_command_test.rb
@@ -40,10 +40,10 @@ module ForemanMaintain
           [dummy-check-fail-skipwhitelist] Check that ends up with fail
           [dummy-check-success] Check that ends up with success
           [dummy-check-warn] Check that ends up with warning
-          [external-service-is-accessible] External_service_is_accessible         [pre-upgrade-check]
-          [present-service-is-running] Present service run check                  [default]
-          [service-is-stopped] Service not running check                          [default]
-          [upgrade-post-upgrade-check] Procedures::Upgrade::PostUpgradeCheck      [post-upgrade-checks]
+          [external-service-is-accessible] External_service_is_accessible                  [pre-upgrade-check]
+          [present-service-is-running] Present service run check                           [default]
+          [service-is-stopped] Service not running check                                   [default]
+          [upgrade-post-upgrade-check] Procedures::Upgrade::PostUpgradeCheck               [post-upgrade-checks]
         OUTPUT
       end
     end

--- a/test/lib/reporter_test.rb
+++ b/test/lib/reporter_test.rb
@@ -388,7 +388,6 @@ module ForemanMaintain
       # simulate carriage returns to get the output as user would see it
       out = capture.read
       out = simulate_carriage_returns(out) if simulate_terminal
-      out = remove_colors(out)
       capture.rewind
       out
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+ENV['NO_COLOR'] = '1'
 require 'foreman_maintain'
 require 'minitest/spec'
 require 'minitest/autorun'
@@ -19,7 +20,7 @@ module CliAssertions
       expected_output = expected_output.gsub(/\s+/, ' ')
       output = output.gsub(/\s+/, ' ')
     end
-    assert_equal expected_output, remove_colors(simulate_carriage_returns(output))
+    assert_equal expected_output, simulate_carriage_returns(output)
   end
 
   def capture_io_with_stderr
@@ -47,10 +48,6 @@ module CliAssertions
 
   def simulate_carriage_returns(output)
     output.gsub(/^.*\r/, '')
-  end
-
-  def remove_colors(output)
-    output.gsub(/\e.*?m/, '')
   end
 end
 


### PR DESCRIPTION
Not all output supports colors. For example, cron doesn't. This copies the autodetection from Kafo to disable colors if needed.

Currently untested. I'd also like to ask others for input: do we want (like the installer) `--[no-]color` flags? Should it have a config option?