### PR TITLE
Drop Ruby < 2.3 compatibility code

### DIFF
--- a/definitions/checks/foreman/check_tuning_requirements.rb
+++ b/definitions/checks/foreman/check_tuning_requirements.rb
@@ -70,8 +70,8 @@ module Checks
       end
 
       def failure_message(tuning_profile)
-        <<-MESSAGE.strip_heredoc
-        \nERROR: The installer is configured to use the #{tuning_profile} tuning profile and does not meet the requirements.
+        <<~MESSAGE
+          \nERROR: The installer is configured to use the #{tuning_profile} tuning profile and does not meet the requirements.
         MESSAGE
       end
     end

--- a/definitions/procedures/foreman_tasks/ui_investigate.rb
+++ b/definitions/procedures/foreman_tasks/ui_investigate.rb
@@ -10,7 +10,7 @@ module Procedures::ForemanTasks
     attr_reader :search_query
 
     def run
-      ask(<<-MESSAGE.strip_heredoc)
+      ask(<<~MESSAGE)
         Go to https://#{hostname}/foreman_tasks/tasks?search=#{CGI.escape(@search_query.to_s)}
         press ENTER after the tasks are resolved.
       MESSAGE

--- a/definitions/procedures/knowledge_base_article.rb
+++ b/definitions/procedures/knowledge_base_article.rb
@@ -12,7 +12,7 @@ class Procedures::KnowledgeBaseArticle < ForemanMaintain::Procedure
   end
 
   def run
-    ask(<<-MESSAGE.strip_heredoc)
+    ask(<<~MESSAGE)
       Go to #{kcs_documents[@doc]}
       please follow steps from above article to resolve this issue
       press ENTER once done.

--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -1,7 +1,3 @@
-if RUBY_VERSION <= '1.8.7'
-  require 'rubygems'
-end
-
 require 'forwardable'
 require 'json'
 require 'logger'

--- a/lib/foreman_maintain/cli/upgrade_command.rb
+++ b/lib/foreman_maintain/cli/upgrade_command.rb
@@ -30,7 +30,7 @@ module ForemanMaintain
                           else
                             '--target-version not specified'
                           end
-          message = <<-MESSAGE.strip_heredoc
+          message = <<~MESSAGE
             #{message_start}
             Possible target versions are:
           MESSAGE

--- a/lib/foreman_maintain/core_ext.rb
+++ b/lib/foreman_maintain/core_ext.rb
@@ -1,17 +1,5 @@
 module ForemanMaintain
   module CoreExt
-    module StripHeredoc
-      def strip_heredoc
-        indent = 0
-        indented_lines = scan(/^[ \t]+(?=\S)/)
-        unless indented_lines.empty?
-          indent = indented_lines.min.size
-        end
-        gsub(/^[ \t]{#{indent}}/, '')
-      end
-    end
-    String.include StripHeredoc
-
     module ValidateOptions
       def validate_options!(*valid_keys)
         valid_keys.flatten!

--- a/lib/foreman_maintain/reporter/cli_reporter.rb
+++ b/lib/foreman_maintain/reporter/cli_reporter.rb
@@ -301,17 +301,17 @@ module ForemanMaintain
         return if scenario.passed? && !scenario.warning?
 
         message = []
-        message << <<-MESSAGE.strip_heredoc
+        message << <<~MESSAGE
           Scenario [#{scenario.description}] failed.
         MESSAGE
         recommend = []
 
         steps_with_abort = scenario.steps_with_abort(:whitelisted => false)
         unless steps_with_abort.empty?
-          message << format(<<-MESSAGE.strip_heredoc, format_steps(steps_with_abort, "\n", 2))
-          The processing was aborted by user during the following steps:
+          message << format(<<~MESSAGE, format_steps(steps_with_abort, "\n", 2))
+            The processing was aborted by user during the following steps:
 
-          %s
+            %s
           MESSAGE
         end
 
@@ -323,28 +323,28 @@ module ForemanMaintain
 
         steps_to_whitelist = steps_with_error + steps_with_skipped - not_skippable_steps
         unless steps_with_error.empty?
-          message << format(<<-MESSAGE.strip_heredoc, format_steps(steps_with_error, "\n", 2))
-          The following steps ended up in failing state:
+          message << format(<<~MESSAGE, format_steps(steps_with_error, "\n", 2))
+            The following steps ended up in failing state:
 
-          %s
+            %s
           MESSAGE
           whitelist_labels = steps_to_whitelist.map(&:label_dashed).join(',')
           unless whitelist_labels.empty?
             recommend << if scenario.detector.feature(:instance).downstream
-                           format(<<-MESSAGE.strip_heredoc)
-              Resolve the failed steps and rerun the command.
+                           format(<<~MESSAGE)
+                             Resolve the failed steps and rerun the command.
 
-              If the situation persists and, you are unclear what to do next,
-              contact #{scenario.detector.feature(:instance).project_support_entity}.
+                             If the situation persists and, you are unclear what to do next,
+                             contact #{scenario.detector.feature(:instance).project_support_entity}.
 
-              In case the failures are false positives, use
-              --whitelist="#{whitelist_labels}"
+                             In case the failures are false positives, use
+                             --whitelist="#{whitelist_labels}"
                            MESSAGE
                          else
-                           format(<<-MESSAGE.strip_heredoc)
-              Resolve the failed steps and rerun the command.
-              In case the failures are false positives, use
-              --whitelist="#{whitelist_labels}"
+                           format(<<~MESSAGE)
+                             Resolve the failed steps and rerun the command.
+                             In case the failures are false positives, use
+                             --whitelist="#{whitelist_labels}"
                            MESSAGE
                          end
           end
@@ -352,15 +352,15 @@ module ForemanMaintain
 
         steps_with_warning = scenario.steps_with_warning(:whitelisted => false)
         unless steps_with_warning.empty?
-          message << format(<<-MESSAGE.strip_heredoc, format_steps(steps_with_warning, "\n", 2))
-          The following steps ended up in warning state:
+          message << format(<<~MESSAGE, format_steps(steps_with_warning, "\n", 2))
+            The following steps ended up in warning state:
 
-          %s
+            %s
           MESSAGE
 
-          recommend << <<-MESSAGE.strip_heredoc
-          The steps in warning state itself might not mean there is an error,
-          but it should be reviewed to ensure the behavior is expected
+          recommend << <<~MESSAGE
+            The steps in warning state itself might not mean there is an error,
+            but it should be reviewed to ensure the behavior is expected
           MESSAGE
         end
         puts((message + recommend).join("\n"))

--- a/lib/foreman_maintain/update_runner.rb
+++ b/lib/foreman_maintain/update_runner.rb
@@ -133,10 +133,10 @@ module ForemanMaintain
       decision = super(scenario)
       # we have not asked the user already about next steps
       if decision.nil? && @ask_to_confirm_update
-        response = reporter.ask_decision(<<-MESSAGE.strip_heredoc.strip)
-            The pre-update checks indicate that the system is ready for update.
-            It's recommended to perform a backup at this stage.
-            Confirm to continue with the modification part of the update
+        response = reporter.ask_decision(<<~MESSAGE.strip)
+          The pre-update checks indicate that the system is ready for update.
+          It's recommended to perform a backup at this stage.
+          Confirm to continue with the modification part of the update
         MESSAGE
         if [:no, :quit].include?(response)
           ask_to_quit

--- a/lib/foreman_maintain/upgrade_runner.rb
+++ b/lib/foreman_maintain/upgrade_runner.rb
@@ -94,7 +94,7 @@ module ForemanMaintain
     def finish_upgrade
       @finished = true
       @reporter.hline
-      @reporter.puts <<-MESSAGE.strip_heredoc
+      @reporter.puts <<~MESSAGE
         Upgrade finished.
       MESSAGE
     end
@@ -136,7 +136,7 @@ module ForemanMaintain
     def skip_phase(skipped_phase)
       with_non_empty_scenario(skipped_phase) do |scenario|
         @reporter.before_scenario_starts(scenario)
-        @reporter.puts <<-MESSAGE.strip_heredoc
+        @reporter.puts <<~MESSAGE
           Skipping #{skipped_phase} phase as it was already run before.
           To enforce to run the phase, use `upgrade run --phase #{skipped_phase}`
         MESSAGE
@@ -164,7 +164,7 @@ module ForemanMaintain
         end
       end
       self.phase = :pre_upgrade_checks # rollback finished
-      @reporter.puts <<-MESSAGE.strip_heredoc
+      @reporter.puts <<~MESSAGE
         The upgrade failed and system was restored to pre-upgrade state.
       MESSAGE
     end
@@ -199,10 +199,10 @@ module ForemanMaintain
       decision = super(scenario)
       # we have not asked the user already about next steps
       if decision.nil? && @ask_to_confirm_upgrade
-        response = reporter.ask_decision(<<-MESSAGE.strip_heredoc.strip)
-            The pre-upgrade checks indicate that the system is ready for upgrade.
-            It's recommended to perform a backup at this stage.
-            Confirm to continue with the modification part of the upgrade
+        response = reporter.ask_decision(<<~MESSAGE.strip)
+          The pre-upgrade checks indicate that the system is ready for upgrade.
+          It's recommended to perform a backup at this stage.
+          Confirm to continue with the modification part of the upgrade
         MESSAGE
         if [:no, :quit].include?(response)
           ask_to_quit

--- a/test/definitions/procedures/foreman_tasks/ui_investigate_test.rb
+++ b/test/definitions/procedures/foreman_tasks/ui_investigate_test.rb
@@ -15,7 +15,7 @@ describe Procedures::ForemanTasks::Resume do
     subject.stubs(:hostname => 'example.com')
     result = run_procedure(subject)
     assert result.success?, 'the procedure was expected to succeed'
-    assert_equal <<-MSG.strip_heredoc.strip, result.reporter.output.strip
+    assert_equal <<~MSG.strip, result.reporter.output.strip
       Go to https://example.com/foreman_tasks/tasks?search=state+%3D+paused
       press ENTER after the tasks are resolved.
     MSG

--- a/test/lib/cli/advanced_procedure_command_test.rb
+++ b/test/lib/cli/advanced_procedure_command_test.rb
@@ -17,7 +17,7 @@ module ForemanMaintain
     end
 
     it 'prints procedure' do
-      assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
+      assert_cmd <<~OUTPUT, :ignore_whitespace => true
         Usage:
             foreman-maintain advanced [OPTIONS] SUBCOMMAND [ARG] ...
 
@@ -40,7 +40,7 @@ module ForemanMaintain
       end
 
       it 'prints: run and by-tag subcommands' do
-        assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
+        assert_cmd <<~OUTPUT, :ignore_whitespace => true
           Usage:
               foreman-maintain advanced procedure [OPTIONS] SUBCOMMAND [ARG] ...
 
@@ -64,7 +64,7 @@ module ForemanMaintain
       end
 
       it 'prints: available subcommands for by-tag' do
-        assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
+        assert_cmd <<~OUTPUT, :ignore_whitespace => true
           Usage:
               foreman-maintain advanced procedure by-tag [OPTIONS] SUBCOMMAND [ARG] ...
 
@@ -93,7 +93,7 @@ module ForemanMaintain
       end
 
       it 'prints: available subcommands for run' do
-        assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
+        assert_cmd <<~OUTPUT, :ignore_whitespace => true
           Usage:
               foreman-maintain advanced procedure run [OPTIONS] SUBCOMMAND [ARG] ...
 

--- a/test/lib/cli/health_command_test.rb
+++ b/test/lib/cli/health_command_test.rb
@@ -11,7 +11,7 @@ module ForemanMaintain
     end
 
     it 'prints help' do
-      assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
+      assert_cmd <<~OUTPUT, :ignore_whitespace => true
         Usage:
             foreman-maintain health [OPTIONS] SUBCOMMAND [ARG] ...
 
@@ -34,7 +34,7 @@ module ForemanMaintain
         %w[health list]
       end
       it 'lists the defined checks' do
-        assert_cmd <<-OUTPUT.strip_heredoc
+        assert_cmd <<~OUTPUT
           [dummy-check-fail] Check that ends up with fail
           [dummy-check-fail2] Check that ends up with fail
           [dummy-check-fail-skipwhitelist] Check that ends up with fail
@@ -53,7 +53,7 @@ module ForemanMaintain
         %w[health list-tags]
       end
       it 'lists the defined tags' do
-        assert_cmd <<-OUTPUT.strip_heredoc
+        assert_cmd <<~OUTPUT
           [default]
           [post-upgrade-checks]
           [pre-upgrade-check]
@@ -88,13 +88,13 @@ module ForemanMaintain
       end
 
       it 'raises errors on empty arguments' do
-        assert_cmd <<-OUTPUT.strip_heredoc, %w[--label]
+        assert_cmd <<~OUTPUT, %w[--label]
           ERROR: option '--label': value not specified
 
           See: 'foreman-maintain health check --help'
         OUTPUT
 
-        assert_cmd <<-OUTPUT.strip_heredoc, %w[--tags]
+        assert_cmd <<~OUTPUT, %w[--tags]
           ERROR: option '--tags': value not specified
 
           See: 'foreman-maintain health check --help'

--- a/test/lib/cli/maintenance_mode_command_test.rb
+++ b/test/lib/cli/maintenance_mode_command_test.rb
@@ -11,7 +11,7 @@ module ForemanMaintain
     end
 
     it 'prints help' do
-      assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
+      assert_cmd <<~OUTPUT, :ignore_whitespace => true
         Usage:
             foreman-maintain maintenance-mode [OPTIONS] SUBCOMMAND [ARG] ...
 

--- a/test/lib/cli/packages_command_test.rb
+++ b/test/lib/cli/packages_command_test.rb
@@ -11,7 +11,7 @@ module ForemanMaintain
     end
 
     it 'prints help' do
-      assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
+      assert_cmd <<~OUTPUT, :ignore_whitespace => true
         Usage:
             foreman-maintain packages [OPTIONS] SUBCOMMAND [ARG] ...
 

--- a/test/lib/cli/plugin_command_test.rb
+++ b/test/lib/cli/plugin_command_test.rb
@@ -10,7 +10,7 @@ module ForemanMaintain
     end
 
     it 'prints help' do
-      assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
+      assert_cmd <<~OUTPUT, :ignore_whitespace => true
         Usage:
             foreman-maintain plugin [OPTIONS] SUBCOMMAND [ARG] ...
 

--- a/test/lib/cli/update_command_test.rb
+++ b/test/lib/cli/update_command_test.rb
@@ -32,7 +32,7 @@ module ForemanMaintain
       end
 
       it 'prints help' do
-        assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
+        assert_cmd <<~OUTPUT, :ignore_whitespace => true
           Usage:
               foreman-maintain update [OPTIONS] SUBCOMMAND [ARG] ...
 
@@ -63,22 +63,22 @@ module ForemanMaintain
 
       it 'run self update if update available for foreman-maintain' do
         foreman_maintain_update_available
-        assert_cmd <<-OUTPUT.strip_heredoc
-        Checking for new version of rubygem-foreman_maintain...
+        assert_cmd <<~OUTPUT
+          Checking for new version of rubygem-foreman_maintain...
 
-        Updating rubygem-foreman_maintain package.
+          Updating rubygem-foreman_maintain package.
 
-        The rubygem-foreman_maintain package successfully updated.
-        Re-run foreman-maintain with required options!
+          The rubygem-foreman_maintain package successfully updated.
+          Re-run foreman-maintain with required options!
         OUTPUT
       end
 
       it 'runs the update checks when update is not available for foreman-maintain' do
         foreman_maintain_update_unavailable
         UpdateRunner.any_instance.expects(:run_phase).with(:pre_update_checks)
-        assert_cmd <<-OUTPUT.strip_heredoc
-        Checking for new version of rubygem-foreman_maintain...
-        Nothing to update, can't find new version of rubygem-foreman_maintain.
+        assert_cmd <<~OUTPUT
+          Checking for new version of rubygem-foreman_maintain...
+          Nothing to update, can't find new version of rubygem-foreman_maintain.
         OUTPUT
       end
 
@@ -97,22 +97,22 @@ module ForemanMaintain
 
       it 'run self update if update available for foreman-maintain' do
         foreman_maintain_update_available
-        assert_cmd <<-OUTPUT.strip_heredoc
-        Checking for new version of rubygem-foreman_maintain...
+        assert_cmd <<~OUTPUT
+          Checking for new version of rubygem-foreman_maintain...
 
-        Updating rubygem-foreman_maintain package.
+          Updating rubygem-foreman_maintain package.
 
-        The rubygem-foreman_maintain package successfully updated.
-        Re-run foreman-maintain with required options!
+          The rubygem-foreman_maintain package successfully updated.
+          Re-run foreman-maintain with required options!
         OUTPUT
       end
 
       it 'runs the update when update is not available for foreman-maintain' do
         foreman_maintain_update_unavailable
         UpdateRunner.any_instance.expects(:run)
-        assert_cmd <<-OUTPUT.strip_heredoc
-        Checking for new version of rubygem-foreman_maintain...
-        Nothing to update, can't find new version of rubygem-foreman_maintain.
+        assert_cmd <<~OUTPUT
+          Checking for new version of rubygem-foreman_maintain...
+          Nothing to update, can't find new version of rubygem-foreman_maintain.
         OUTPUT
       end
 
@@ -124,24 +124,24 @@ module ForemanMaintain
 
       it 'runs the self update when update available for rubygem-foreman_maintain' do
         foreman_maintain_update_available
-        assert_cmd <<-OUTPUT.strip_heredoc
-        Checking for new version of rubygem-foreman_maintain...
+        assert_cmd <<~OUTPUT
+          Checking for new version of rubygem-foreman_maintain...
 
-        Updating rubygem-foreman_maintain package.
+          Updating rubygem-foreman_maintain package.
 
-        The rubygem-foreman_maintain package successfully updated.
-        Re-run foreman-maintain with required options!
+          The rubygem-foreman_maintain package successfully updated.
+          Re-run foreman-maintain with required options!
         OUTPUT
 
         run_cmd
 
-        assert_cmd(<<-OUTPUT.strip_heredoc)
-        Checking for new version of rubygem-foreman_maintain...
+        assert_cmd(<<~OUTPUT)
+          Checking for new version of rubygem-foreman_maintain...
 
-        Updating rubygem-foreman_maintain package.
+          Updating rubygem-foreman_maintain package.
 
-        The rubygem-foreman_maintain package successfully updated.
-        Re-run foreman-maintain with required options!
+          The rubygem-foreman_maintain package successfully updated.
+          Re-run foreman-maintain with required options!
         OUTPUT
       end
     end

--- a/test/lib/cli/upgrade_command_test.rb
+++ b/test/lib/cli/upgrade_command_test.rb
@@ -33,7 +33,7 @@ module ForemanMaintain
       end
 
       it 'prints help' do
-        assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
+        assert_cmd <<~OUTPUT, :ignore_whitespace => true
           Usage:
               foreman-maintain upgrade [OPTIONS] SUBCOMMAND [ARG] ...
 
@@ -59,13 +59,13 @@ module ForemanMaintain
       it 'run self upgrade if upgrade available for foreman-maintain' do
         foreman_maintain_update_available
         command << '--target-version=1.15'
-        assert_cmd <<-OUTPUT.strip_heredoc
-        Checking for new version of rubygem-foreman_maintain...
+        assert_cmd <<~OUTPUT
+          Checking for new version of rubygem-foreman_maintain...
 
-        Updating rubygem-foreman_maintain package.
+          Updating rubygem-foreman_maintain package.
 
-        The rubygem-foreman_maintain package successfully updated.
-        Re-run foreman-maintain with required options!
+          The rubygem-foreman_maintain package successfully updated.
+          Re-run foreman-maintain with required options!
         OUTPUT
       end
 
@@ -73,9 +73,9 @@ module ForemanMaintain
         foreman_maintain_update_unavailable
         command << '--target-version=1.15'
         UpgradeRunner.any_instance.expects(:run_phase).with(:pre_upgrade_checks)
-        assert_cmd <<-OUTPUT.strip_heredoc
-        Checking for new version of rubygem-foreman_maintain...
-        Nothing to update, can't find new version of rubygem-foreman_maintain.
+        assert_cmd <<~OUTPUT
+          Checking for new version of rubygem-foreman_maintain...
+          Nothing to update, can't find new version of rubygem-foreman_maintain.
         OUTPUT
       end
 
@@ -101,13 +101,13 @@ module ForemanMaintain
       it 'run self upgrade if upgrade available for foreman-maintain' do
         foreman_maintain_update_available
         command << '--target-version=1.15'
-        assert_cmd <<-OUTPUT.strip_heredoc
-        Checking for new version of rubygem-foreman_maintain...
+        assert_cmd <<~OUTPUT
+          Checking for new version of rubygem-foreman_maintain...
 
-        Updating rubygem-foreman_maintain package.
+          Updating rubygem-foreman_maintain package.
 
-        The rubygem-foreman_maintain package successfully updated.
-        Re-run foreman-maintain with required options!
+          The rubygem-foreman_maintain package successfully updated.
+          Re-run foreman-maintain with required options!
         OUTPUT
       end
 
@@ -115,9 +115,9 @@ module ForemanMaintain
         foreman_maintain_update_unavailable
         command << '--target-version=1.15'
         UpgradeRunner.any_instance.expects(:run)
-        assert_cmd <<-OUTPUT.strip_heredoc
-        Checking for new version of rubygem-foreman_maintain...
-        Nothing to update, can't find new version of rubygem-foreman_maintain.
+        assert_cmd <<~OUTPUT
+          Checking for new version of rubygem-foreman_maintain...
+          Nothing to update, can't find new version of rubygem-foreman_maintain.
         OUTPUT
       end
 
@@ -129,38 +129,38 @@ module ForemanMaintain
 
       it 'runs the self upgrade when update available for rubygem-foreman_maintain' do
         foreman_maintain_update_available
-        assert_cmd <<-OUTPUT.strip_heredoc
-        Checking for new version of rubygem-foreman_maintain...
+        assert_cmd <<~OUTPUT
+          Checking for new version of rubygem-foreman_maintain...
 
-        Updating rubygem-foreman_maintain package.
+          Updating rubygem-foreman_maintain package.
 
-        The rubygem-foreman_maintain package successfully updated.
-        Re-run foreman-maintain with required options!
+          The rubygem-foreman_maintain package successfully updated.
+          Re-run foreman-maintain with required options!
         OUTPUT
 
         UpgradeRunner.current_target_version = '1.15'
 
         run_cmd
 
-        assert_cmd(<<-OUTPUT.strip_heredoc, ['--target-version', '1.16'])
-        Checking for new version of rubygem-foreman_maintain...
+        assert_cmd(<<~OUTPUT, ['--target-version', '1.16'])
+          Checking for new version of rubygem-foreman_maintain...
 
-        Updating rubygem-foreman_maintain package.
+          Updating rubygem-foreman_maintain package.
 
-        The rubygem-foreman_maintain package successfully updated.
-        Re-run foreman-maintain with required options!
+          The rubygem-foreman_maintain package successfully updated.
+          Re-run foreman-maintain with required options!
         OUTPUT
       end
 
       it 'remembers the current target version and informs no update available' do
         foreman_maintain_update_unavailable
         Cli::MainCommand.any_instance.expects(:exit!).twice
-        assert_cmd <<-OUTPUT.strip_heredoc
-        Checking for new version of rubygem-foreman_maintain...
-        Nothing to update, can't find new version of rubygem-foreman_maintain.
-        --target-version not specified
-        Possible target versions are:
-        1.15
+        assert_cmd <<~OUTPUT
+          Checking for new version of rubygem-foreman_maintain...
+          Nothing to update, can't find new version of rubygem-foreman_maintain.
+          --target-version not specified
+          Possible target versions are:
+          1.15
         OUTPUT
 
         UpgradeRunner.current_target_version = '1.15'
@@ -168,7 +168,7 @@ module ForemanMaintain
 
         run_cmd
 
-        assert_cmd(<<-OUTPUT.strip_heredoc, ['--target-version', '1.16'])
+        assert_cmd(<<~OUTPUT, ['--target-version', '1.16'])
           Checking for new version of rubygem-foreman_maintain...
           Nothing to update, can't find new version of rubygem-foreman_maintain.
           Can't set target version 1.16, 1.15 already in progress
@@ -178,7 +178,7 @@ module ForemanMaintain
       it 'remembers the current target version when self upgrade disabled' do
         command << '--disable-self-upgrade'
         Cli::MainCommand.any_instance.expects(:exit!)
-        assert_cmd <<-OUTPUT.strip_heredoc
+        assert_cmd <<~OUTPUT
           --target-version not specified
           Possible target versions are:
           1.15
@@ -190,7 +190,7 @@ module ForemanMaintain
         UpgradeRunner.current_target_version = '1.15'
         Cli::MainCommand.any_instance.expects(:exit!)
 
-        assert_cmd(<<-OUTPUT.strip_heredoc, ['--target-version', '1.16'])
+        assert_cmd(<<~OUTPUT, ['--target-version', '1.16'])
           Checking for new version of rubygem-foreman_maintain...
           Nothing to update, can't find new version of rubygem-foreman_maintain.
           Can't set target version 1.16, 1.15 already in progress

--- a/test/lib/cli_test.rb
+++ b/test/lib/cli_test.rb
@@ -11,7 +11,7 @@ module ForemanMaintain
     end
 
     it 'prints help' do
-      assert_cmd <<-OUTPUT.strip_heredoc, :ignore_whitespace => true
+      assert_cmd <<~OUTPUT, :ignore_whitespace => true
         Usage:
             foreman-maintain [OPTIONS] SUBCOMMAND [ARG] ...
 

--- a/test/lib/reporter_test.rb
+++ b/test/lib/reporter_test.rb
@@ -82,7 +82,7 @@ module ForemanMaintain
       reporter.before_scenario_starts(fail_scenario)
       run_scenario(fail_scenario)
 
-      assert_equal <<-STR.strip_heredoc, captured_out
+      assert_equal <<~STR, captured_out
         Running Scenarios::Dummy::Fail
         ================================================================================
         Check that ends up with fail:                                         [FAIL]
@@ -102,7 +102,7 @@ module ForemanMaintain
 
       will_press('2')
       assert_equal restart_step, reporter.on_next_steps([start_step, restart_step])
-      assert_equal <<-STR.strip_heredoc.strip, captured_out(false).strip
+      assert_equal <<~STR.strip, captured_out(false).strip
         There are multiple steps to proceed:
         1) Start the present service
         2) Restart present service
@@ -118,29 +118,29 @@ module ForemanMaintain
       fake_instance_feature
       run_scenario(fail_multiple_scenario)
       reporter.after_scenario_finishes(fail_multiple_scenario)
-      assert_equal <<-MESSAGE.strip_heredoc.strip, captured_out(false).strip
-      Check that ends up with fail:                                         [FAIL]
-      this check is always causing failure
-      --------------------------------------------------------------------------------
-      Check that ends up with fail:                                         [FAIL]
-      this check is always causing failure
-      --------------------------------------------------------------------------------
-      Check that ends up with success:                                      [OK]
-      --------------------------------------------------------------------------------
-      Scenario [Scenarios::Dummy::FailMultiple] failed.
+      assert_equal <<~MESSAGE.strip, captured_out(false).strip
+        Check that ends up with fail:                                         [FAIL]
+        this check is always causing failure
+        --------------------------------------------------------------------------------
+        Check that ends up with fail:                                         [FAIL]
+        this check is always causing failure
+        --------------------------------------------------------------------------------
+        Check that ends up with success:                                      [OK]
+        --------------------------------------------------------------------------------
+        Scenario [Scenarios::Dummy::FailMultiple] failed.
 
-      The following steps ended up in failing state:
+        The following steps ended up in failing state:
 
-        [dummy-check-fail]
-        [dummy-check-fail2]
+          [dummy-check-fail]
+          [dummy-check-fail2]
 
-      Resolve the failed steps and rerun the command.
+        Resolve the failed steps and rerun the command.
 
-      If the situation persists and, you are unclear what to do next,
-      contact Red Hat Technical Support.
+        If the situation persists and, you are unclear what to do next,
+        contact Red Hat Technical Support.
 
-      In case the failures are false positives, use
-      --whitelist="dummy-check-fail,dummy-check-fail2"
+        In case the failures are false positives, use
+        --whitelist="dummy-check-fail,dummy-check-fail2"
       MESSAGE
     end
 
@@ -150,32 +150,32 @@ module ForemanMaintain
       fake_instance_feature
       run_scenario(fail_multiple_scenario)
       reporter.after_scenario_finishes(fail_multiple_scenario)
-      assert_equal <<-MESSAGE.strip_heredoc.strip, captured_out(false).strip
-      Check that ends up with fail:                                         [FAIL]
-      this check is always causing failure
-      --------------------------------------------------------------------------------
-      Check that ends up with fail:                                         [FAIL]
-      this check is always causing failure
-      --------------------------------------------------------------------------------
-      Check that ends up with success:                                      [OK]
-      --------------------------------------------------------------------------------
-      Scenario [Scenarios::Dummy::FailMultiple] failed.
+      assert_equal <<~MESSAGE.strip, captured_out(false).strip
+        Check that ends up with fail:                                         [FAIL]
+        this check is always causing failure
+        --------------------------------------------------------------------------------
+        Check that ends up with fail:                                         [FAIL]
+        this check is always causing failure
+        --------------------------------------------------------------------------------
+        Check that ends up with success:                                      [OK]
+        --------------------------------------------------------------------------------
+        Scenario [Scenarios::Dummy::FailMultiple] failed.
 
-      The following steps ended up in failing state:
+        The following steps ended up in failing state:
 
-        [dummy-check-fail]
-        [dummy-check-fail2]
+          [dummy-check-fail]
+          [dummy-check-fail2]
 
-      Resolve the failed steps and rerun the command.
-      In case the failures are false positives, use
-      --whitelist="dummy-check-fail,dummy-check-fail2"
+        Resolve the failed steps and rerun the command.
+        In case the failures are false positives, use
+        --whitelist="dummy-check-fail,dummy-check-fail2"
       MESSAGE
     end
 
     it 'informs the user about warnings of the last scenario' do
       run_scenario(warn_scenario)
       reporter.after_scenario_finishes(warn_scenario)
-      assert_equal <<-MESSAGE.strip_heredoc.strip, captured_out(false).strip
+      assert_equal <<~MESSAGE.strip, captured_out(false).strip
         Check that ends up with warning:                                      [WARNING]
         this check is always causing warnings
         --------------------------------------------------------------------------------
@@ -198,7 +198,7 @@ module ForemanMaintain
       fake_instance_feature
       run_scenario(warn_and_fail_scenario)
       reporter.after_scenario_finishes(warn_and_fail_scenario)
-      assert_equal <<-MESSAGE.strip_heredoc.strip, captured_out(false).strip
+      assert_equal <<~MESSAGE.strip, captured_out(false).strip
         Check that ends up with warning:                                      [WARNING]
         this check is always causing warnings
         --------------------------------------------------------------------------------
@@ -231,7 +231,7 @@ module ForemanMaintain
       fake_instance_feature
       run_scenario(warn_and_fail_scenario)
       reporter.after_scenario_finishes(warn_and_fail_scenario)
-      assert_equal <<-MESSAGE.strip_heredoc.strip, captured_out(false).strip
+      assert_equal <<~MESSAGE.strip, captured_out(false).strip
         Check that ends up with warning:                                      [WARNING]
         this check is always causing warnings
         --------------------------------------------------------------------------------
@@ -266,7 +266,7 @@ module ForemanMaintain
     it 'skips whitelisted warnings and failures of the last scenario' do
       run_scenario(warn_and_fail_scenario, :whitelisted => true)
       reporter.after_scenario_finishes(warn_and_fail_scenario)
-      assert_equal <<-MESSAGE.strip_heredoc.strip, captured_out(false).strip
+      assert_equal <<~MESSAGE.strip, captured_out(false).strip
         Check that ends up with warning:                                      [SKIPPED]
         --------------------------------------------------------------------------------
         Check that ends up with fail:                                         [SKIPPED]
@@ -282,7 +282,7 @@ module ForemanMaintain
       fake_instance_feature
       run_scenario(warn_and_fail_skipwhitelist)
       reporter.after_scenario_finishes(warn_and_fail_skipwhitelist)
-      assert_equal <<-MESSAGE.strip_heredoc.strip, captured_out(false).strip
+      assert_equal <<~MESSAGE.strip, captured_out(false).strip
         Check that ends up with warning:                                      [WARNING]
         this check is always causing warnings
         --------------------------------------------------------------------------------
@@ -320,25 +320,25 @@ module ForemanMaintain
       fake_instance_feature
       run_scenario(fail_multiple_skipwhitelist)
       reporter.after_scenario_finishes(fail_multiple_skipwhitelist)
-      assert_equal <<-MESSAGE.strip_heredoc.strip, captured_out(false).strip
-      Check that ends up with fail:                                         [FAIL]
-      this check is always causing failure
-      --------------------------------------------------------------------------------
-      Check that ends up with fail:                                         [FAIL]
-      this check is always causing failure
-      --------------------------------------------------------------------------------
-      Check that ends up with success:                                      [OK]
-      --------------------------------------------------------------------------------
-      Scenario [Scenarios::DummySkipWhitelist::FailMultiple] failed.
+      assert_equal <<~MESSAGE.strip, captured_out(false).strip
+        Check that ends up with fail:                                         [FAIL]
+        this check is always causing failure
+        --------------------------------------------------------------------------------
+        Check that ends up with fail:                                         [FAIL]
+        this check is always causing failure
+        --------------------------------------------------------------------------------
+        Check that ends up with success:                                      [OK]
+        --------------------------------------------------------------------------------
+        Scenario [Scenarios::DummySkipWhitelist::FailMultiple] failed.
 
-      The following steps ended up in failing state:
+        The following steps ended up in failing state:
 
-        [dummy-check-fail]
-        [dummy-check-fail-skipwhitelist]
+          [dummy-check-fail]
+          [dummy-check-fail-skipwhitelist]
 
-      Resolve the failed steps and rerun the command.
-      In case the failures are false positives, use
-      --whitelist="dummy-check-fail"
+        Resolve the failed steps and rerun the command.
+        In case the failures are false positives, use
+        --whitelist="dummy-check-fail"
       MESSAGE
     end
 
@@ -358,11 +358,11 @@ module ForemanMaintain
         start_step = Procedures::PresentServiceStart.new
         restart_step = Procedures::PresentServiceRestart.new
         assert_equal start_step, reporter.on_next_steps([start_step, restart_step])
-        assert_equal <<-STR.strip_heredoc.strip, captured_out(false).strip
-        There are multiple steps to proceed:
-        1) Start the present service
-        2) Restart present service
-        (assuming option 1)
+        assert_equal <<~STR.strip, captured_out(false).strip
+          There are multiple steps to proceed:
+          1) Start the present service
+          2) Restart present service
+          (assuming option 1)
         STR
       end
     end

--- a/test/lib/upgrade_runner_test.rb
+++ b/test/lib/upgrade_runner_test.rb
@@ -37,7 +37,7 @@ module ForemanMaintain
 
     it 'asks for confirmation before getting into pre_migrations from pre upgrade checks' do
       upgrade_runner_with_whitelist.run
-      _(reporter.log.last).must_equal ['ask', <<-MESSAGE.strip_heredoc.strip]
+      _(reporter.log.last).must_equal ['ask', <<~MESSAGE.strip]
         The pre-upgrade checks indicate that the system is ready for upgrade.
         It's recommended to perform a backup at this stage.
         Confirm to continue with the modification part of the upgrade, [y(yes), n(no), q(quit)]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -108,16 +108,7 @@ module UnitTestHelper
   def described_class
     # Memoization doesn't work on class methods need to think how to cache it per test
     # One option is to use 'let' per test file
-    @described_class ||=
-      begin
-        const_name = self.class.name
-        return described_class_ruby_187(const_name) if RUBY_VERSION >= '1.8.7'
-        Object.const_get(const_name)
-      end
-  end
-
-  def described_class_ruby_187(const_name)
-    const_name.split('::').inject(Object) do |mod, class_name|
+    @described_class ||= self.class.name.split('::').inject(Object) do |mod, class_name|
       mod.const_get(class_name)
     end
   end


### PR DESCRIPTION
Heredoc has been supported since Ruby 2.3 and the gemspec already mandates Ruby 2.7+. Also drops code that was guarded by `RUBY_VERSION < 1.8.7` which is never executed on 2.7+.