### PR TITLE
manage cron by default

### DIFF
--- a/config/foreman_maintain.yml.example
+++ b/config/foreman_maintain.yml.example
@@ -31,7 +31,7 @@
 
 # Mention true/false.
 # Value true will to enable cron service stop/restart on maintenance-mode start/stop
-# :manage_crond: false
+# :manage_crond: true
 
 # URL of the Foreman/Satellite server
 # :foreman_url:

--- a/config/foreman_maintain.yml.packaging
+++ b/config/foreman_maintain.yml.packaging
@@ -28,4 +28,4 @@
 
 # Mention true/false.
 # Value true will to enable cron service stop/restart on maintenance-mode start/stop
-# :manage_crond: false
+# :manage_crond: true

--- a/definitions/checks/maintenance_mode/check_consistency.rb
+++ b/definitions/checks/maintenance_mode/check_consistency.rb
@@ -48,7 +48,7 @@ module Checks::MaintenanceMode
     end
 
     def check_for_cron(is_mode_on)
-      unless ForemanMaintain.config.manage_crond && feature(:cron)
+      unless feature(:cron)
         return ['cron jobs: not managed', []]
       end
 

--- a/definitions/features/cron.rb
+++ b/definitions/features/cron.rb
@@ -2,7 +2,7 @@ class Features::Cron < ForemanMaintain::Feature
   metadata do
     label :cron
     confine do
-      ForemanMaintain.config.manage_crond && feature(:instance).downstream
+      ForemanMaintain.config.manage_crond
     end
   end
 

--- a/definitions/scenarios/restore.rb
+++ b/definitions/scenarios/restore.rb
@@ -28,7 +28,7 @@ module ForemanMaintain::Scenarios
       add_steps_with_context(Procedures::Restore::Confirmation,
         Procedures::Restore::RequiredPackages,
         Procedures::Restore::Configs)
-      add_step_with_context(Procedures::Crond::Stop) if feature(:cron)
+      add_step_with_context(Procedures::Crond::Stop)
       unless backup.incremental?
         add_steps_with_context(Procedures::Restore::InstallerReset)
       end
@@ -48,7 +48,7 @@ module ForemanMaintain::Scenarios
 
       add_step(Procedures::Installer::Run.new(:assumeyes => true))
       add_step_with_context(Procedures::Installer::UpgradeRakeTask)
-      add_step_with_context(Procedures::Crond::Start) if feature(:cron)
+      add_step_with_context(Procedures::Crond::Start)
     end
     # rubocop:enable Metrics/MethodLength,Metrics/AbcSize
 
@@ -93,7 +93,7 @@ module ForemanMaintain::Scenarios
     end
 
     def compose
-      add_step_with_context(Procedures::Crond::Stop) if feature(:cron)
+      add_step_with_context(Procedures::Crond::Stop)
     end
   end
 end

--- a/lib/foreman_maintain/config.rb
+++ b/lib/foreman_maintain/config.rb
@@ -52,8 +52,8 @@ module ForemanMaintain
     end
 
     def load_cron_option
-      opt_val = @options.fetch(:manage_crond, false)
-      @manage_crond = boolean?(opt_val) ? opt_val : false
+      opt_val = @options.fetch(:manage_crond, true)
+      @manage_crond = boolean?(opt_val) ? opt_val : true
     end
 
     def load_config

--- a/test/definitions/scenarios/capsule_upgrade_test.rb
+++ b/test/definitions/scenarios/capsule_upgrade_test.rb
@@ -5,7 +5,6 @@ describe "capsule upgrade scenarios" do
 
   before(:each) do
     assume_feature_present(:capsule)
-    ForemanMaintain.config.stubs(:manage_crond).returns(true)
   end
 
   describe Scenarios::Satellite::PreUpgradeCheck do

--- a/test/definitions/scenarios/foreman_upgrade_test.rb
+++ b/test/definitions/scenarios/foreman_upgrade_test.rb
@@ -62,6 +62,7 @@ describe "foreman upgrade scenarios" do
       assert_scenario_has_steps(
         scenario,
         Procedures::MaintenanceMode::EnableMaintenanceMode,
+        Procedures::Crond::Stop,
       )
     end
 
@@ -71,6 +72,7 @@ describe "foreman upgrade scenarios" do
       assert_scenario_has_steps(
         scenario,
         Procedures::MaintenanceMode::EnableMaintenanceMode,
+        Procedures::Crond::Stop,
       )
     end
   end
@@ -121,6 +123,7 @@ describe "foreman upgrade scenarios" do
         Procedures::RefreshFeatures,
         Procedures::Service::Start,
         Procedures::MaintenanceMode::DisableMaintenanceMode,
+        Procedures::Crond::Start,
       )
     end
 
@@ -132,6 +135,7 @@ describe "foreman upgrade scenarios" do
         Procedures::RefreshFeatures,
         Procedures::Service::Start,
         Procedures::MaintenanceMode::DisableMaintenanceMode,
+        Procedures::Crond::Start,
       )
     end
   end

--- a/test/definitions/scenarios/satellite_upgrade_test.rb
+++ b/test/definitions/scenarios/satellite_upgrade_test.rb
@@ -5,7 +5,6 @@ describe "satellite upgrade scenarios" do
 
   before(:each) do
     assume_satellite_present
-    ForemanMaintain.config.stubs(:manage_crond).returns(true)
   end
 
   describe Scenarios::Satellite::PreUpgradeCheck do

--- a/test/definitions/scenarios/update_test.rb
+++ b/test/definitions/scenarios/update_test.rb
@@ -20,7 +20,6 @@ describe "update scenarios" do
   context 'Satellite update' do
     before(:each) do
       assume_satellite_present
-      ForemanMaintain.config.stubs(:manage_crond).returns(true)
     end
 
     describe Scenarios::Update::PreUpdateCheck do
@@ -221,7 +220,6 @@ describe "update scenarios" do
   context 'Foreman update' do
     before(:each) do
       assume_foreman_present
-      ForemanMaintain.config.stubs(:manage_crond).returns(true)
     end
 
     describe Scenarios::Update::PreUpdateCheck do
@@ -422,7 +420,6 @@ describe "update scenarios" do
   context 'Katello update' do
     before(:each) do
       assume_katello_present
-      ForemanMaintain.config.stubs(:manage_crond).returns(true)
     end
 
     describe Scenarios::Update::PreUpdateCheck do


### PR DESCRIPTION
- **Don't confine cron feature to downstream**
- **don't conditionally add Procedures::Crond::\* during restore**
- **don't stub manage_crond config option**
- **don't check for both manage_crond config option and cron feature**
- **default manage_crond to true**
