### PR TITLE
Drop --target-version parameter

### DIFF
--- a/definitions/features/instance.rb
+++ b/definitions/features/instance.rb
@@ -101,6 +101,10 @@ class Features::Instance < ForemanMaintain::Feature
     version.to_s[/^\d+\.\d+\.\d+/]
   end
 
+  def current_major_version
+    current_version.to_s[/^\d+\.\d+/]
+  end
+
   def target_version
     if feature(:instance).downstream
       Features::Satellite.new.target_version

--- a/definitions/scenarios/update.rb
+++ b/definitions/scenarios/update.rb
@@ -5,7 +5,7 @@ module Scenarios::Update
         tags :update_scenario
 
         confine do
-          feature(:instance).target_version == feature(:instance).current_version.to_s[/^\d+\.\d+/]
+          feature(:instance).target_version == feature(:instance).current_major_version
         end
 
         instance_eval(&block)

--- a/lib/foreman_maintain/runner.rb
+++ b/lib/foreman_maintain/runner.rb
@@ -4,6 +4,9 @@ module ForemanMaintain
     include Concerns::Logger
     attr_reader :reporter, :exit_code
 
+    WARNING_EXIT_CODE = 78
+    FAILURE_EXIT_CODE = 1
+
     require 'foreman_maintain/runner/execution'
     require 'foreman_maintain/runner/stored_execution'
     def initialize(reporter, scenarios, options = {})
@@ -61,8 +64,8 @@ module ForemanMaintain
         @last_scenario = scenario
         @last_scenario_continuation_confirmed = false
       end
-      @exit_code = 78 if scenario.warning?
-      @exit_code = 1 if scenario.failed?
+      @exit_code = WARNING_EXIT_CODE if scenario.warning?
+      @exit_code = FAILURE_EXIT_CODE if scenario.failed?
     end
 
     def whitelisted_step?(step)

--- a/test/lib/support/definitions/features/fake_instance.rb
+++ b/test/lib/support/definitions/features/fake_instance.rb
@@ -10,4 +10,16 @@ class Features::FakeInstance < ForemanMaintain::Feature
   def downstream
     false
   end
+
+  def product_name
+    "FakeyFakeFake"
+  end
+
+  def current_version
+    '3.14.2'
+  end
+
+  def current_major_version
+    current_version.to_s[/^\d+\.\d+/]
+  end
 end

--- a/test/lib/upgrade_runner_test.rb
+++ b/test/lib/upgrade_runner_test.rb
@@ -12,11 +12,11 @@ module ForemanMaintain
     end
 
     let(:upgrade_runner) do
-      UpgradeRunner.new('1.15', reporter)
+      UpgradeRunner.new(reporter)
     end
 
     let(:upgrade_runner_with_whitelist) do
-      UpgradeRunner.new('1.15', reporter,
+      UpgradeRunner.new(reporter,
         :whitelist => %w[present-service-is-running service-is-stopped])
     end
 
@@ -56,7 +56,7 @@ module ForemanMaintain
       original_scenario = upgrade_runner_with_whitelist.scenario(:pre_upgrade_checks)
 
       ForemanMaintain.detector.refresh
-      new_upgrade_runner = UpgradeRunner.new('1.15', reporter)
+      new_upgrade_runner = UpgradeRunner.new(reporter)
       new_upgrade_runner.load
       _(new_upgrade_runner.phase).must_equal :migrations
       restored_scenario = new_upgrade_runner.scenario(:pre_upgrade_checks)
@@ -87,7 +87,7 @@ module ForemanMaintain
       upgrade_runner_with_whitelist.run
       upgrade_runner_with_whitelist.save
 
-      new_upgrade_runner = UpgradeRunner.new('1.15', reporter)
+      new_upgrade_runner = UpgradeRunner.new(reporter)
       new_upgrade_runner.load
       _(new_upgrade_runner.phase).must_equal :pre_upgrade_checks
       _(UpgradeRunner.current_target_version).must_be_nil


### PR DESCRIPTION
This parameter is no longer used by the upgrade runner as it is defined internally by the scenarios.