### PR TITLE
Always include the installer answer file in backups

### DIFF
--- a/definitions/features/installer.rb
+++ b/definitions/features/installer.rb
@@ -8,7 +8,7 @@ class Features::Installer < ForemanMaintain::Feature
   end
 
   def answers
-    load_answers(configuration)
+    YAML.load_file(answer_file)
   end
 
   def configuration
@@ -28,11 +28,13 @@ class Features::Installer < ForemanMaintain::Feature
   end
 
   def config_files
-    Dir.glob(File.join(config_directory, '**/*')) +
-      [
-        '/opt/puppetlabs/puppet/cache/foreman_cache_data',
-        '/opt/puppetlabs/puppet/cache/pulpcore_cache_data',
-      ]
+    paths = [
+      config_directory,
+      '/opt/puppetlabs/puppet/cache/foreman_cache_data',
+      '/opt/puppetlabs/puppet/cache/pulpcore_cache_data',
+    ]
+    paths << answer_file unless answer_file.start_with?("#{config_directory}/")
+    paths
   end
 
   def last_scenario
@@ -80,8 +82,8 @@ class Features::Installer < ForemanMaintain::Feature
 
   private
 
-  def load_answers(config)
-    YAML.load_file(config[:answer_file])
+  def answer_file
+    configuration[:answer_file]
   end
 
   def last_scenario_config

--- a/test/definitions/features/installer_test.rb
+++ b/test/definitions/features/installer_test.rb
@@ -9,18 +9,16 @@ describe Features::Installer do
 
   context 'installer with scenarios' do
     before do
-      installer_config_dir(["#{data_dir}/installer/simple_config"])
+      installer_config_dir("#{data_dir}/installer/simple_config")
       mock_installer_package('foreman-installer')
     end
 
     it 'loads list of configs on the start' do
       expected_config_files = [
-        "#{data_dir}/installer/simple_config/scenarios.d",
-        "#{data_dir}/installer/simple_config/scenarios.d/foreman-answers.yaml",
-        "#{data_dir}/installer/simple_config/scenarios.d/foreman.yaml",
-        "#{data_dir}/installer/simple_config/scenarios.d/last_scenario.yaml",
+        "#{data_dir}/installer/simple_config",
         '/opt/puppetlabs/puppet/cache/foreman_cache_data',
         '/opt/puppetlabs/puppet/cache/pulpcore_cache_data',
+        'test/data/installer/simple_config/scenarios.d/foreman-answers.yaml',
       ].sort
       _(subject.config_files.sort).must_equal(expected_config_files)
     end


### PR DESCRIPTION
If the user has changed the answer file location in their scenario to something outside of `/etc/foreman-installer` then it isn't backed up.

This changes the installer feature's config_files to include it if needed. It also stops globbing the files and simply trust that you can list a directory, which we already do for the cached data.

I'm unsure about the implications for restores.

Note that this also prepares for the case where we will move the answer files to `/var/lib/foreman-installer` (provided we keep the scenario files in `/etc`).