### PR TITLE
Fixes #37776 Improve available_space Check in foreman_maintain

### DIFF
--- a/definitions/checks/disk/available_space.rb
+++ b/definitions/checks/disk/available_space.rb
@@ -3,7 +3,8 @@ module Checks
     class AvailableSpace < ForemanMaintain::Check
       metadata do
         label :available_space
-        description 'Check if /var/cache partition has enough space for dnf transaction:'
+        # /var/cache usually contains the cache for the most used package-managers (rpm, apt...)
+        description 'Check if /var/cache partition has enough space for transaction:'
         tags :pre_upgrade
       end
 

--- a/definitions/checks/disk/available_space.rb
+++ b/definitions/checks/disk/available_space.rb
@@ -3,7 +3,7 @@ module Checks
     class AvailableSpace < ForemanMaintain::Check
       metadata do
         label :available_space
-        description 'Check to make sure root(/) partition has enough space'
+        description 'Check if /var/cache partition has enough space for dnf transaction:'
         tags :pre_upgrade
       end
 
@@ -11,11 +11,12 @@ module Checks
 
       def run
         assert(enough_space?, "System has less than #{MIN_SPACE_IN_MB / 1024}GB space available"\
-              ' on root(/) partition')
+              ' on /var/cache partition')
       end
 
       def enough_space?
-        io_obj = ForemanMaintain::Utils::Disk::IODevice.new('/')
+        device = ForemanMaintain::Utils::Disk::Device.new('/var/cache').name
+        io_obj = ForemanMaintain::Utils::Disk::IODevice.new(device)
         io_obj.available_space > MIN_SPACE_IN_MB
       end
     end


### PR DESCRIPTION
**Description of problem:**

The / free-space check was included in foreman_maintain but it was from the perspective of yum not able to complete the package updates due to lack of disk space in /var/cache , under the assumption that it was residing under / itself.

Mostly people would have a seperate FS for /var or have a large enough /  to work with. And those with separate /var partition may not even need 4 GB free space in /.

There are some scenarios where Check fails even when there is plenty of space to handle the yum transaction

**How reproducible:**

Always when / partition available space < 4096 and /var/ has enough partition

**Is this issue a regression from an earlier version:**

No

**Actual behavior:**
The space_available Check fails