### PR TITLE
Implement "restart" for RemoteDB services

### DIFF
--- a/lib/foreman_maintain/utils/service/abstract.rb
+++ b/lib/foreman_maintain/utils/service/abstract.rb
@@ -55,6 +55,10 @@ module ForemanMaintain::Utils
         raise NotImplementedError
       end
 
+      def restart
+        raise NotImplementedError
+      end
+
       def enable
         raise NotImplementedError
       end

--- a/lib/foreman_maintain/utils/service/remote_db.rb
+++ b/lib/foreman_maintain/utils/service/remote_db.rb
@@ -38,6 +38,14 @@ module ForemanMaintain::Utils
         [0, db_status.last]
       end
 
+      def restart
+        command_name = ForemanMaintain.command_name
+        db_status(<<~MSG
+          Remote databases are not managed by #{command_name} and therefore was not restarted.
+        MSG
+                 )
+      end
+
       def running?
         status.first == 0
       end


### PR DESCRIPTION
It's not really a restart, as we can't control it, but it checks the DB
and returns the status properly.

Fixes: 7cdffe78727b48ca148ba50e9eb069fc522429f8
