### PR TITLE
Drop rotate-script from executables-section in gemspec

### DIFF
--- a/foreman_maintain.gemspec
+++ b/foreman_maintain.gemspec
@@ -18,8 +18,7 @@ the Foreman/Satellite up and running."
   s.files += `git ls-files extras`.split("\n")
   s.extra_rdoc_files = ['LICENSE', 'README.md']
   s.require_paths = ['lib']
-  s.executables = ['foreman-maintain',
-                   'foreman-maintain-complete', 'foreman-maintain-rotate-tar']
+  s.executables = ['foreman-maintain', 'foreman-maintain-complete']
   s.required_ruby_version = ">= 2.7", "< 4"
 
   s.add_dependency 'clamp'


### PR DESCRIPTION
Fixes #929

### ToDo:

- [ ] Drop from [foreman-packaging](https://github.com/theforeman/foreman-packaging/blob/36daef0ed33329be3106f14a870c9264c15ee69c/packages/foreman/rubygem-foreman_maintain/rubygem-foreman_maintain.spec#L92)