### PR TITLE
make pulpcore-(api|content) same priority as workers

### DIFF
--- a/definitions/features/pulpcore.rb
+++ b/definitions/features/pulpcore.rb
@@ -68,8 +68,8 @@ class Features::Pulpcore < ForemanMaintain::Feature
 
   def self.pulpcore_common_services
     [
-      ForemanMaintain::Utils.system_service('pulpcore-api', 10, :socket => 'pulpcore-api'),
-      ForemanMaintain::Utils.system_service('pulpcore-content', 10, :socket => 'pulpcore-content'),
+      ForemanMaintain::Utils.system_service('pulpcore-api', 20, :socket => 'pulpcore-api'),
+      ForemanMaintain::Utils.system_service('pulpcore-content', 20, :socket => 'pulpcore-content'),
     ]
   end
 end


### PR DESCRIPTION
there is no good reason to have them at different priorities.
additionally, having them at 10 actually hurts as it's the same priority
as PostgreSQL which means the logs will be spammed by "connection
refused" if the DB is shut down while api/content are still in the
process of being shut-down (or booted up).

this does *not* fix the segfaults problem -- but at least makes the logs
a tad cleaner
