### PR TITLE
shorten the image metadata import messages

### DIFF
--- a/definitions/procedures/pulpcore/container_handle_image_metadata.rb
+++ b/definitions/procedures/pulpcore/container_handle_image_metadata.rb
@@ -14,8 +14,7 @@ module Procedures::Pulpcore
 
         feature(:service).handle_services(spinner, 'start', :only => necessary_services)
 
-        spinner.update('Adding image metadata to pulp. You can continue using the ' \
-               'system normally while the task runs in the background.')
+        spinner.update('Adding image metadata to pulp.')
         execute!(pulpcore_manager('container-handle-image-data'))
       end
     end

--- a/definitions/procedures/repositories/index_katello_repositories_container_metadata.rb
+++ b/definitions/procedures/repositories/index_katello_repositories_container_metadata.rb
@@ -8,8 +8,7 @@ module Procedures::Repositories
     end
 
     def run
-      with_spinner(('Adding image metadata. You can continue using the ' \
-                    'system normally while the task runs in the background.')) do
+      with_spinner('Adding image metadata to Katello.') do
         execute!('foreman-rake katello:import_container_manifest_labels')
       end
     end


### PR DESCRIPTION
This drops the "You can continue using …" part of the message to
1. make it shorter in the UI
2. make it less confusing when the import is actually finished
