### PR TITLE
Ensure sha1 check works with default certificates

### DIFF
--- a/definitions/checks/check_sha1_certificate_authority.rb
+++ b/definitions/checks/check_sha1_certificate_authority.rb
@@ -14,6 +14,8 @@ class Checks::CheckSha1CertificateAuthority < ForemanMaintain::Check
     installer_answers = feature(:installer).answers
     server_ca = installer_answers['certs']['server_ca_cert']
 
+    return unless server_ca
+
     certificate = OpenSSL::X509::Certificate.new(File.read(server_ca))
 
     msg = <<~MSG

--- a/test/definitions/checks/check_sha1_certificate_authority_test.rb
+++ b/test/definitions/checks/check_sha1_certificate_authority_test.rb
@@ -43,4 +43,15 @@ describe Checks::CheckSha1CertificateAuthority do
 
     assert result.fail?
   end
+
+  it 'succeeds when using default certificates' do
+    assume_feature_present(:katello)
+    assume_feature_present(
+      :installer,
+      answers: { 'certs' => { 'server_ca_cert' => nil } }
+    )
+    result = run_step(subject)
+
+    assert result.success?
+  end
 end


### PR DESCRIPTION
The server_cert parameter is nil when using default certificates.