### PR TITLE
add Ruby 3.3 to the test matrix

### DIFF
--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -11,7 +11,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7.4', '3.0.2', '3.1.3', '3.2.1']
+        ruby-version:
+          - '2.7.4'
+          - '3.0.2'
+          - '3.1.3'
+          - '3.2.1'
+          - '3.3.5'
     steps:
       - uses: actions/checkout@v2
       - name: Setup Ruby


### PR DESCRIPTION
3.3.5 is what's currently in CentOS Stream 10
