### PR TITLE
Fixes #38119: When the "server_ca_cert" is set and has an empty line, it will fail

### DIFF
--- a/definitions/checks/check_sha1_certificate_authority.rb
+++ b/definitions/checks/check_sha1_certificate_authority.rb
@@ -42,7 +42,7 @@ class Checks::CheckSha1CertificateAuthority < ForemanMaintain::Check
       File.binread(bundle_pem).
         lines.
         slice_after(/END CERTIFICATE/).
-        map { |pem| OpenSSL::X509::Certificate.new(pem.join) }
+        map { |pem| OpenSSL::X509::Certificate.new(pem.join) if pem.join =~ /-+BEGIN .+-+END/m }
     end
   end
 end


### PR DESCRIPTION
When bundle_pem contains non-certificate contents after the final `---END CERTIFICATE---` line, the `OpenSSL::X509::Certificate.new(pem.join)` action will fail because `pem.join` will be an empty or non-certificate string and the `load_fullchain(bundle_pem)` function will fail.

This change adds a check for the presence of `-+BEGIN` followed (however many lines later) by `-+END` before trying to load it as an x509 certificate object, thus preventing blank contents from being loaded as x509 certificates.