### PR TITLE
reword remote-db restart message to avoid command name

### DIFF
--- a/lib/foreman_maintain/utils/service/remote_db.rb
+++ b/lib/foreman_maintain/utils/service/remote_db.rb
@@ -39,9 +39,8 @@ module ForemanMaintain::Utils
       end
 
       def restart
-        command_name = ForemanMaintain.command_name
         db_status(<<~MSG
-          Remote databases are not managed by #{command_name} and therefore was not restarted.
+          Remote databases are not managed and therefore no restart was performed.
         MSG
                  )
       end


### PR DESCRIPTION
For some reason calling ForemanMaintain.command_name results in

    /usr/share/gems/gems/foreman_maintain-1.8.1/lib/foreman_maintain/concerns/metadata.rb:227:in `evaluate_confines': Recursive confine block call detected (RuntimeError)
        from /usr/share/gems/gems/foreman_maintain-1.8.1/lib/foreman_maintain/concerns/metadata.rb:204:in `present?'
        from /usr/share/gems/gems/foreman_maintain-1.8.1/lib/foreman_maintain/detector.rb:113:in `each'
        from /usr/share/gems/gems/foreman_maintain-1.8.1/lib/foreman_maintain/detector.rb:113:in `find'
        from /usr/share/gems/gems/foreman_maintain-1.8.1/lib/foreman_maintain/detector.rb:113:in `detect_feature'
        from /usr/share/gems/gems/foreman_maintain-1.8.1/lib/foreman_maintain/detector.rb:11:in `feature'
        from /usr/share/gems/gems/foreman_maintain-1.8.1/lib/foreman_maintain/concerns/finders.rb:9:in `feature'
        from /usr/share/gems/gems/foreman_maintain-1.8.1/definitions/features/instance.rb:58:in `downstream'
        from /usr/share/gems/gems/foreman_maintain-1.8.1/lib/foreman_maintain.rb:171:in `pkg_and_cmd_name'
        from /usr/share/gems/gems/foreman_maintain-1.8.1/lib/foreman_maintain.rb:179:in `command_name'
        from /usr/share/gems/gems/foreman_maintain-1.8.1/lib/foreman_maintain/utils/service/remote_db.rb:42:in `restart'
        from /usr/share/gems/gems/foreman_maintain-1.8.1/definitions/features/service.rb:94:in `block (2 levels) in fork_threads_for_services'

At least when the Satellite/Capsule features are not present.

I *guess* that's because the service feature itself iterates over
existing features?

Either way, I couldn't find a good way to fix this, so let's just not
need `command_name` here in the message.
