### PR TITLE
Strip the output of the executed command

### DIFF
--- a/lib/foreman_maintain/utils/command_runner.rb
+++ b/lib/foreman_maintain/utils/command_runner.rb
@@ -89,6 +89,7 @@ module ForemanMaintain
 
       def run_non_interactively
         @output, @stderr, status = Open3.capture3(@env, full_command, :stdin_data => @stdin)
+        @output.strip!
         @exit_status = status.exitstatus
       end
 


### PR DESCRIPTION
Consumers of the command runner expect the output not to have any
trailing spaces, so let's strip them.

Fixes: 34609dfbe5bd00e2908e9876279f2e057bf2898d
