### PR TITLE
Rely on command_runner success after move to Open3

### DIFF
--- a/lib/foreman_maintain/concerns/system_helpers.rb
+++ b/lib/foreman_maintain/concerns/system_helpers.rb
@@ -46,8 +46,7 @@ module ForemanMaintain
       end
 
       def execute?(command, options = {})
-        execute(command, options)
-        $CHILD_STATUS.success?
+        execute_runner(command, options).success?
       end
 
       def command_present?(command_name)


### PR DESCRIPTION
Otherwise, just about everything is true!

```
rpm -q 'satellite'
package satellite is not installed
pid 21243 exit 0
```