### PR TITLE
Add report for collecting Katello content facts

### DIFF
--- a/definitions/reports/alternate_content_sources.rb
+++ b/definitions/reports/alternate_content_sources.rb
@@ -1,0 +1,46 @@
+module Checks
+  module Report
+    class AlternateContentSources < ForemanMaintain::Report
+      metadata do
+        description 'Facts about ACSs'
+        confine do
+          feature(:katello)
+        end
+      end
+
+      def run
+        data_field('custom_alternate_content_sources_count') { custom_alternate_content_sources }
+        data_field('simplified_alternate_content_sources_count') do
+          simplified_alternate_content_sources
+        end
+        data_field('rhui_alternate_content_sources_count') { rhui_alternate_content_sources }
+        data_field('yum_alternate_content_sources_count') { yum_alternate_content_sources }
+        data_field('file_alternate_content_sources_count') { file_alternate_content_sources }
+      end
+
+      def custom_alternate_content_sources
+        sql_count(
+          "katello_alternate_content_sources WHERE alternate_content_source_type = 'custom'"
+        )
+      end
+
+      def simplified_alternate_content_sources
+        sql_count(
+          "katello_alternate_content_sources WHERE alternate_content_source_type = 'simplified'"
+        )
+      end
+
+      def rhui_alternate_content_sources
+        sql_count("katello_alternate_content_sources WHERE alternate_content_source_type = 'rhui'")
+      end
+
+      def yum_alternate_content_sources
+        sql_count("katello_alternate_content_sources WHERE content_type = 'yum'")
+      end
+
+      def file_alternate_content_sources
+        sql_count("katello_alternate_content_sources WHERE content_type = 'file'")
+      end
+    end
+  end
+end

--- a/definitions/reports/content.rb
+++ b/definitions/reports/content.rb
@@ -11,67 +11,43 @@ module Checks
       def run
         data_field('custom_library_yum_repositories_count') { custom_library_yum_repositories }
         data_field('redhat_library_yum_repositories_count') { redhat_library_yum_repositories }
-        data_field('library_debian_repositories_count') { library_debian_repositories }
-        data_field('library_container_repositories_count') { library_container_repositories }
-        data_field('library_file_repositories_count') { library_file_repositories }
-        data_field('library_python_repositories_count') { library_python_repositories }
+        data_field('library_debian_repositories_count') { library_repositories('deb') }
+        data_field('library_container_repositories_count') { library_repositories('docker') }
+        data_field('library_file_repositories_count') { library_repositories('file') }
+        data_field('library_python_repositories_count') { library_repositories('python') }
         data_field('library_ansible_collection_repositories_count') do
-          library_ansible_collection_repositories
+          library_repositories('ansible_collection')
         end
-        data_field('library_ostree_repositories_count') { library_ostree_repositories }
+        data_field('library_ostree_repositories_count') { library_repositories('ostree') }
       end
 
       def custom_library_yum_repositories
-        query =
-          query(
-            <<-SQL
-              SELECT count(*) as yum_custom_count FROM "katello_root_repositories"
-                WHERE "katello_root_repositories"."id" NOT IN
-                (SELECT "katello_root_repositories"."id" FROM "katello_root_repositories" INNER JOIN "katello_products"
-                  ON "katello_products"."id" = "katello_root_repositories"."product_id" INNER JOIN "katello_providers"
-                  ON "katello_providers"."id" = "katello_products"."provider_id" WHERE "katello_providers"."provider_type" = 'Red Hat')
-                AND "katello_root_repositories"."content_type" = 'yum'
-            SQL
-          )
-        query.first['yum_custom_count'].to_i
+        query_snippet =
+          <<-SQL
+            "katello_root_repositories"
+              WHERE "katello_root_repositories"."id" NOT IN
+              (SELECT "katello_root_repositories"."id" FROM "katello_root_repositories" INNER JOIN "katello_products"
+                ON "katello_products"."id" = "katello_root_repositories"."product_id" INNER JOIN "katello_providers"
+                ON "katello_providers"."id" = "katello_products"."provider_id" WHERE "katello_providers"."provider_type" = 'Red Hat')
+              AND "katello_root_repositories"."content_type" = 'yum'
+          SQL
+        sql_count(query_snippet)
       end
 
       def redhat_library_yum_repositories
-        query =
-          query(
-            <<-SQL
-              SELECT count(*) as yum_rh_count FROM "katello_root_repositories"
-                INNER JOIN "katello_products" ON "katello_products"."id" = "katello_root_repositories"."product_id"
-                INNER JOIN "katello_providers" ON "katello_providers"."id" = "katello_products"."provider_id"
-                  WHERE "katello_providers"."provider_type" = 'Red Hat'
-                AND "katello_root_repositories"."content_type" = 'yum'
-            SQL
-          )
-        query.first['yum_rh_count'].to_i
+        query_snippet =
+          <<-SQL
+            "katello_root_repositories"
+              INNER JOIN "katello_products" ON "katello_products"."id" = "katello_root_repositories"."product_id"
+              INNER JOIN "katello_providers" ON "katello_providers"."id" = "katello_products"."provider_id"
+                WHERE "katello_providers"."provider_type" = 'Red Hat'
+              AND "katello_root_repositories"."content_type" = 'yum'
+          SQL
+        sql_count(query_snippet)
       end
 
-      def library_container_repositories
-        sql_count("katello_root_repositories WHERE content_type = 'docker'")
-      end
-
-      def library_ostree_repositories
-        sql_count("katello_root_repositories WHERE content_type = 'ostree'")
-      end
-
-      def library_ansible_collection_repositories
-        sql_count("katello_root_repositories WHERE content_type = 'ansible_collection'")
-      end
-
-      def library_file_repositories
-        sql_count("katello_root_repositories WHERE content_type = 'file'")
-      end
-
-      def library_python_repositories
-        sql_count("katello_root_repositories WHERE content_type = 'python'")
-      end
-
-      def library_debian_repositories
-        sql_count("katello_root_repositories WHERE content_type = 'deb'")
+      def library_repositories(content_type)
+        sql_count("katello_root_repositories WHERE content_type = '#{content_type}'")
       end
     end
   end

--- a/definitions/reports/content.rb
+++ b/definitions/reports/content.rb
@@ -51,63 +51,27 @@ module Checks
       end
 
       def library_container_repositories
-        query =
-          query(
-            <<-SQL
-              SELECT count(*) as container_count FROM "katello_root_repositories" WHERE "katello_root_repositories"."content_type" = 'docker'
-            SQL
-          )
-        query.first['container_count'].to_i
+        sql_count("katello_root_repositories WHERE content_type = 'docker'")
       end
 
       def library_ostree_repositories
-        query =
-          query(
-            <<-SQL
-              SELECT count(*) as ostree_count FROM "katello_root_repositories" WHERE "katello_root_repositories"."content_type" = 'ostree'
-            SQL
-          )
-        query.first['ostree_count'].to_i
+        sql_count("katello_root_repositories WHERE content_type = 'ostree'")
       end
 
       def library_ansible_collection_repositories
-        query =
-          query(
-            <<-SQL
-              SELECT count(*) as ansible_collection_count FROM "katello_root_repositories" WHERE "katello_root_repositories"."content_type" = 'ansible_collection'
-            SQL
-          )
-        query.first['ansible_collection_count'].to_i
+        sql_count("katello_root_repositories WHERE content_type = 'ansible_collection'")
       end
 
       def library_file_repositories
-        query =
-          query(
-            <<-SQL
-              SELECT count(*) as file_count FROM "katello_root_repositories" WHERE "katello_root_repositories"."content_type" = 'file'
-            SQL
-          )
-        query.first['file_count'].to_i
+        sql_count("katello_root_repositories WHERE content_type = 'file'")
       end
 
       def library_python_repositories
-        query =
-          query(
-            <<-SQL
-              SELECT count(*) as python_count FROM "katello_root_repositories" WHERE "katello_root_repositories"."content_type" = 'python'
-            SQL
-          )
-        query.first['python_count'].to_i
+        sql_count("katello_root_repositories WHERE content_type = 'python'")
       end
 
       def library_debian_repositories
-        query =
-          query(
-            <<-SQL
-              SELECT count(*) as debian_count FROM "katello_root_repositories" WHERE "katello_root_repositories"."content_type" = 'deb'
-            SQL
-          )
-        query.first['debian_count'].to_i
+        sql_count("katello_root_repositories WHERE content_type = 'deb'")
       end
     end
   end

--- a/definitions/reports/content.rb
+++ b/definitions/reports/content.rb
@@ -1,0 +1,114 @@
+module Checks
+  module Report
+    class Content < ForemanMaintain::Report
+      metadata do
+        description 'Facts about Katello content'
+        confine do
+          feature(:katello)
+        end
+      end
+
+      def run
+        data_field('custom_library_yum_repositories_count') { custom_library_yum_repositories }
+        data_field('redhat_library_yum_repositories_count') { redhat_library_yum_repositories }
+        data_field('library_debian_repositories_count') { library_debian_repositories }
+        data_field('library_container_repositories_count') { library_container_repositories }
+        data_field('library_file_repositories_count') { library_file_repositories }
+        data_field('library_python_repositories_count') { library_python_repositories }
+        data_field('library_ansible_collection_repositories_count') do
+          library_ansible_collection_repositories
+        end
+        data_field('library_ostree_repositories_count') { library_ostree_repositories }
+      end
+
+      def custom_library_yum_repositories
+        query =
+          query(
+            <<-SQL
+              SELECT count(*) as yum_custom_count FROM "katello_root_repositories"
+                WHERE "katello_root_repositories"."id" NOT IN
+                (SELECT "katello_root_repositories"."id" FROM "katello_root_repositories" INNER JOIN "katello_products"
+                  ON "katello_products"."id" = "katello_root_repositories"."product_id" INNER JOIN "katello_providers"
+                  ON "katello_providers"."id" = "katello_products"."provider_id" WHERE "katello_providers"."provider_type" = 'Red Hat')
+                AND "katello_root_repositories"."content_type" = 'yum'
+            SQL
+          )
+        query.first['yum_custom_count'].to_i
+      end
+
+      def redhat_library_yum_repositories
+        query =
+          query(
+            <<-SQL
+              SELECT count(*) as yum_rh_count FROM "katello_root_repositories"
+                INNER JOIN "katello_products" ON "katello_products"."id" = "katello_root_repositories"."product_id"
+                INNER JOIN "katello_providers" ON "katello_providers"."id" = "katello_products"."provider_id"
+                  WHERE "katello_providers"."provider_type" = 'Red Hat'
+                AND "katello_root_repositories"."content_type" = 'yum'
+            SQL
+          )
+        query.first['yum_rh_count'].to_i
+      end
+
+      def library_container_repositories
+        query =
+          query(
+            <<-SQL
+              SELECT count(*) as container_count FROM "katello_root_repositories" WHERE "katello_root_repositories"."content_type" = 'docker'
+            SQL
+          )
+        query.first['container_count'].to_i
+      end
+
+      def library_ostree_repositories
+        query =
+          query(
+            <<-SQL
+              SELECT count(*) as ostree_count FROM "katello_root_repositories" WHERE "katello_root_repositories"."content_type" = 'ostree'
+            SQL
+          )
+        query.first['ostree_count'].to_i
+      end
+
+      def library_ansible_collection_repositories
+        query =
+          query(
+            <<-SQL
+              SELECT count(*) as ansible_collection_count FROM "katello_root_repositories" WHERE "katello_root_repositories"."content_type" = 'ansible_collection'
+            SQL
+          )
+        query.first['ansible_collection_count'].to_i
+      end
+
+      def library_file_repositories
+        query =
+          query(
+            <<-SQL
+              SELECT count(*) as file_count FROM "katello_root_repositories" WHERE "katello_root_repositories"."content_type" = 'file'
+            SQL
+          )
+        query.first['file_count'].to_i
+      end
+
+      def library_python_repositories
+        query =
+          query(
+            <<-SQL
+              SELECT count(*) as python_count FROM "katello_root_repositories" WHERE "katello_root_repositories"."content_type" = 'python'
+            SQL
+          )
+        query.first['python_count'].to_i
+      end
+
+      def library_debian_repositories
+        query =
+          query(
+            <<-SQL
+              SELECT count(*) as debian_count FROM "katello_root_repositories" WHERE "katello_root_repositories"."content_type" = 'deb'
+            SQL
+          )
+        query.first['debian_count'].to_i
+      end
+    end
+  end
+end


### PR DESCRIPTION
Begins Katello content fact collection for the analytics report. Starts with repository type information.

Example output:

```
[root@centos9-stream-katello-nightly foreman_maintain]# bin/foreman-maintain report generate | grep repositories
custom_library_yum_repositories_count: 1
redhat_library_yum_repositories_count: 1
library_debian_repositories_count: 1
library_container_repositories_count: 1
library_file_repositories_count: 1
library_python_repositories_count: 1
library_ansible_collection_repositories_count: 1
library_ostree_repositories_count: 1
```

Also adds some alternate content source fact collection:

```
[root@centos9-stream-katello-nightly foreman_maintain]# bin/foreman-maintain report generate | grep alternate
custom_alternate_content_sources_count: 2
simplified_alternate_content_sources_count: 1
rhui_alternate_content_sources_count: 1
yum_alternate_content_sources_count: 3
file_alternate_content_sources_count: 1
```