### PR TITLE
Fix modified settings in report

### DIFF
--- a/definitions/reports/platform.rb
+++ b/definitions/reports/platform.rb
@@ -57,7 +57,7 @@ module Reports
 
     def settings_fields
       data_field('modified_settings') do
-        query("select name from settings").
+        query("select name from settings WHERE value IS NOT NULL").
           map { |setting_line| setting_line['name'] }.
           join(',')
       end


### PR DESCRIPTION
When a setting is modified, but then reset to its default value, an entry still remains in the settings table, but its value is null.