### PR TITLE
Add report for collecting image mode host counts

### DIFF
--- a/definitions/reports/image_mode_hosts.rb
+++ b/definitions/reports/image_mode_hosts.rb
@@ -1,0 +1,27 @@
+module Reports
+  class ImageModeHosts < ForemanMaintain::Report
+    metadata do
+      description 'Report number of image mode hosts registered by operating system'
+      confine do
+        feature(:katello)
+      end
+    end
+
+    def run
+      merge_data('image_mode_hosts_by_os_count') { image_mode_hosts_by_os_count }
+    end
+
+    # OS usage on image mode hosts
+    def image_mode_hosts_by_os_count
+      query(
+        <<-SQL
+          select max(operatingsystems.name) as os_name, count(*) as hosts_count
+          from hosts inner join operatingsystems on operatingsystem_id = operatingsystems.id inner join katello_content_facets on hosts.id = katello_content_facets.host_id
+          where bootc_booted_digest is not null
+          group by operatingsystems.name
+        SQL
+      ).
+        to_h { |row| [row['os_name'], row['hosts_count'].to_i] }
+    end
+  end
+end


### PR DESCRIPTION
Host counts or sorted by OS same as the existing `hosts_count_by_os`.

Open question: Should image mode hosts should still be counted in existing `hosts_count_by_os`? Or should the total host count be split between `image_mode_hosts_count_by_os` and `hosts_count_by_os`?