### PR TITLE
Condense the generated report

### DIFF
--- a/definitions/reports/inventory.rb
+++ b/definitions/reports/inventory.rb
@@ -36,7 +36,7 @@ module Reports
         <<-SQL
             select max(operatingsystems.type) as os_family, count(*) as hosts_count
             from hosts inner join operatingsystems on operatingsystem_id = operatingsystems.id
-            group by operatingsystem_id
+            group by operatingsystems.type
         SQL
       ).
         to_h { |row| [row['os_family'], row['hosts_count'].to_i] }

--- a/definitions/reports/inventory.rb
+++ b/definitions/reports/inventory.rb
@@ -7,6 +7,7 @@ module Reports
     def run
       merge_data('hosts_by_type_count') { hosts_by_type_count }
       merge_data('hosts_by_os_count') { hosts_by_os_count }
+      merge_data('hosts_by_family_count') { hosts_by_family_count}
       merge_data('facts_by_type') { facts_by_type }
       merge_data('audits') { audits }
       merge_data('parameters_count') { parameters }
@@ -28,6 +29,17 @@ module Reports
         SQL
       ).
         to_h { |row| [row['os_name'], row['hosts_count'].to_i] }
+    end
+
+    def hosts_by_family_count
+      query(
+        <<-SQL
+            select max(operatingsystems.type) as os_family, count(*) as hosts_count
+            from hosts inner join operatingsystems on operatingsystem_id = operatingsystems.id
+            group by operatingsystem_id
+        SQL
+      ).
+        to_h { |row| [row['os_family'], row['hosts_count'].to_i] }
     end
 
     # Facts usage

--- a/definitions/reports/inventory.rb
+++ b/definitions/reports/inventory.rb
@@ -7,7 +7,7 @@ module Reports
     def run
       merge_data('hosts_by_type_count') { hosts_by_type_count }
       merge_data('hosts_by_os_count') { hosts_by_os_count }
-      merge_data('hosts_by_family_count') { hosts_by_family_count}
+      merge_data('hosts_by_family_count') { hosts_by_family_count }
       merge_data('facts_by_type') { facts_by_type }
       merge_data('audits') { audits }
       merge_data('parameters_count') { parameters }

--- a/lib/foreman_maintain/cli/report_command.rb
+++ b/lib/foreman_maintain/cli/report_command.rb
@@ -37,10 +37,10 @@ module ForemanMaintain
       subcommand 'condense', 'Condense the report' do
         def execute
           data = if fresh_enough?(@input, @max_age)
-            YAML.load_file(@input)
-          else
-            generate_report
-          end
+                   YAML.load_file(@input)
+                 else
+                   generate_report
+                 end
 
           report = condense_report(data)
           report = prefix_keys(report)
@@ -49,8 +49,9 @@ module ForemanMaintain
 
         def condense_report(data)
           result = {}
-          result['advisor_on_prem_remediations_count'] = data['advisor_on_prem_remediations_count'] || 0
-          result['rhel_ai_workload_host_count'] = data['rhel_ai_workload_host_count'] || 0
+          %w[advisor_on_prem_remediations_count rhel_ai_workload_host_count].each do |key|
+            result[key] = data[key] || 0
+          end
           result.merge!(aggregate_host_count(data))
           result.merge!(aggregate_image_mode_host_count(data))
           result.merge!(aggregate_networking_metrics(data))
@@ -67,7 +68,9 @@ module ForemanMaintain
           rh_count = data['hosts_by_family_count|Redhat'] || 0
           result['host_rhel_count'] = rhel_count
           result['host_redhat_count'] = rh_count - rhel_count
-          result['host_other_count'] = data.select { |k, _| k.start_with?('hosts_by_os_count') }.values.sum - rhel_count - rh_count
+          result['host_other_count'] = data.select do |k, _|
+            k.start_with?('hosts_by_os_count')
+          end.values.sum - rhel_count - rh_count
           result
         end
 
@@ -77,20 +80,36 @@ module ForemanMaintain
         end
 
         def aggregate_networking_metrics(data)
-          ipv6 = data.values_at('subnet_ipv6_count', 'hosts_with_ipv6only_interface_count', 'foreman_interfaces_ipv6only_count').map { |v| v || 0 }.any?(&:positive?)
-
+          ipv6 = any_positive?(data, %w[subnet_ipv6_count hosts_with_ipv6only_interface_count
+                                        foreman_interfaces_ipv6only_count])
           # Deployment is considered to run in dualstack mode if:
           # - Foreman has both ipv6 and ipv4 addresses on a single interface
           # - or if any host in Foreman has both ipv6 and ipv4 addresses on a single interface
-          dualstack = data.values_at('hosts_with_dualstack_interface_count', 'foreman_interfaces_dualstack_count').map { |v| v || 0 }.any?(&:positive?)
+          dualstack = any_positive?(data, %w[hosts_with_dualstack_interface_count
+                                             foreman_interfaces_dualstack_count])
+
           # - or if there are both ipv4 and ipv6 subnets defined
-          dualstack |= data.values_at('subnet_ipv4_count', 'subnet_ipv6_count').map { |v| v || 0 }.all?(&:positive?)
-          # - or if any host in Foreman has an interface with only an ipv4 address as well as another interface with ipv6 address
-          dualstack |= data.values_at('hosts_with_ipv4only_interface_count', 'hosts_with_ipv6only_interface_count').map { |v| v || 0 }.all?(&:positive?)
-          # - Foreman has an interface with only an ipv4 address as well as another interface with ipv6 address
-          dualstack |= data.values_at('foreman_interfaces_ipv4only_count', 'foreman_interfaces_ipv6only_count').map { |v| v || 0 }.all?(&:positive?)
+          dualstack |= all_positive?(data, %w[subnet_ipv4_count subnet_ipv6_count])
+
+          # - or if any host in Foreman has an interface with only an ipv4 address
+          #   as well as another interface with ipv6 address
+          dualstack |= all_positive?(data, %w[hosts_with_ipv4only_interface_count
+                                              hosts_with_ipv6only_interface_count])
+
+          # - or if Foreman has an interface with only an ipv4 address
+          #   as well as another interface with ipv6 address
+          dualstack |= all_positive?(data,
+            %w[foreman_interfaces_ipv4only_count foreman_interfaces_ipv6only_count])
 
           { 'use_dualstack' => dualstack, 'use_ipv6' => ipv6 }
+        end
+
+        def all_positive?(source, keys)
+          source.values_at(*keys).map { |x| x || 0 }.all?(&:positive?)
+        end
+
+        def any_positive?(source, keys)
+          source.values_at(*keys).map { |x| x || 0 }.any?(&:positive?)
         end
 
         def prefix_keys(data)
@@ -98,7 +117,7 @@ module ForemanMaintain
         end
 
         def fresh_enough?(input, max_age)
-          @input && File.exists?(input) &&
+          @input && File.exist?(input) &&
             (@max_age.nil? || (Time.now - File.stat(input).mtime <= 60 * 60 * max_age.to_i))
         end
       end

--- a/lib/foreman_maintain/cli/report_command.rb
+++ b/lib/foreman_maintain/cli/report_command.rb
@@ -3,21 +3,99 @@ module ForemanMaintain
     class ReportCommand < Base
       extend Concerns::Finders
 
+      def generate_report
+        scenario = run_scenario(Scenarios::Report::Generate.new({}, [:reports])).first
+
+        # description can be used too
+        report_data = scenario.steps.map(&:data).compact.reduce(&:merge).transform_keys(&:to_s)
+        report_data['version'] = 1
+        report_data
+      end
+
+      def save_report(report, file)
+        if file
+          File.write(file, report)
+        else
+          puts report
+        end
+      end
+
       option '--output', 'FILE', 'Output the generate report into FILE'
       subcommand 'generate', 'Generates the usage reports' do
         def execute
-          scenario = run_scenario(Scenarios::Report::Generate.new({}, [:reports])).first
-
-          # description can be used too
-          report_data = scenario.steps.map(&:data).compact.reduce(&:merge).transform_keys(&:to_s)
-          report_data['version'] = 1
+          report_data = generate_report
           yaml = report_data.to_yaml
-          if @output
-            File.write(@output, yaml)
-          else
-            puts yaml
-          end
+          save_report(yaml, @output)
+
           exit runner.exit_code
+        end
+      end
+
+      option '--input', 'FILE', 'Input the report from FILE'
+      option '--output', 'FILE', 'Output the condense report into FILE'
+      option '--max-age', 'HOURS', 'Max age of the report in hours'
+      subcommand 'condense', 'Condense the report' do
+        def execute
+          data = if fresh_enough?(@input, @max_age)
+            YAML.load_file(@input)
+          else
+            generate_report
+          end
+
+          report = condense_report(data)
+          report = prefix_keys(report)
+          save_report(JSON.dump(report), @output)
+        end
+
+        def condense_report(data)
+          result = data.slice('advisor_on_prem_remediations', 'rhel_ai_workload_host_count')
+          result.merge!(aggregate_host_count(data))
+          result.merge!(aggregate_image_mode_host_count(data))
+          result.merge!(aggregate_networking_metrics(data))
+          result
+        end
+
+        # Aggregates the host count numbers. The goal is to distinguish
+        # - RHEL hosts
+        # - RedHat family but not RHEL hosts
+        # - Other hosts
+        def aggregate_host_count(data)
+          result = {}
+          result['host_rhel_count'] = data['hosts_by_os_count|RedHat']
+          result['host_redhat_count'] = data['hosts_by_family_count|Redhat'] - data['hosts_by_os_count|RedHat']
+          result['host_other_count'] = data.select { |k, _| k.start_with?('hosts_by_os_count') }.values.sum - result['host_rhel_count'] - result['host_redhat_count']
+          result
+        end
+
+        def aggregate_image_mode_host_count(data)
+          count = data.select { |k, _| k.start_with?('image_mode_hosts_by_os_count') }.values.sum
+          { 'image_mode_host_count' => count }
+        end
+
+        def aggregate_networking_metrics(data)
+          ipv6 = data.values_at('subnet_ipv6_count', 'hosts_with_ipv6only_interface_count', 'foreman_interfaces_ipv6only_count').map { |v| v || 0 }.any?(&:positive?)
+
+          # Deployment is considered to run in dualstack mode if:
+          # - Foreman has both ipv6 and ipv4 addresses on a single interface
+          # - or if any host in Foreman has both ipv6 and ipv4 addresses on a single interface
+          dualstack = data.values_at('hosts_with_dualstack_interface_count', 'foreman_interfaces_dualstack_count').map { |v| v || 0 }.any?(&:positive?)
+          # - or if there are both ipv4 and ipv6 subnets defined
+          dualstack |= data.values_at('subnet_ipv4_count', 'subnet_ipv6_count').map { |v| v || 0 }.all?(&:positive?)
+          # - or if any host in Foreman has an interface with only an ipv4 address as well as another interface with ipv6 address
+          dualstack |= data.values_at('hosts_with_ipv4only_interface_count', 'hosts_with_ipv6only_interface_count').map { |v| v || 0 }.all?(&:positive?)
+          # - Foreman has an interface with only an ipv4 address as well as another interface with ipv6 address
+          dualstack |= data.values_at('foreman_interfaces_ipv4only_count', 'foreman_interfaces_ipv6only_count').map { |v| v || 0 }.all?(&:positive?)
+
+          { 'use_dualstack' => dualstack, 'use_ipv6' => ipv6 }
+        end
+
+        def prefix_keys(data)
+          data.transform_keys { |key| 'foreman.' + key }
+        end
+
+        def fresh_enough?(input, max_age)
+          @input && File.exists?(input) &&
+            (@max_age.nil? || (Time.now - File.stat(input).mtime <= 60 * 60 * max_age.to_i))
         end
       end
     end

--- a/lib/foreman_maintain/cli/report_command.rb
+++ b/lib/foreman_maintain/cli/report_command.rb
@@ -49,7 +49,7 @@ module ForemanMaintain
 
         def condense_report(data)
           result = {}
-          result['advisor_on_prem_remediations'] = data['advisor_on_prem_remediations'] || 0
+          result['advisor_on_prem_remediations_count'] = data['advisor_on_prem_remediations_count'] || 0
           result['rhel_ai_workload_host_count'] = data['rhel_ai_workload_host_count'] || 0
           result.merge!(aggregate_host_count(data))
           result.merge!(aggregate_image_mode_host_count(data))

--- a/lib/foreman_maintain/cli/report_command.rb
+++ b/lib/foreman_maintain/cli/report_command.rb
@@ -34,7 +34,7 @@ module ForemanMaintain
       option '--input', 'FILE', 'Input the report from FILE'
       option '--output', 'FILE', 'Output the condense report into FILE'
       option '--max-age', 'HOURS', 'Max age of the report in hours'
-      subcommand 'condense', 'Condense the report' do
+      subcommand 'condense', 'Generate a JSON formatted report with condensed data from the original report.' do
         def execute
           data = if fresh_enough?(@input, @max_age)
                    YAML.load_file(@input)

--- a/lib/foreman_maintain/cli/report_command.rb
+++ b/lib/foreman_maintain/cli/report_command.rb
@@ -48,7 +48,9 @@ module ForemanMaintain
         end
 
         def condense_report(data)
-          result = data.slice('advisor_on_prem_remediations', 'rhel_ai_workload_host_count')
+          result = {}
+          result['advisor_on_prem_remediations'] = data['advisor_on_prem_remediations'] || 0
+          result['rhel_ai_workload_host_count'] = data['rhel_ai_workload_host_count'] || 0
           result.merge!(aggregate_host_count(data))
           result.merge!(aggregate_image_mode_host_count(data))
           result.merge!(aggregate_networking_metrics(data))
@@ -61,9 +63,11 @@ module ForemanMaintain
         # - Other hosts
         def aggregate_host_count(data)
           result = {}
-          result['host_rhel_count'] = data['hosts_by_os_count|RedHat']
-          result['host_redhat_count'] = data['hosts_by_family_count|Redhat'] - data['hosts_by_os_count|RedHat']
-          result['host_other_count'] = data.select { |k, _| k.start_with?('hosts_by_os_count') }.values.sum - result['host_rhel_count'] - result['host_redhat_count']
+          rhel_count = data['hosts_by_os_count|RedHat'] || 0
+          rh_count = data['hosts_by_family_count|Redhat'] || 0
+          result['host_rhel_count'] = rhel_count
+          result['host_redhat_count'] = rh_count - rhel_count
+          result['host_other_count'] = data.select { |k, _| k.start_with?('hosts_by_os_count') }.values.sum - rhel_count - rh_count
           result
         end
 

--- a/lib/foreman_maintain/cli/report_command.rb
+++ b/lib/foreman_maintain/cli/report_command.rb
@@ -34,7 +34,8 @@ module ForemanMaintain
       option '--input', 'FILE', 'Input the report from FILE'
       option '--output', 'FILE', 'Output the condense report into FILE'
       option '--max-age', 'HOURS', 'Max age of the report in hours'
-      subcommand 'condense', 'Generate a JSON formatted report with condensed data from the original report.' do
+      subcommand 'condense',
+        'Generate a JSON formatted report with condensed data from the original report.' do
         def execute
           data = if fresh_enough?(@input, @max_age)
                    YAML.load_file(@input)


### PR DESCRIPTION
I admit this is a bit rough, but I wanted to put together something quick that we can talk about something a bit more specific.

TODO:
- [x] polish this
- [x] make it less prone to crashing if some of the source data is missing
- [ ] ? move the code around
- [ ] ???
- [x] have all the prerequisites

# Prerequisites
- https://github.com/theforeman/foreman_maintain/pull/990
- https://github.com/theforeman/foreman_maintain/pull/994
- https://github.com/theforeman/foreman_maintain/pull/993
- https://github.com/theforeman/foreman_maintain/pull/992

# Rationale

`foreman-maintain report generate` collects _a lot_ of metrics. This high number may be fine in some cases, but it might be problematic in others. The goal here is to be able to derive a condensed report containing only the data points that we absolutely need.

# How it's meant to be used
The goal is to have something that is able to generate the condensed report either on the fly or from an pre-existing full report. It can also take into consideration the modification time of the full report so that the condensed report is reasonably fresh.

# Example data
```
# foreman-maintain report condense --output /tmp/condensed-report.json
-----B<-----SNIP-----B<-----

# json_reformat </tmp/condensed-report.json
{
    "foreman.advisor_on_prem_remediations: 12,
    "foreman.rhel_ai_workload_host_count: 1,
    "foreman.host_rhel_count": 203,
    "foreman.host_redhat_count": 20,
    "foreman.host_other_count": 8,
    "foreman.image_mode_host_count": 4,
    "foreman.use_dualstack": false,
    "foreman.use_ipv6": true
}
```