### PR TITLE
Fix host_count_by_os grouping

### DIFF
--- a/definitions/reports/inventory.rb
+++ b/definitions/reports/inventory.rb
@@ -24,7 +24,7 @@ module Reports
         <<-SQL
             select max(operatingsystems.name) as os_name, count(*) as hosts_count
             from hosts inner join operatingsystems on operatingsystem_id = operatingsystems.id
-            group by operatingsystem_id
+            group by operatingsystems.name
         SQL
       ).
         to_h { |row| [row['os_name'], row['hosts_count'].to_i] }


### PR DESCRIPTION
Before
```
# select max(operatingsystems.name) as os_name, count(*) as hosts_count
            from hosts inner join operatingsystems on operatingsystem_id = operatingsystems.id
            group by operatingsystem_id;
    os_name    | hosts_count
---------------+-------------
 CentOS        |           1
 RedHat        |           4
 Fedora        |           1
 RedHat        |           1
 CentOS_Stream |           1
 RedHat        |           3
 CentOS        |           4
 RedHat        |           1
 Fedora_CoreOS |           1
 CentOS_Stream |           3
 RedHat        |           1
 Debian        |           3
 OracleLinux   |           1
 CentOS        |           1
 Fedora        |           1
 RedHat        |           1
 OracleLinux   |           1
 RedHat        |           4
 CentOS        |           6
 RedHat        |           2
 CentOS        |           9
 CentOS        |           1
 CentOS        |           2
 Ubuntu        |           1
 CentOS        |           3
 RedHat        |           2
 CentOS_Stream |           7
(27 rows)
```

After
```
# select max(operatingsystems.name) as os_name, count(*) as hosts_count
            from hosts inner join operatingsystems on operatingsystem_id = operatingsystems.id
            group by operatingsystems.name;
    os_name    | hosts_count
---------------+-------------
 RedHat        |          19
 Fedora        |           2
 CentOS_Stream |          11
 Fedora_CoreOS |           1
 OracleLinux   |           2
 Debian        |           3
 Ubuntu        |           1
 CentOS        |          27
(8 rows)
```