### PR TITLE
Add report for package actions on image mode hosts

### DIFF
--- a/definitions/reports/image_mode_hosts.rb
+++ b/definitions/reports/image_mode_hosts.rb
@@ -1,7 +1,7 @@
 module Reports
   class ImageModeHosts < ForemanMaintain::Report
     metadata do
-      description 'Report number of image mode hosts registered by operating system'
+      description 'Report metrics related to use of image mode'
       confine do
         feature(:katello)
       end
@@ -9,6 +9,7 @@ module Reports
 
     def run
       merge_data('image_mode_hosts_by_os_count') { image_mode_hosts_by_os_count }
+      data['remote_execution_transient_package_actions_count'] = transient_actions_count
     end
 
     # OS usage on image mode hosts
@@ -22,6 +23,28 @@ module Reports
         SQL
       ).
         to_h { |row| [row['os_name'], row['hosts_count'].to_i] }
+    end
+
+    def transient_actions_count
+      cte = <<~CTE
+        WITH bootc_hosts AS (
+          SELECT hosts.id FROM hosts
+          INNER JOIN katello_content_facets AS kcf ON hosts.id = kcf.host_id
+          WHERE kcf.bootc_booted_digest IS NOT NULL
+        )
+      CTE
+
+      sql = <<~SQL
+        job_invocations AS ji
+          INNER JOIN remote_execution_features AS ref ON ji.remote_execution_feature_id = ref.id
+          INNER JOIN template_invocations AS ti ON ji.id = ti.job_invocation_id
+          INNER JOIN bootc_hosts ON bootc_hosts.id = ti.host_id
+          WHERE ref.label LIKE 'katello_package%'
+             OR ref.label LIKE 'katello_errata%'
+             OR ref.label LIKE 'katello_group%'
+      SQL
+
+      sql_count(sql, cte: cte)
     end
   end
 end


### PR DESCRIPTION
The way it is currently implemented, package-related jobs being run against image mode hosts imply transient package installations.