### PR TITLE
fix in os count calculations

### DIFF
--- a/lib/foreman_maintain/cli/report_command.rb
+++ b/lib/foreman_maintain/cli/report_command.rb
@@ -70,7 +70,7 @@ module ForemanMaintain
           rhel_count = data['hosts_by_os_count|RedHat'] || 0
           rh_count = data['hosts_by_family_count|Redhat'] || 0
           result['host_rhel_count'] = rhel_count
-          result['host_redhat_count_without_rhel'] = rh_count - rhel_count
+          result['host_redhat_without_rhel_count'] = rh_count - rhel_count
           result['host_other_count'] = data.select do |k, _|
             k.start_with?('hosts_by_os_count')
           end.values.sum - rh_count

--- a/lib/foreman_maintain/cli/report_command.rb
+++ b/lib/foreman_maintain/cli/report_command.rb
@@ -70,10 +70,10 @@ module ForemanMaintain
           rhel_count = data['hosts_by_os_count|RedHat'] || 0
           rh_count = data['hosts_by_family_count|Redhat'] || 0
           result['host_rhel_count'] = rhel_count
-          result['host_redhat_count'] = rh_count - rhel_count
+          result['host_redhat_count_without_rhel'] = rh_count - rhel_count
           result['host_other_count'] = data.select do |k, _|
             k.start_with?('hosts_by_os_count')
-          end.values.sum - rhel_count - rh_count
+          end.values.sum - rh_count
           result
         end
 


### PR DESCRIPTION
before:
```
~]# cat sample.yml 
---
hosts_by_os_count|RedHat: 20
hosts_by_os_count|CentOS: 10
hosts_by_family_count|Redhat: 30

~]# foreman-maintain report condense --input sample.yml --output smallreport

~]# cat smallreport 
{...
"foreman.host_rhel_count":20,"foreman.host_redhat_count":10,"foreman.host_other_count":-20,
...}
```

Assuming other means "other than RH os", not "other than RH family"

with this change:
```
~]# cat smallreport 
{...
"foreman.host_rhel_count":20,"foreman.host_redhat_count":30,"foreman.host_other_count":10,
...}
```
