### PR TITLE
remove vmaas-sync from list of services

### DIFF
--- a/definitions/features/iop.rb
+++ b/definitions/features/iop.rb
@@ -39,7 +39,6 @@ class Features::Iop < ForemanMaintain::Feature
       system_service('iop-service-vuln-listener', 20),
       system_service('iop-service-vuln-manager', 20),
       system_service('iop-service-vuln-taskomatic', 20),
-      system_service('iop-service-vuln-vmaas-sync', 20),
     ]
   end
   # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
it's a timer that behaves like cron, we need to implement handling for that specifically