### PR TITLE
backup kafka volume

### DIFF
--- a/definitions/features/iop.rb
+++ b/definitions/features/iop.rb
@@ -10,7 +10,7 @@ class Features::Iop < ForemanMaintain::Feature
 
   def config_files
     [
-      '/var/lib/kafka',
+      '/var/lib/containers/storage/volumes/iop-core-kafka-data',
       '/var/lib/vmaas',
     ]
   end


### PR DESCRIPTION
In https://github.com/theforeman/puppet-iop/pull/40 we switched to a podman volume, so we should backup that instead of /var/lib/kafka