### PR TITLE
mark steps that were filtered due to confine as skipped

### DIFF
--- a/lib/foreman_maintain/executable.rb
+++ b/lib/foreman_maintain/executable.rb
@@ -139,7 +139,11 @@ module ForemanMaintain
       setup_execution_state(execution)
       unless skipped?
         if defined?(self.class.present?)
-          run if self.class.present?
+          if self.class.present?
+            run
+          else
+            skip
+          end
         else
           run
         end


### PR DESCRIPTION
this is especially interesting when running checks, as sometimes a check is not applicable to a system (and thus confined) but we'd still report the result as "OK" which can confuse the user