### PR TITLE
extract pulp data *after* the DB has been restored

### DIFF
--- a/definitions/scenarios/restore.rb
+++ b/definitions/scenarios/restore.rb
@@ -34,12 +34,13 @@ module ForemanMaintain::Scenarios
         add_steps_with_context(Procedures::Restore::InstallerReset)
       end
       add_step_with_context(Procedures::Service::Stop)
-      add_steps_with_context(Procedures::Restore::ExtractFiles) if backup.tar_backups_exist?
 
       if backup.sql_needs_dump_restore?
         add_steps_with_context(Procedures::Restore::DropDatabases)
         restore_sql_dumps(backup)
       end
+
+      add_steps_with_context(Procedures::Restore::ExtractFiles) if backup.tar_backups_exist?
 
       add_step(Procedures::Installer::Run.new(:assumeyes => true))
       add_step_with_context(Procedures::Installer::UpgradeRakeTask)


### PR DESCRIPTION
this has the benefit that if the DB restore fails for some reason, this is detected faster
