### PR TITLE
execute amcheck before doing backups

### DIFF
--- a/definitions/checks/candlepin/db_index.rb
+++ b/definitions/checks/candlepin/db_index.rb
@@ -1,0 +1,25 @@
+module Checks
+  module Candlepin
+    class DBIndex < ForemanMaintain::Check
+      metadata do
+        description 'Make sure Candlepin DB indexes are OK'
+        label :candlepin_db_index
+        tags :db_index
+        for_feature :candlepin_database
+        confine do
+          feature(:candlepin_database)&.local?
+        end
+      end
+
+      def run
+        status, output = feature(:candlepin_database).amcheck
+
+        if !status.nil?
+          assert(status == 0, "Candlepin DB indexes have issues:\n#{output}")
+        else
+          skip 'amcheck is not available in this setup'
+        end
+      end
+    end
+  end
+end

--- a/definitions/checks/foreman/db_index.rb
+++ b/definitions/checks/foreman/db_index.rb
@@ -1,0 +1,25 @@
+module Checks
+  module Foreman
+    class DBIndex < ForemanMaintain::Check
+      metadata do
+        description 'Make sure Foreman DB indexes are OK'
+        label :foreman_db_index
+        tags :db_index
+        for_feature :foreman_database
+        confine do
+          feature(:foreman_database)&.local?
+        end
+      end
+
+      def run
+        status, output = feature(:foreman_database).amcheck
+
+        if !status.nil?
+          assert(status == 0, "Foreman DB indexes have issues:\n#{output}")
+        else
+          skip 'amcheck is not available in this setup'
+        end
+      end
+    end
+  end
+end

--- a/definitions/checks/pulpcore/db_index.rb
+++ b/definitions/checks/pulpcore/db_index.rb
@@ -1,0 +1,25 @@
+module Checks
+  module Pulpcore
+    class DBIndex < ForemanMaintain::Check
+      metadata do
+        description 'Make sure Pulpcore DB indexes are OK'
+        label :pulpcore_db_index
+        tags :db_index
+        for_feature :pulpcore_database
+        confine do
+          feature(:pulpcore_database)&.local?
+        end
+      end
+
+      def run
+        status, output = feature(:pulpcore_database).amcheck
+
+        if !status.nil?
+          assert(status == 0, "Pulpcore DB indexes have issues:\n#{output}")
+        else
+          skip 'amcheck is not available in this setup'
+        end
+      end
+    end
+  end
+end

--- a/definitions/scenarios/backup.rb
+++ b/definitions/scenarios/backup.rb
@@ -18,6 +18,9 @@ module ForemanMaintain::Scenarios
 
     def compose
       check_valid_strategy
+      add_step(Checks::Foreman::DBIndex)
+      add_step(Checks::Candlepin::DBIndex)
+      add_step(Checks::Pulpcore::DBIndex)
       add_step(Checks::ForemanTasks::NotRunning.new(:wait_for_tasks => wait_for_tasks?))
       add_step(Checks::Pulpcore::NoRunningTasks.new(:wait_for_tasks => wait_for_tasks?))
       add_step_with_context(Procedures::Backup::AccessibilityConfirmation) if strategy == :offline

--- a/test/definitions/scenarios/backup_test.rb
+++ b/test/definitions/scenarios/backup_test.rb
@@ -29,7 +29,11 @@ module Scenarios
     end
 
     let(:checks) do
-      task_checks
+      task_checks + [
+        Checks::Foreman::DBIndex,
+        Checks::Candlepin::DBIndex,
+        Checks::Pulpcore::DBIndex,
+      ]
     end
 
     describe 'offline' do


### PR DESCRIPTION
this ensures that the database is restorable or if it isn't (when there are index issues) the user knows at the time of the backup