### PR TITLE
Run rpm-datarepair on upgrade Pulp RPM 4073

### DIFF
--- a/definitions/procedures/pulpcore/rpm_datarepair.rb
+++ b/definitions/procedures/pulpcore/rpm_datarepair.rb
@@ -1,0 +1,17 @@
+module Procedures::Pulpcore
+  class RpmDatarepair < ForemanMaintain::Procedure
+    include ForemanMaintain::Concerns::PulpCommon
+
+    metadata do
+      description 'Rename ContentArtifact relative_paths to match `{N-V-R.A.rpm}`'
+      for_feature :pulpcore
+    end
+
+    def run
+      with_spinner('Running pulpcore-manager rpm-datarepair 4073') do
+        # Assumption: services are already started
+        execute!(pulpcore_manager('rpm-datarepair 4073'))
+      end
+    end
+  end
+end

--- a/definitions/scenarios/foreman_upgrade.rb
+++ b/definitions/scenarios/foreman_upgrade.rb
@@ -113,6 +113,7 @@ module Scenarios::Foreman
       add_steps(
         Procedures::RefreshFeatures,
         Procedures::Service::Start,
+        Procedures::Pulpcore::RpmDatarepair,
         Procedures::Crond::Start,
         Procedures::Timer::Start,
         Procedures::SyncPlans::Enable,

--- a/definitions/scenarios/satellite_upgrade.rb
+++ b/definitions/scenarios/satellite_upgrade.rb
@@ -117,6 +117,7 @@ module Scenarios::Satellite
       add_steps(
         Procedures::RefreshFeatures,
         Procedures::Service::Start,
+        Procedures::Pulpcore::RpmDatarepair,
         Procedures::Crond::Start,
         Procedures::Timer::Start,
         Procedures::SyncPlans::Enable,

--- a/test/definitions/procedures/pulpcore/rpm_datarepair_test.rb
+++ b/test/definitions/procedures/pulpcore/rpm_datarepair_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+describe Procedures::Pulpcore::RpmDatarepair do
+  include DefinitionsTestHelper
+
+  subject { Procedures::Pulpcore::RpmDatarepair.new }
+
+  it 'runs pulpcore-manager rpm-datarepair 4073' do
+    assume_feature_present(:pulpcore)
+    assume_feature_present(:pulpcore_database, :services => [])
+    assume_feature_present(:service)
+
+    subject.expects(:execute!).with(
+      'PULP_SETTINGS=/etc/pulp/settings.py runuser -u pulp -- ' \
+      'pulpcore-manager rpm-datarepair 4073'
+    ).once
+
+    result = run_procedure(subject)
+    assert result.success?
+  end
+end

--- a/test/definitions/scenarios/satellite_upgrade_test.rb
+++ b/test/definitions/scenarios/satellite_upgrade_test.rb
@@ -148,6 +148,7 @@ describe "satellite upgrade scenarios" do
         scenario,
         Procedures::RefreshFeatures,
         Procedures::Service::Start,
+        Procedures::Pulpcore::RpmDatarepair,
         Procedures::Crond::Start,
         Procedures::Timer::Start,
         Procedures::SyncPlans::Enable,


### PR DESCRIPTION
Adds a post-upgrade step to run a Pulp data repair for https://github.com/pulp/pulp_rpm/issues/4073

AI warning: I whipped this up quickly by feeding the requirements to Claude and mentioned to base the PR off of https://github.com/theforeman/foreman_maintain/pull/718

I haven't tested it yet, but I reviewed the code and made some edits to make the output better for humans.