### PR TITLE
Handle satellite-utils repo during upgrade

### DIFF
--- a/lib/foreman_maintain/concerns/downstream.rb
+++ b/lib/foreman_maintain/concerns/downstream.rb
@@ -21,8 +21,14 @@ module ForemanMaintain
           execute!(%(subscription-manager register #{org_options}\
                       --activationkey #{shellescape(activation_key)} --force))
         else
+          had_utils_enabled = repository_manager.enabled_repos.keys.any? { |r| r.start_with?("satellite-utils-") }
+
           repository_manager.rhsm_disable_repos(['*'])
-          repository_manager.rhsm_enable_repos(rh_repos(version))
+
+          repos = rh_repos(version)
+          repos << utils_repo(version) if had_utils_enabled
+
+          repository_manager.rhsm_enable_repos(repos)
         end
       end
 
@@ -63,6 +69,12 @@ module ForemanMaintain
       end
 
       private
+
+      def utils_repo(server_version)
+        server_version = version(server_version)
+        full_version   = "#{server_version.major}.#{server_version.minor}"
+        "satellite-utils-#{full_version}-for-rhel-#{el_major_version}-x86_64-rpms"
+      end
 
       def satellite_maintain_config
         if File.exist?(SATELLITE_MAINTAIN_CONFIG)

--- a/lib/foreman_maintain/concerns/downstream.rb
+++ b/lib/foreman_maintain/concerns/downstream.rb
@@ -21,7 +21,9 @@ module ForemanMaintain
           execute!(%(subscription-manager register #{org_options}\
                       --activationkey #{shellescape(activation_key)} --force))
         else
-          had_utils_enabled = repository_manager.enabled_repos.keys.any? { |r| r.start_with?("satellite-utils-") }
+          had_utils_enabled = repository_manager.enabled_repos.keys.any? do |r|
+            r.start_with?("satellite-utils-")
+          end
 
           repository_manager.rhsm_disable_repos(['*'])
 


### PR DESCRIPTION
foreman_maintain disables all repos during upgrade and re-enables only a known set. The `satellite-utils` repos was not included, which caused dependency conflicts when `hammer_cli` was installed from `utils`.