### PR TITLE
self-upgrade next target_version

### DIFF
--- a/definitions/scenarios/self_upgrade.rb
+++ b/definitions/scenarios/self_upgrade.rb
@@ -4,7 +4,10 @@ module ForemanMaintain::Scenarios
     include ForemanMaintain::Concerns::Versions
 
     def target_version
-      feature(:instance).target_version
+      @target_version ||= begin
+        v = Gem::Version.new(feature(:instance).target_version)
+        "#{v.segments[0]}.#{v.segments[1] + 1}"
+      end
     end
 
     def current_version
@@ -39,19 +42,30 @@ module ForemanMaintain::Scenarios
       true
     end
 
+    def maintain_version
+      @maintain_version ||= feature(:instance).target_version
+    end
+
+    def current_major
+      Gem::Version.new(current_version).segments[0..1].join('.')
+    end
+
+    def upgrade_repo_version
+      Gem::Version.new(current_version).bump.segments[0..1].join('.')
+    end
+
     def req_repos_to_update_pkgs
+      version = upgrade_repo_version
       if use_rhsm?
-        main_rh_repos + [maintenance_repo_id(target_version)]
+        main_rh_repos + [maintenance_repo_id(version)]
       else
-        [maintenance_repo_id(target_version)]
+        [maintenance_repo_id(version)]
       end
     end
 
     def self_upgrade_allowed?
-      target = Gem::Version.new(target_version).version
-
-      Gem::Version.new(current_version).segments[0..1].join('.') == target ||
-        Gem::Version.new(current_version).bump.segments[0..1].join('.') == target
+      current_major == maintain_version ||
+        Gem::Version.new(current_version).bump.segments[0..1].join('.') == maintain_version
     end
   end
 
@@ -67,10 +81,10 @@ module ForemanMaintain::Scenarios
       unless self_upgrade_allowed?
         raise(
           ForemanMaintain::Error::Warn,
-          "foreman-maintain is too many versions ahead. The target " \
-          "version is #{target_version} while the currently installed " \
-          "version is #{current_version}. Please rollback " \
-          "foreman-maintain to the proper version."
+          "foreman-maintain does not support the installed version of Satellite." \
+          "The currently installed version in #{current_version}," \
+          "while foreman-maintain only supports #{maintain_version}." \
+          "Please install the right version of foreman-maintain."
         )
       end
 

--- a/test/definitions/scenarios/self_upgrade_test.rb
+++ b/test/definitions/scenarios/self_upgrade_test.rb
@@ -16,40 +16,29 @@ describe ForemanMaintain::Scenarios::SelfUpgradeBase do
 
   it 'computes the target version correctly for downstream' do
     assume_satellite_present
+    ForemanMaintain.package_manager.
+      stubs(:find_installed_package).
+      with('satellite', '%{VERSION}').returns('6.16.0')
 
-    assert_equal '6.16', scenario.target_version
+    assert_equal '6.17', scenario.upgrade_repo_version
   end
 
   it 'returns target version correctly for upstream' do
     assume_feature_present(:foreman_install)
 
-    assert_equal '3.11', scenario.target_version
-  end
-
-  it 'allow upgrade when versions are equal' do
-    assume_satellite_present
-    scenario.expects(:current_version).returns('6.16.0')
-
-    assert scenario.self_upgrade_allowed?
-  end
-
-  it 'allow upgrade when versions are equal for z-stream' do
-    assume_satellite_present
-    scenario.expects(:current_version).returns('6.16.4')
-
-    assert scenario.self_upgrade_allowed?
+    assert_equal '3.12', scenario.target_version
   end
 
   it 'allow upgrade when versions are off by 1' do
     assume_satellite_present
-    scenario.expects(:current_version).twice.returns('6.15.8')
+    scenario.stubs(:current_version).returns('6.15.8')
 
     assert scenario.self_upgrade_allowed?
   end
 
   it 'does not allow upgrade when versions are off by 2 or more' do
     assume_satellite_present
-    scenario.expects(:current_version).twice.returns('6.14.4')
+    scenario.stubs(:current_version).returns('6.14.4')
 
     refute scenario.self_upgrade_allowed?
   end
@@ -63,60 +52,115 @@ describe ForemanMaintain::Scenarios::SelfUpgrade do
     mock_satellite_maintain_config
   end
 
-  it 'runs successfully for downstream Satellite' do
-    ForemanMaintain.
-      package_manager.
+  def mock_satellite_package_version(satver)
+    ForemanMaintain.package_manager.
       expects(:find_installed_package).
-      with('satellite', "%{VERSION}").
-      returns('6.16.0')
-    assume_feature_present(:satellite)
-    scenario = ForemanMaintain::Scenarios::SelfUpgrade.new
-    scenario.compose
-
-    assert run_step(scenario)
+      with('satellite', '%{VERSION}').returns(satver)
   end
 
-  it 'runs successfully for downstream Capsule' do
-    ForemanMaintain.
-      package_manager.
-      expects(:find_installed_package).
-      with('satellite-capsule', "%{VERSION}").
-      returns('6.16.3')
-    assume_feature_present(:capsule)
-    scenario = ForemanMaintain::Scenarios::SelfUpgrade.new
-    scenario.compose
+  describe 'downstream' do
+    before do
+      ForemanMaintain::Scenarios::SelfUpgrade.any_instance.stubs(:el_major_version).returns(9)
+    end
 
-    assert run_step(scenario)
-  end
+    let(:expected_repos) do
+      [
+        'rhel-9-for-x86_64-baseos-rpms',
+        'rhel-9-for-x86_64-appstream-rpms',
+        'satellite-maintenance-6.17-for-rhel-9-x86_64-rpms',
+      ]
+    end
 
-  it 'run successfully if current and target version are off by 1' do
-    ForemanMaintain.
-      package_manager.
-      expects(:find_installed_package).
-      with('satellite', "%{VERSION}").
-      returns('6.15.3')
-    assume_feature_present(:satellite)
-    scenario = ForemanMaintain::Scenarios::SelfUpgrade.new
-    scenario.compose
+    it 'with maintain from 6.16 on satellite 6.14.1 raises error' do
+      mock_satellite_package_version('6.14.1')
+      assume_feature_present(:satellite)
 
-    assert run_step(scenario)
-  end
+      assert_raises(ForemanMaintain::Error::Warn) do
+        ForemanMaintain::Scenarios::SelfUpgrade.new
+      end
+    end
 
-  it 'fails if versions are off 2 or more' do
-    ForemanMaintain.
-      package_manager.
-      expects(:find_installed_package).
-      with('satellite', "%{VERSION}").
-      returns('6.14.1')
-    assume_feature_present(:satellite)
+    it 'with maintain from 6.16 on satellite 6.15.1 upgrades maintain using 6.16 repos' do
+      mock_satellite_package_version('6.15.1')
+      assume_feature_present(:satellite)
 
-    msg = "foreman-maintain is too many versions ahead. The target " \
-          "version is 6.16 while the currently installed " \
-          "version is 6.14.1. Please rollback " \
-          "foreman-maintain to the proper version."
-    assert_raises(ForemanMaintain::Error::Warn, msg) do
       scenario = ForemanMaintain::Scenarios::SelfUpgrade.new
       scenario.compose
+
+      expected_616_repos = [
+        'rhel-9-for-x86_64-baseos-rpms',
+        'rhel-9-for-x86_64-appstream-rpms',
+        'satellite-maintenance-6.16-for-rhel-9-x86_64-rpms',
+      ]
+      update_step = scenario.steps.find { |s| s.is_a?(Procedures::Packages::Update) }
+      assert update_step, 'Expected a Packages::Update step'
+      assert_equal expected_616_repos, update_step.instance_variable_get(:@enabled_repos)
+    end
+
+    it 'with maintain from 6.16 on satellite 6.16.1 upgrades maintain to latest from 6.17' do
+      mock_satellite_package_version('6.16.1')
+      assume_feature_present(:satellite)
+      scenario = ForemanMaintain::Scenarios::SelfUpgrade.new
+      scenario.compose
+
+      update_step = scenario.steps.find { |s| s.is_a?(Procedures::Packages::Update) }
+      assert update_step, 'Expected a Packages::Update step'
+      assert_equal expected_repos, update_step.instance_variable_get(:@enabled_repos)
+    end
+
+    it 'with maintain from 6.16 on satellite 6.17.1 raises error' do
+      mock_satellite_package_version('6.17.1')
+      assume_feature_present(:satellite)
+
+      assert_raises(ForemanMaintain::Error::Warn) do
+        ForemanMaintain::Scenarios::SelfUpgrade.new
+      end
+    end
+
+    it 'with Capsule from 6.16 updates by temp-enabling 6.17 repos' do
+      ForemanMaintain.package_manager.
+        expects(:find_installed_package).
+        with('satellite-capsule', '%{VERSION}').returns('6.16.3')
+      assume_feature_present(:capsule)
+      ForemanMaintain::Scenarios::SelfUpgrade.any_instance.stubs(:el_major_version).returns(9)
+      scenario = ForemanMaintain::Scenarios::SelfUpgrade.new
+      scenario.compose
+
+      update_step = scenario.steps.find { |s| s.is_a?(Procedures::Packages::Update) }
+      assert update_step, 'Expected a Packages::Update step'
+      assert_equal expected_repos, update_step.instance_variable_get(:@enabled_repos)
+    end
+  end
+
+  describe 'upstream' do
+    before do
+      assume_feature_present(:foreman_install)
+    end
+
+    it 'with f-m from 3.11 sets up 3.12 repos' do
+      ForemanMaintain.package_manager.stubs(:find_installed_package).
+        with('foreman', "%{VERSION}").returns('3.11.0')
+      ForemanMaintain.package_manager.stubs(:find_installed_package).
+        with('foreman-release', '%{VERSION}').returns('3.11')
+      scenario = ForemanMaintain::Scenarios::SelfUpgrade.new
+      scenario.compose
+
+      setup_step = scenario.steps.find { |s| s.is_a?(Procedures::Repositories::Setup) }
+      assert setup_step, 'Expected a Repositories::Setup step'
+      assert_equal '3.12', setup_step.instance_variable_get(:@version)
+    end
+
+    it 'with f-m from 3.12 sets up 3.12 repos' do
+      ForemanMaintain.package_manager.stubs(:find_installed_package).
+        with('foreman', "%{VERSION}").returns('3.12.0')
+      ForemanMaintain.package_manager.stubs(:find_installed_package).
+        with('foreman-release', '%{VERSION}').returns('3.12')
+      scenario = ForemanMaintain::Scenarios::SelfUpgrade.new
+      scenario.compose
+
+      setup_step = scenario.steps.find { |s| s.is_a?(Procedures::Repositories::Setup) }
+      assert setup_step, 'Expected a Repositories::Setup step'
+      assert_equal '3.12', setup_step.instance_variable_get(:@version)
     end
   end
 end


### PR DESCRIPTION
For the self-upgrade scenario:
* set the target version to X.Y+1
* disable the repository after the upgrade