### PR TITLE
Fixes #1092 - Adds CheckForReboot in packages update scenario

### DIFF
--- a/definitions/scenarios/packages.rb
+++ b/definitions/scenarios/packages.rb
@@ -106,6 +106,7 @@ module ForemanMaintain::Scenarios
         if Packages.skip_installer_run?(context.get(:packages))
           add_step_with_context(Procedures::Packages::Update,
             :force => true, :warn_on_errors => true)
+          add_step(Procedures::Packages::CheckForReboot)
         else
           unless context.get(:downloadonly)
             add_steps_with_context(
@@ -126,6 +127,7 @@ module ForemanMaintain::Scenarios
             add_step_with_context(Procedures::Packages::LockVersions)
           else
             add_step_with_context(Procedures::Installer::Run)
+            add_step(Procedures::Packages::CheckForReboot)
           end
 
           add_step(Procedures::Packages::LockingStatus)


### PR DESCRIPTION
Attempting to fix https://github.com/theforeman/foreman_maintain/issues/1092 

When executing "foreman-maintain packages update", it does everything else fine, but it never shows whether a system reboot would be needed or not, and that is something important.

With `Procedures::Packages::CheckForReboot` included in that action, this now correctly shows whether a reboot is required or not.

Example:

When not needed:

~~~
--------------------------------------------------------------------------------
Unlock packages:                                                      [OK]
--------------------------------------------------------------------------------
Update package(s) :                                                   [OK]
--------------------------------------------------------------------------------
Running satellite-installer :                                         [OK]
--------------------------------------------------------------------------------
Check if system needs reboot:                                         [OK]
Updating Subscription Management repositories.
No core libraries or services have been updated since boot-up.
Reboot should not be necessary.
--------------------------------------------------------------------------------
Check status of version locking of packages: 
  Automatic locking of package versions is enabled in installer.
  Packages are locked.                                                [OK]
--------------------------------------------------------------------------------
~~~

And when needed:

~~~
--------------------------------------------------------------------------------
Unlock packages:                                                      [OK]
--------------------------------------------------------------------------------
Update package(s) :                                                   [OK]
--------------------------------------------------------------------------------
Running foreman-installer :                                           [OK]
--------------------------------------------------------------------------------
Check if system needs reboot:                                         [WARNING]
Updating Subscription Management repositories.
Core libraries or services have been updated since boot-up:
  * glibc
  * kernel
  * linux-firmware
  * microcode_ctl
  * systemd

Reboot is required to fully utilize these updates.
More information: https://access.redhat.com/solutions/27943
--------------------------------------------------------------------------------
Check status of version locking of packages: 
  Automatic locking of package versions is enabled in installer.
  Packages are locked.                                                [OK]
--------------------------------------------------------------------------------
~~~


**Assisted-By: Claude Sonnet 4.6**